### PR TITLE
GL_BOOL

### DIFF
--- a/src/templates/org/lwjgl/opengl/templates/GL20.kt
+++ b/src/templates/org/lwjgl/opengl/templates/GL20.kt
@@ -60,6 +60,7 @@ fun GL20() = "GL20".nativeClassGL("GL20") {
 		"INT_VEC2" _ 0x8B53,
 		"INT_VEC3" _ 0x8B54,
 		"INT_VEC4" _ 0x8B55,
+		"BOOL" _ 0x8B56,
 		"BOOL_VEC2" _ 0x8B57,
 		"BOOL_VEC3" _ 0x8B58,
 		"BOOL_VEC4" _ 0x8B59,


### PR DESCRIPTION
GL_BOOL (0x8B56), from GL2.0, seems to be missing.
