### PR TITLE
Add VERTEX_BINDING_BUFFER constant

### DIFF
--- a/src/templates/org/lwjgl/opengl/templates/GL43.kt
+++ b/src/templates/org/lwjgl/opengl/templates/GL43.kt
@@ -1227,7 +1227,8 @@ for ( i = 0; i < primcount; i++ ) {
 
 		"VERTEX_BINDING_DIVISOR" _ 0x82D6,
 		"VERTEX_BINDING_OFFSET" _ 0x82D7,
-		"VERTEX_BINDING_STRIDE" _ 0x82D8
+		"VERTEX_BINDING_STRIDE" _ 0x82D8,
+		"VERTEX_BINDING_BUFFER" _ 0x8F4F
 	)
 
 	IntConstant.block(


### PR DESCRIPTION
Exists in ARBVertexAttribBinding, missing here.