### PR TITLE
Fix for running $ ant tests on Mac OSX

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -237,6 +237,9 @@
 	</target>
 
 	<target name="tests" description="Runs the LWJGL test suite" depends="compile-tests, compile-native, -init-runtime">
+		<condition property="osxargs" value="-XstartOnFirstThread" else="">
+			<isset property="platform.macosx"/>
+		</condition>
 		<testng outputDir="${generated.tests}" classpathref="runtime.classpath" taskname="Tests">
 			<classpath>
 				<pathelement path="${lib}/jcommander.jar"/>
@@ -246,6 +249,7 @@
 			<jvmarg value="-ea"/>
 			<jvmarg value="-Dorg.lwjgl.util.Debug=true"/>
 			<jvmarg value="-Djava.library.path=${library.path}"/>
+			<jvmarg line="${osxargs}"/>
 
 			<xmlfileset dir="${config}" includes="tests.xml,tests_${platform}.xml"/>
 		</testng>


### PR DESCRIPTION
Fix for #43 on my local environment.

After looking into the cause of #43 , I came up with this fix. I also included the observed stack trace a little more verbosely than the one in the issue's description.

## Observed Stack trace:
```
java.lang.IllegalStateException: Please run the JVM with -XstartOnFirstThread.
	at org.lwjgl.system.macosx.EventLoop.checkFirstThread(EventLoop.java:20)
	at org.lwjgl.glfw.GLFW.glfwInit(GLFW.java:426)
	at org.lwjgl.system.libffi.LibFFITest.createGLFWWindow(LibFFITest.java:114)
	at org.lwjgl.system.libffi.LibFFITest.testLibFFI(LibFFITest.java:29)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:483)
	at org.testng.internal.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:84)
	at org.testng.internal.Invoker.invokeMethod(Invoker.java:714)
	at org.testng.internal.Invoker.invokeTestMethod(Invoker.java:901)
	at org.testng.internal.Invoker.invokeTestMethods(Invoker.java:1231)
	at org.testng.internal.TestMethodWorker.invokeTestMethods(TestMethodWorker.java:127)
	at org.testng.internal.TestMethodWorker.run(TestMethodWorker.java:111)
	at org.testng.TestRunner.privateRun(TestRunner.java:767)
	at org.testng.TestRunner.run(TestRunner.java:617)
	at org.testng.SuiteRunner.runTest(SuiteRunner.java:348)
	at org.testng.SuiteRunner.runSequentially(SuiteRunner.java:343)
	at org.testng.SuiteRunner.privateRun(SuiteRunner.java:305)
	at org.testng.SuiteRunner.run(SuiteRunner.java:254)
	at org.testng.SuiteRunnerWorker.runSuite(SuiteRunnerWorker.java:52)
	at org.testng.SuiteRunnerWorker.run(SuiteRunnerWorker.java:86)
	at org.testng.TestNG.runSuitesSequentially(TestNG.java:1224)
	at org.testng.TestNG.runSuitesLocally(TestNG.java:1149)
	at org.testng.TestNG.run(TestNG.java:1057)
	at org.testng.TestNG.privateMain(TestNG.java:1364)
	at org.testng.TestNG.main(TestNG.java:1333)
```