### PR TITLE
Added an exclusion for reference counting on "NVIDIA CUDA" platform.

### DIFF
--- a/src/tests/org/lwjgl/opencl/CLTest.java
+++ b/src/tests/org/lwjgl/opencl/CLTest.java
@@ -331,8 +331,9 @@ public class CLTest {
 		contextTest(CL11_FILTER, new ContextTest() {
 			@Override
 			public void test(CLPlatform platform, PointerBuffer ctxProps, CLDevice device) {
-				// TODO: Intel has broken reference counting atm
+				// TODO: Intel and NVIDIA CUDA have broken reference counting atm
 				boolean doContextCountChecks = !"Intel(R) OpenCL".equals(clGetPlatformInfoStringUTF8(platform.getPointer(), CL_PLATFORM_NAME));
+				doContextCountChecks &= !"NVIDIA CUDA" .equals(clGetPlatformInfoStringUTF8(platform.getPointer(), CL_PLATFORM_NAME));
 
 				IntBuffer errcode_ret = BufferUtils.createIntBuffer(1);
 


### PR DESCRIPTION
Noticed that this test was failing when I ran it.
Incidentally, the run with "AMD Accelerated Parallel Processing" is working for me.