### PR TITLE
Make LWJGL 3 Java 1.5 compatible

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -132,40 +132,40 @@ License terms: http://lwjgl.org/license.php
 			<not>
 				<or>
 					<isset property="env.JAVA_HOME"/>
-					<isset property="env.JAVA6_HOME"/>
+					<isset property="env.JAVA5_HOME"/>
 				</or>
 			</not>
 		</condition>
 		<fail if="java.home.missing" message="Please set the JAVA_HOME environment variable."/>
 		<!--
-			JAVA6_HOME will be used for the bootclasspath. This will cause compilation to fail
-			if a Java 7+ API is used by mistake. Do not fail if it is not set, try to use
+			JAVA5_HOME will be used for the bootclasspath. This will cause compilation to fail
+			if a Java 6+ API is used by mistake. Do not fail if it is not set, try to use
 			JAVA_HOME instead and issue a warning if that's not a Java 6 SDK.
 		-->
 		<sequential>
 		<script language="javascript">
-		if ( !java.lang.System.getenv().containsKey("JAVA6_HOME") ) {
+		if ( !java.lang.System.getenv().containsKey("JAVA5_HOME") ) {
 			var version = java.lang.System.getProperty("java.specification.version");
-			if ( !version.equals("1.6") )
-				print("The environment variable JAVA6_HOME has not been set. Using JAVA_HOME (version " + version + ").");
+			if ( !version.equals("1.5") )
+				print("The environment variable JAVA5_HOME has not been set. Using JAVA_HOME (version " + version + ").");
 		}
 		</script>
 		</sequential>
-		<property name="env.JAVA6_HOME" value="${env.JAVA_HOME}" unless:set="env.JAVA6_HOME"/>
+		<property name="env.JAVA5_HOME" value="${env.JAVA_HOME}" unless:set="env.JAVA5_HOME"/>
 
 		<path id="jdk.boot.classpath.jars">
-			<fileset dir="${env.JAVA6_HOME}/jre/lib">
+			<fileset dir="${env.JAVA5_HOME}/jre/lib">
 				<include name="*.jar"/>
 			</fileset>
-			<fileset file="${env.JAVA6_HOME}/lib/tools.jar"/>
+			<fileset file="${env.JAVA5_HOME}/lib/tools.jar"/>
 		</path>
 		<path id="jdk.boot.classpath.applejars">
-			<fileset dir="${env.JAVA6_HOME}/bundle/Classes">
+			<fileset dir="${env.JAVA5_HOME}/bundle/Classes">
 				<include name="*.jar"/>
 			</fileset>
 		</path>
 		<condition property="jdk.boot.classpath" value="jdk.boot.classpath.applejars" else="jdk.boot.classpath.jars">
-			<available file="${env.JAVA6_HOME}/bundle/Classes/classes.jar"/>
+			<available file="${env.JAVA5_HOME}/bundle/Classes/classes.jar"/>
 		</condition>
 
 		<patternset id="src.core.files">
@@ -206,7 +206,7 @@ License terms: http://lwjgl.org/license.php
 
 	<target name="-compile-templates" description="Compiles the Templates module" depends="-init-compile" unless="templates-uptodate">
 		<!-- Compile Java dependencies -->
-		<javac debug="yes" destdir="${bin}/Templates" encoding="utf8" source="1.6" target="1.6" bootclasspathref="${jdk.boot.classpath}" taskname="Java dependencies">
+		<javac debug="yes" destdir="${bin}/Templates" encoding="utf8" source="1.5" target="1.5" bootclasspathref="${jdk.boot.classpath}" taskname="Java dependencies">
 			<src path="${src.templates}"/>
 			<include name="org/lwjgl/**"/>
 		</javac>
@@ -247,7 +247,7 @@ License terms: http://lwjgl.org/license.php
 	</target>
 
 	<target name="formatter" description="Runs the template formatter tool" depends="init, -init-compile"> <!-- Removed "compile-templates" until Kotlin adds support for incremental compilation -->
-		<javac debug="yes" destdir="${bin.templates}" encoding="utf8" source="1.6" target="1.6" bootclasspathref="${jdk.boot.classpath}">
+		<javac debug="yes" destdir="${bin.templates}" encoding="utf8" source="1.5" target="1.5" bootclasspathref="${jdk.boot.classpath}">
 			<src path="${src.templates}"/>
 			<include name="org/lwjgl/**"/>
 		</javac>
@@ -298,7 +298,7 @@ License terms: http://lwjgl.org/license.php
 	</target>
 
 	<target name="compile" description="Compiles the Java source code" depends="generate">
-		<javac debug="yes" sourcepath="" destdir="${bin.core}" encoding="utf8" source="1.6" target="1.6" bootclasspathref="${jdk.boot.classpath}" taskname="Core">
+		<javac debug="yes" sourcepath="" destdir="${bin.core}" encoding="utf8" source="1.5" target="1.5" bootclasspathref="${jdk.boot.classpath}" taskname="Core">
 			<src>
 				<pathelement path="${src.core}"/>
 				<pathelement path="${src.util}"/>
@@ -319,7 +319,7 @@ License terms: http://lwjgl.org/license.php
 	</target>
 
 	<target name="compile-tests" description="Compiles the LWJGL test suite" depends="compile">
-		<javac debug="yes" destdir="${bin.tests}" encoding="utf8" source="1.6" target="1.6" bootclasspathref="${jdk.boot.classpath}" taskname="Tests">
+		<javac debug="yes" destdir="${bin.tests}" encoding="utf8" source="1.5" target="1.5" bootclasspathref="${jdk.boot.classpath}" taskname="Tests">
 			<classpath>
 				<pathelement path="${bin.core}"/>
 				<pathelement path="${bin.util}"/>
@@ -398,7 +398,7 @@ License terms: http://lwjgl.org/license.php
 		<delete dir="${generated.javadoc}"/>
 		<javadoc
 			destdir="${generated.javadoc}"
-			source="1.6"
+			source="1.5"
 			bootclasspathref="${jdk.boot.classpath}"
 			windowtitle="LWJGL ${build.version}"
 			encoding="utf8"

--- a/src/core/org/lwjgl/BufferUtils.java
+++ b/src/core/org/lwjgl/BufferUtils.java
@@ -54,7 +54,6 @@ public final class BufferUtils {
 
 		if ( "page".equals(alignment) )
 			return new BufferAllocator() {
-				@Override
 				public ByteBuffer malloc(int capacity) {
 					return createAlignedByteBufferPage(capacity);
 				}
@@ -62,7 +61,6 @@ public final class BufferUtils {
 
 		if ( "cache-line".equals(alignment) )
 			return new BufferAllocator() {
-				@Override
 				public ByteBuffer malloc(int capacity) {
 					return createAlignedByteBufferCacheLine(capacity);
 				}
@@ -70,7 +68,6 @@ public final class BufferUtils {
 
 		if ( "default".equals(alignment) )
 			return new BufferAllocator() {
-				@Override
 				public ByteBuffer malloc(int capacity) {
 					return createUnalignedByteBuffer(capacity);
 				}
@@ -80,7 +77,6 @@ public final class BufferUtils {
 			final int bytes = Integer.parseInt(alignment);
 			if ( mathIsPoT(bytes) && 8 < bytes )
 				return new BufferAllocator() {
-					@Override
 					public ByteBuffer malloc(int capacity) {
 						return createAlignedByteBuffer(capacity, bytes);
 					}

--- a/src/core/org/lwjgl/LWJGLUtil.java
+++ b/src/core/org/lwjgl/LWJGLUtil.java
@@ -389,7 +389,6 @@ public final class LWJGLUtil {
 	}
 
 	private static final LibraryLoader<Boolean> LOADER_SYSTEM = new LibraryLoader<Boolean>() {
-		@Override
 		public Boolean load(File library) {
 			System.load(library.getAbsolutePath());
 			return true;
@@ -397,7 +396,6 @@ public final class LWJGLUtil {
 	};
 
 	private static final LibraryLoader<DynamicLinkLibrary> LOADER_NATIVE = new LibraryLoader<DynamicLinkLibrary>() {
-		@Override
 		public DynamicLinkLibrary load(File library) {
 			return apiCreateLibrary(library.getPath());
 		}

--- a/src/core/org/lwjgl/PointerBuffer.java
+++ b/src/core/org/lwjgl/PointerBuffer.java
@@ -902,7 +902,6 @@ public class PointerBuffer implements Comparable<PointerBuffer> {
 	 * @return A negative integer, zero, or a positive integer as this buffer
 	 * is less than, equal to, or greater than the specified buffer
 	 */
-	@Override
 	public int compareTo(PointerBuffer that) {
 		int n = this.position() + Math.min(this.remaining(), that.remaining());
 		for ( int i = this.position(), j = that.position(); i < n; i++, j++ ) {

--- a/src/core/org/lwjgl/Sys.java
+++ b/src/core/org/lwjgl/Sys.java
@@ -31,7 +31,6 @@ public final class Sys {
 		log("Version " + getVersion() + " | " + System.getProperty("os.name") + " | " + System.getProperty("os.arch"));
 
 		AccessController.doPrivileged(new PrivilegedAction<Object>() {
-			@Override
 			public Object run() {
 				LWJGLUtil.loadLibrarySystem(JNI_LIBRARY_NAME);
 				return null;

--- a/src/core/org/lwjgl/glfw/Callbacks.java
+++ b/src/core/org/lwjgl/glfw/Callbacks.java
@@ -128,7 +128,6 @@ public final class Callbacks {
 	public static GLFWErrorCallback errorCallbackPrint(final PrintStream stream) {
 		return new GLFWErrorCallback() {
 			private final Map<Integer, String> ERROR_CODES = LWJGLUtil.getClassTokens(new TokenFilter() {
-				@Override
 				public boolean accept(Field field, int value) {
 					return 0x10000 < value && value < 0x20000;
 				}

--- a/src/core/org/lwjgl/openal/AL.java
+++ b/src/core/org/lwjgl/openal/AL.java
@@ -35,7 +35,6 @@ public final class AL {
 			// the OpenAL native library.
 			private final long alGetProcAddress = ALC.getFunctionProvider().getFunctionAddress("alGetProcAddress");
 
-			@Override
 			public long getFunctionAddress(CharSequence functionName) {
 				APIBuffer __buffer = apiBuffer();
 				__buffer.stringParamASCII(functionName, true);

--- a/src/core/org/lwjgl/openal/ALC.java
+++ b/src/core/org/lwjgl/openal/ALC.java
@@ -65,7 +65,6 @@ public final class ALC {
 				}
 			}
 
-			@Override
 			public long getFunctionAddress(CharSequence functionName) {
 				long address = OPENAL.getFunctionAddress(functionName);
 				if ( address == NULL )
@@ -74,7 +73,6 @@ public final class ALC {
 				return address;
 			}
 
-			@Override
 			public long getFunctionAddress(long handle, CharSequence functionName) {
 				APIBuffer __buffer = apiBuffer();
 				__buffer.stringParamASCII(functionName, true);

--- a/src/core/org/lwjgl/opencl/CL.java
+++ b/src/core/org/lwjgl/opencl/CL.java
@@ -118,7 +118,6 @@ public final class CL {
 				return 1 < version.major || 2 <= version.minor;
 			}
 
-			@Override
 			public long getFunctionAddress(CharSequence functionName) {
 				APIBuffer __buffer = apiBuffer();
 				__buffer.stringParamASCII(functionName, true);
@@ -133,7 +132,6 @@ public final class CL {
 				return address;
 			}
 
-			@Override
 			public long getFunctionAddress(long handle, CharSequence functionName) {
 				APIBuffer __buffer = apiBuffer();
 				__buffer.stringParamASCII(functionName, true);

--- a/src/core/org/lwjgl/opencl/CLPlatform.java
+++ b/src/core/org/lwjgl/opencl/CLPlatform.java
@@ -121,7 +121,6 @@ public class CLPlatform extends PointerWrapper {
 			platformIDs[i] = __buffer.pointerValue(i << POINTER_SHIFT);
 
 		return filterObjects(platformIDs, filter, new Factory<CLPlatform>() {
-			@Override
 			public CLPlatform create(long object_id) {
 				return new CLPlatform(object_id);
 			}
@@ -168,7 +167,6 @@ public class CLPlatform extends PointerWrapper {
 			deviceIDs[i] = __buffer.pointerValue(i << POINTER_SHIFT);
 
 		return filterObjects(deviceIDs, filter, new Factory<CLDevice>() {
-			@Override
 			public CLDevice create(long object_id) {
 				return new CLDevice(object_id, getCapabilities());
 			}

--- a/src/core/org/lwjgl/opencl/CLUtil.java
+++ b/src/core/org/lwjgl/opencl/CLUtil.java
@@ -18,7 +18,6 @@ public final class CLUtil {
 	/** Maps OpenCL error token values to their String representations. */
 	private static final Map<Integer, String> CL_ERROR_TOKENS = LWJGLUtil.getClassTokens(
 		new LWJGLUtil.TokenFilter() {
-			@Override
 			public boolean accept(Field field, int value) {
 				return value < 0; // Currently, all OpenCL errors have negative values.
 			}

--- a/src/core/org/lwjgl/opengl/GL.java
+++ b/src/core/org/lwjgl/opengl/GL.java
@@ -75,7 +75,6 @@ public final class GL {
 		abstract class FunctionProviderGL extends FunctionProvider.Default {
 			abstract long getExtensionAddress(long name);
 
-			@Override
 			public long getFunctionAddress(CharSequence functionName) {
 				APIBuffer __buffer = apiBuffer();
 				__buffer.stringParamASCII(functionName, true);

--- a/src/core/org/lwjgl/opengl/GLContextLinux.java
+++ b/src/core/org/lwjgl/opengl/GLContextLinux.java
@@ -32,7 +32,6 @@ public class GLContextLinux extends GLContext {
 			makeCurrentAction = null;
 	}
 
-	@Override
 	public long getPointer() {
 		return ctx;
 	}
@@ -89,7 +88,6 @@ public class GLContextLinux extends GLContext {
 
 	private static class MakeCurrentActionSGI implements MakeCurrentAction {
 
-		@Override
 		public int invoke(long display, long draw, long read, long ctx) {
 			return glXMakeCurrentReadSGI(display, draw, read, ctx);
 		}
@@ -97,7 +95,6 @@ public class GLContextLinux extends GLContext {
 
 	private static class MakeCurrentActionARB implements MakeCurrentAction {
 
-		@Override
 		public int invoke(long display, long draw, long read, long ctx) {
 			return glXMakeContextCurrent(display, draw, read, ctx);
 		}

--- a/src/core/org/lwjgl/opengl/GLContextMacOSX.java
+++ b/src/core/org/lwjgl/opengl/GLContextMacOSX.java
@@ -16,7 +16,6 @@ public class GLContextMacOSX extends GLContext {
 		this.handle = handle;
 	}
 
-	@Override
 	public long getPointer() {
 		return handle;
 	}

--- a/src/core/org/lwjgl/opengl/GLContextWindows.java
+++ b/src/core/org/lwjgl/opengl/GLContextWindows.java
@@ -26,7 +26,6 @@ public class GLContextWindows extends GLContext {
 		this.hglrc = hglrc;
 	}
 
-	@Override
 	public long getPointer() {
 		return hglrc;
 	}

--- a/src/core/org/lwjgl/system/APIBuffer.java
+++ b/src/core/org/lwjgl/system/APIBuffer.java
@@ -8,7 +8,6 @@ import org.lwjgl.BufferUtils;
 import org.lwjgl.PointerBuffer;
 
 import java.nio.ByteBuffer;
-import java.util.Arrays;
 
 import static org.lwjgl.Pointer.*;
 import static org.lwjgl.system.MathUtil.*;
@@ -36,6 +35,13 @@ public class APIBuffer {
 		address = memAddress(buffer);
 	}
 
+    private static int[] copyOf(int[] original, int newLength) {
+        int[] copy = new int[newLength];
+        System.arraycopy(original, 0, copy, 0,
+                         Math.min(original.length, newLength));
+        return copy;
+    }
+
 	/** Resets the parameter offset to 0. */
 	public APIBuffer reset() {
 		offset = 0;
@@ -45,7 +51,7 @@ public class APIBuffer {
 	/** Pushes the current parameter offset to a stack. */
 	public APIBuffer push() {
 		if ( stackDepth == stack.length )
-			stack = Arrays.copyOf(stack, stack.length << 1);
+			stack = copyOf(stack, stack.length << 1);
 
 		stack[stackDepth++] = offset;
 

--- a/src/core/org/lwjgl/system/CharSequenceNT.java
+++ b/src/core/org/lwjgl/system/CharSequenceNT.java
@@ -13,19 +13,16 @@ final class CharSequenceNT implements CharSequence {
 		this.source = source;
 	}
 
-	@Override
 	public int length() {
 		return source.length() + 1;
 
 	}
 
-	@Override
 	public char charAt(int index) {
 		return index == source.length() ? '\0' : source.charAt(index);
 
 	}
 
-	@Override
 	public CharSequence subSequence(int start, int end) {
 		return new CharSequenceNT(source.subSequence(start, Math.min(end, source.length())));
 	}

--- a/src/core/org/lwjgl/system/FunctionProvider.java
+++ b/src/core/org/lwjgl/system/FunctionProvider.java
@@ -25,7 +25,6 @@ public interface FunctionProvider extends Retainable {
 	/** A {@code FunctionProvider} implementation that always returns {@code NULL}. */
 	FunctionProvider DUMMY = new Default() {
 
-		@Override
 		public long getFunctionAddress(CharSequence functionName) {
 			return NULL;
 		}

--- a/src/core/org/lwjgl/system/FunctionProviderLocal.java
+++ b/src/core/org/lwjgl/system/FunctionProviderLocal.java
@@ -27,12 +27,10 @@ public interface FunctionProviderLocal extends FunctionProvider {
 	/** A {@code FunctionProviderLocal} implementation that always returns {@code NULL}. */
 	FunctionProviderLocal DUMMY = new Default() {
 
-		@Override
 		public long getFunctionAddress(CharSequence functionName) {
 			return NULL;
 		}
 
-		@Override
 		public long getFunctionAddress(long handle, CharSequence functionName) {
 			return NULL;
 		}

--- a/src/core/org/lwjgl/system/PointerWrapper.java
+++ b/src/core/org/lwjgl/system/PointerWrapper.java
@@ -21,7 +21,6 @@ public abstract class PointerWrapper implements Pointer {
 		this.pointer = pointer;
 	}
 
-	@Override
 	public final long getPointer() {
 		return pointer;
 	}

--- a/src/core/org/lwjgl/system/Retainable.java
+++ b/src/core/org/lwjgl/system/Retainable.java
@@ -28,7 +28,6 @@ public interface Retainable {
 
 		private int refCount = 1;
 
-		@Override
 		public void retain() {
 			if ( LWJGLUtil.DEBUG && refCount == 0 )
 				throw new IllegalStateException("This object has been released already.");
@@ -36,7 +35,6 @@ public interface Retainable {
 			refCount++;
 		}
 
-		@Override
 		public void release() {
 			if ( LWJGLUtil.DEBUG && refCount == 0 )
 				throw new IllegalStateException("This object has been released already.");

--- a/src/core/org/lwjgl/system/libffi/Closure.java
+++ b/src/core/org/lwjgl/system/libffi/Closure.java
@@ -147,7 +147,6 @@ public abstract class Closure extends Retainable.Default implements Pointer {
 			registry.register(this);
 	}
 
-	@Override
 	public long getPointer() {
 		if ( isDestroyed() )
 			throw new IllegalStateException("This closure instance has been destroyed.");

--- a/src/core/org/lwjgl/system/linux/LinuxLibrary.java
+++ b/src/core/org/lwjgl/system/linux/LinuxLibrary.java
@@ -31,17 +31,14 @@ public class LinuxLibrary extends DynamicLinkLibrary.Default {
 		this.handle = handle;
 	}
 
-	@Override
 	public long getPointer() {
 		return handle;
 	}
 
-	@Override
 	public String getName() {
 		return name;
 	}
 
-	@Override
 	public long getFunctionAddress(CharSequence name) {
 		return dlsym(handle, name);
 	}

--- a/src/core/org/lwjgl/system/macosx/MacOSXLibrary.java
+++ b/src/core/org/lwjgl/system/macosx/MacOSXLibrary.java
@@ -15,7 +15,6 @@ public abstract class MacOSXLibrary extends DynamicLinkLibrary.Default {
 		this.name = name;
 	}
 
-	@Override
 	public String getName() {
 		return name;
 	}

--- a/src/core/org/lwjgl/system/macosx/MacOSXLibraryBundle.java
+++ b/src/core/org/lwjgl/system/macosx/MacOSXLibraryBundle.java
@@ -41,12 +41,10 @@ public class MacOSXLibraryBundle extends MacOSXLibrary {
 		}
 	}
 
-	@Override
 	public long getPointer() {
 		return bundleRef;
 	}
 
-	@Override
 	public long getFunctionAddress(CharSequence functionName) {
 		APIBuffer __buffer = apiBuffer();
 		__buffer.stringParamASCII(functionName, true);

--- a/src/core/org/lwjgl/system/macosx/MacOSXLibraryDL.java
+++ b/src/core/org/lwjgl/system/macosx/MacOSXLibraryDL.java
@@ -19,12 +19,10 @@ public class MacOSXLibraryDL extends MacOSXLibrary {
 			throw new RuntimeException("Failed to dynamically load library: " + name);
 	}
 
-	@Override
 	public long getPointer() {
 		return handle;
 	}
 
-	@Override
 	public long getFunctionAddress(CharSequence name) {
 		return dlsym(handle, name);
 	}

--- a/src/core/org/lwjgl/system/windows/WindowsLibrary.java
+++ b/src/core/org/lwjgl/system/windows/WindowsLibrary.java
@@ -33,17 +33,14 @@ public class WindowsLibrary extends DynamicLinkLibrary.Default {
 			windowsThrowException("Failed to load library: " + name);
 	}
 
-	@Override
 	public String getName() {
 		return name;
 	}
 
-	@Override
 	public long getPointer() {
 		return handle;
 	}
 
-	@Override
 	public long getFunctionAddress(CharSequence name) {
 		return GetProcAddress(handle, name);
 	}

--- a/src/core/org/lwjgl/system/windows/WindowsPlatform.java
+++ b/src/core/org/lwjgl/system/windows/WindowsPlatform.java
@@ -15,7 +15,6 @@ public class WindowsPlatform implements Platform {
 	public WindowsPlatform() {
 	}
 
-	@Override
 	public boolean has64Bit() {
 		return true;
 	}

--- a/src/native/system/common_tools.c
+++ b/src/native/system/common_tools.c
@@ -116,7 +116,7 @@ JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved) {
 	jvm = vm;
 
     envTLSInit();
-    return JNI_VERSION_1_6;
+    return JNI_VERSION_1_4;
 }
 
 JNIEXPORT void JNICALL JNI_OnUnload(JavaVM *vm, void *reserved) {

--- a/src/templates/org/lwjgl/generator/Structs.kt
+++ b/src/templates/org/lwjgl/generator/Structs.kt
@@ -221,7 +221,6 @@ class Struct(
 		return struct;
 	}
 
-	@Override
 	public long getPointer() {
 		return memAddress(struct);
 	}

--- a/src/tests/org/lwjgl/demo/glfw/Events.java
+++ b/src/tests/org/lwjgl/demo/glfw/Events.java
@@ -147,7 +147,6 @@ public final class Events {
 
 		glfwSetKeyCallback(window, new GLFWKeyCallback() {
 			private final Map<Integer, String> KEY_CODES = LWJGLUtil.getClassTokens(new TokenFilter() {
-				@Override
 				public boolean accept(Field field, int value) {
 					return field.getName().startsWith("GLFW_KEY_");
 				}
@@ -236,7 +235,6 @@ public final class Events {
 				printEvent("drop %d file%s", window, count, count == 1 ? "" : "s");
 
 				dropCallbackNamesApply(count, names, new DropConsumerString() {
-					@Override
 					public void accept(int index, String name) {
 						System.out.format("\t%d: %s%n", index + 1, name);
 					}

--- a/src/tests/org/lwjgl/demo/openal/OpenALInfo.java
+++ b/src/tests/org/lwjgl/demo/openal/OpenALInfo.java
@@ -76,7 +76,7 @@ public class OpenALInfo {
 		System.out.println("ALC extensions:");
 		String[] extensions = alcGetString(alContext.getDevice().getPointer(), ALC_EXTENSIONS).split(" ");
 		for ( String extension : extensions ) {
-			if ( extension.trim().isEmpty() ) {
+			if ( extension.trim().length() == 0 ) {
 				continue;
 			}
 			System.out.println("    " + extension);
@@ -91,7 +91,7 @@ public class OpenALInfo {
 		System.out.println("AL extensions:");
 		String[] extensions = alGetString(AL_EXTENSIONS).split(" ");
 		for ( String extension : extensions ) {
-			if ( extension.trim().isEmpty() ) {
+			if ( extension.trim().length() == 0 ) {
 				continue;
 			}
 			System.out.println("    " + extension);

--- a/src/tests/org/lwjgl/demo/opencl/CLGLInteropDemo.java
+++ b/src/tests/org/lwjgl/demo/opencl/CLGLInteropDemo.java
@@ -109,7 +109,6 @@ public final class CLGLInteropDemo {
 		final String vendorGL = getOpenGLVendor();
 
 		final Filter<CLPlatform> platformFilter = new Filter<CLPlatform>() {
-			@Override
 			public boolean accept(CLPlatform platform) {
 				CLCapabilities caps = platform.getCapabilities();
 				return caps.cl_khr_gl_sharing || caps.cl_APPLE_gl_sharing;
@@ -118,7 +117,6 @@ public final class CLGLInteropDemo {
 
 		// Try to match GL_VENDOR and CL_PLATFORM_VENDOR
 		List<CLPlatform> platforms = CLPlatform.getPlatforms(new Filter<CLPlatform>() {
-			@Override
 			public boolean accept(CLPlatform platform) {
 				return platformFilter.accept(platform) && clGetPlatformInfoStringUTF8(platform.getPointer(), CL_PLATFORM_VENDOR).contains(vendorGL);
 			}

--- a/src/tests/org/lwjgl/demo/opencl/Mandelbrot.java
+++ b/src/tests/org/lwjgl/demo/opencl/Mandelbrot.java
@@ -179,7 +179,6 @@ public class Mandelbrot {
 		try {
 			// Find devices with GL sharing support
 			Filter<CLDevice> glSharingFilter = new Filter<CLDevice>() {
-				@Override
 				public boolean accept(CLDevice device) {
 					CLCapabilities caps = device.getCapabilities();
 					return caps.cl_khr_gl_sharing || caps.cl_APPLE_gl_sharing;
@@ -323,7 +322,7 @@ public class Mandelbrot {
 			                    "}");
 			glCompileShader(vsh);
 			String log = glGetShaderInfoLog(vsh, glGetShaderi(vsh, GL_INFO_LOG_LENGTH));
-			if ( !log.isEmpty() )
+			if ( log.length() > 0 )
 				System.err.println("VERTEX SHADER LOG: " + log);
 
 			fsh = glCreateShader(GL_FRAGMENT_SHADER);
@@ -340,7 +339,7 @@ public class Mandelbrot {
 			                    "}");
 			glCompileShader(fsh);
 			log = glGetShaderInfoLog(fsh, glGetShaderi(fsh, GL_INFO_LOG_LENGTH));
-			if ( !log.isEmpty() )
+			if ( log.length() > 0 )
 				System.err.println("FRAGMENT SHADER LOG: " + log);
 
 			glProgram = glCreateProgram();
@@ -348,7 +347,7 @@ public class Mandelbrot {
 			glAttachShader(glProgram, fsh);
 			glLinkProgram(glProgram);
 			log = glGetProgramInfoLog(glProgram, glGetProgrami(glProgram, GL_INFO_LOG_LENGTH));
-			if ( !log.isEmpty() )
+			if ( log.length() > 0 )
 				System.err.println("PROGRAM LOG: " + log);
 
 			int posIN = glGetAttribLocation(glProgram, "posIN");
@@ -386,7 +385,6 @@ public class Mandelbrot {
 					return;
 
 				events.add(new Runnable() {
-					@Override
 					public void run() {
 						Mandelbrot.this.ww = width;
 						Mandelbrot.this.wh = height;
@@ -404,7 +402,6 @@ public class Mandelbrot {
 					return;
 
 				events.add(new Runnable() {
-					@Override
 					public void run() {
 						Mandelbrot.this.fbw = width;
 						Mandelbrot.this.fbh = height;
@@ -434,7 +431,6 @@ public class Mandelbrot {
 						break;
 					case GLFW_KEY_D:
 						events.offer(new Runnable() {
-							@Override
 							public void run() {
 								doublePrecision = !doublePrecision;
 								log("DOUBLE PRECISION IS NOW: " + (doublePrecision ? "ON" : "OFF"));
@@ -444,7 +440,6 @@ public class Mandelbrot {
 						break;
 					case GLFW_KEY_HOME:
 						events.offer(new Runnable() {
-							@Override
 							public void run() {
 								offsetX = -0.5;
 								offsetY = 0.0;
@@ -565,7 +560,6 @@ public class Mandelbrot {
 
 	private void cleanup() {
 		CLCleaner memObjCleaner = new CLCleaner() {
-			@Override
 			public int release(long object) {
 				return clReleaseMemObject(object);
 			}
@@ -575,28 +569,24 @@ public class Mandelbrot {
 		release(clColorMap, memObjCleaner);
 
 		release(clKernel, new CLCleaner() {
-			@Override
 			public int release(long object) {
 				return clReleaseKernel(object);
 			}
 		});
 
 		release(clProgram, new CLCleaner() {
-			@Override
 			public int release(long object) {
 				return clReleaseProgram(object);
 			}
 		});
 
 		release(clQueue, new CLCleaner() {
-			@Override
 			public int release(long object) {
 				return clReleaseCommandQueue(object);
 			}
 		});
 
 		release(clContext, new CLCleaner() {
-			@Override
 			public int release(long object) {
 				return clReleaseContext(object);
 			}
@@ -763,7 +753,7 @@ public class Mandelbrot {
 					clGetProgramBuildInfoInt(program, cl_device_id, CL_PROGRAM_BUILD_STATUS) == CL_SUCCESS ? "successfully" : "unsuccessfully"
 				);
 				String log = clGetProgramBuildInfoStringASCII(program, cl_device_id, CL_PROGRAM_BUILD_LOG);
-				if ( !log.isEmpty() )
+				if ( log.length() > 0 )
 					System.err.printf("BUILD LOG:\n----\n%s\n-----\n", log);
 
 				latch.countDown();

--- a/src/tests/org/lwjgl/demo/util/ClosureGC.java
+++ b/src/tests/org/lwjgl/demo/util/ClosureGC.java
@@ -31,7 +31,6 @@ public class ClosureGC implements ClosureRegistry {
 		return ClosureGCLoader.INSTANCE;
 	}
 
-	@Override
 	public void register(Closure closure) {
 		stacks.get().register(closure);
 	}

--- a/src/tests/org/lwjgl/opencl/CLTest.java
+++ b/src/tests/org/lwjgl/opencl/CLTest.java
@@ -29,7 +29,6 @@ import static org.testng.Assert.*;
 public class CLTest {
 
 	private static final Filter<CLPlatform> CL11_FILTER = new Filter<CLPlatform>() {
-		@Override
 		public boolean accept(CLPlatform platform) {
 			return platform.getCapabilities().OpenCL11;
 
@@ -37,7 +36,6 @@ public class CLTest {
 	};
 
 	private static final Filter<CLPlatform> CL12_FILTER = new Filter<CLPlatform>() {
-		@Override
 		public boolean accept(CLPlatform platform) {
 			return platform.getCapabilities().OpenCL12;
 
@@ -111,7 +109,6 @@ public class CLTest {
 
 	public void testContext() {
 		contextTest(new ContextTest() {
-			@Override
 			public void test(CLPlatform platform, PointerBuffer ctxProps, CLDevice device) {
 				IntBuffer errcode_ret = BufferUtils.createIntBuffer(1);
 
@@ -136,7 +133,6 @@ public class CLTest {
 
 	public void testNativeKernel() {
 		contextTest(new ContextTest() {
-			@Override
 			public void test(CLPlatform platform, PointerBuffer ctxProps, CLDevice device) {
 				if ( (clGetDeviceInfoLong(device.getPointer(), CL_DEVICE_EXECUTION_CAPABILITIES) & CL_EXEC_NATIVE_KERNEL) == 0 )
 					return;
@@ -235,7 +231,6 @@ public class CLTest {
 
 	public void testMemObjectDestructor() {
 		contextTest(CL11_FILTER, new ContextTest() {
-			@Override
 			public void test(CLPlatform platform, PointerBuffer ctxProps, CLDevice device) {
 				IntBuffer errcode_ret = BufferUtils.createIntBuffer(1);
 
@@ -284,7 +279,6 @@ public class CLTest {
 
 	public void testEventCallback() {
 		contextTest(CL11_FILTER, new ContextTest() {
-			@Override
 			public void test(CLPlatform platform, PointerBuffer ctxProps, CLDevice device) {
 				IntBuffer errcode_ret = BufferUtils.createIntBuffer(1);
 
@@ -329,7 +323,6 @@ public class CLTest {
 
 	public void testSubBuffer() {
 		contextTest(CL11_FILTER, new ContextTest() {
-			@Override
 			public void test(CLPlatform platform, PointerBuffer ctxProps, CLDevice device) {
 				IntBuffer errcode_ret = BufferUtils.createIntBuffer(1);
 


### PR DESCRIPTION
Since LWJGL 3 does not make use of any important Java 1.6 API or JNI functionality, we can just lower the bar on the required Java version even further to 1.5.
And who knows whoever is still using a Java 1.5 JRE because they cannot/don't want to update.
Oh and LWJGL 2 also looks like its 1.5 compatible. So people upgrading from 2 to 3 would have an easy life. :)

The only thing that needed adaptation is the change in the semantics of `@Override` between Java 1.5 and Java 1.6. So, with Java 1.5 source level we would not have a check for unimplemented interface methods in abstract classes anymore with this annotation. But since most code is generated anyway, this should be a minor point.

However, LWJGL 3 still needs to be built with at least a 1.6 JDK, since Kotlin requires that. But I guess the LWJGL 3 build infrastructure does that anyway, if not already with JDK1.7.

I successfully tested a build of the proposed changes under Windows 7 x64 with a VS2013 native build under jre1.5.0_22.