### PR TITLE
Added fix for javax.script.ScriptException seen on Mac OS X

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -18,10 +18,9 @@
     if ( !version.equals("1.6") )
       var messageString = "The environment variable JAVA6_HOME has not been set. Using JAVA_HOME (version " + version + ").";
       if (typeof println === 'undefined') {
-        this.println = messageString;
-      } else {
-        println(messageString);
+        this.println = print;
       }
+      println(messageString);
   }
   </script>
   </sequential>


### PR DESCRIPTION
Fixes #24

[This snippet](https://github.com/virtuoushub/lwjgl3/blob/develop/build.xml#L16-25) has the necissary code to allow me to run `$ ant clean` in my environment.

I also replaced the tab character with two spaces to prevent various editors from displaying the file differently.
