### PR TITLE
Simple Gradle build file to deploy to SonaType or local Maven repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@
 *.wav
 *.zip
 touch.txt
+/.gradle
+/build

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,125 @@
+apply plugin: "maven"
+apply plugin: "signing"
+
+project.group = "org.lwjgl"
+project.version = "3.0.0a"
+
+def isDevBuild
+def isCiBuild
+def isReleaseBuild
+
+def repositoryUrl
+def repositoryUser
+def repositoryPassword
+
+//set build variables based on build type (release, continuous integration, development)
+if(hasProperty("release")) {
+    isReleaseBuild = true
+    repositoryUrl = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"                             
+    repositoryUser = sonatypeUsername
+	repositoryPassword = sonatypePassword
+    println "Performing release build"
+} else if (hasProperty("snapshot")) {
+    isCiBuild = true
+    version += "-SNAPSHOT"
+    repositoryUrl = "https://oss.sonatype.org/content/repositories/snapshots/"
+    repositoryUser = sonatypeUsername
+	repositoryPassword = sonatypePassword
+    println "Performing snapshot build"
+} else {
+    isDevBuild = true
+    repositoryUrl = repositories.mavenLocal().url
+    repositoryUser = ""
+	repositoryPassword = ""
+    println "Performing local build"
+}
+
+artifacts {
+  archives file: file("release/jar/lwjgl.jar"), name: "lwjgl", type: "jar"
+  archives file: file("release/src.jar"), name: "lwjgl", type: "jar", classifier: "sources"
+  archives file: file("release/jar/lwjgl-natives-windows.jar"), name: "lwjgl-windows", type: "jar", classifier: "natives-windows"
+  archives file: file("release/jar/lwjgl-natives-macosx.jar"), name: "lwjgl-macosx", type: "jar", classifier: "natives-osx"
+  archives file: file("release/jar/lwjgl-natives-linux.jar"), name: "lwjgl-linux", type: "jar", classifier: "natives-linux"
+}
+
+if(isReleaseBuild) {
+    signing {
+        sign configurations.archives
+    }
+} else {
+    task signArchives {
+        // do nothing
+    }
+}
+
+Closure defaultPom = {
+	project {
+		packaging "jar"        
+		description 'LWJGL'
+		url 'http://www.lwjgl.org'
+
+		scm {
+		   url 'scm:git@github.com:LWJGL/lwjgl3.git'
+		   connection 'scm:git@github.com:LWJGL/lwjgl3.git'
+		   developerConnection 'scm:git@github.com:LWJGL/lwjgl3.git'
+		}
+
+		licenses {
+		   license {
+		       name 'BSD'
+		       url 'http://www.lwjgl.org/license'
+		       distribution 'repo'
+		   }
+		}
+	}
+}
+
+uploadArchives {
+	repositories {
+		mavenDeployer {
+			repository(url: repositoryUrl) {
+            	authentication(userName: repositoryUser, password: repositoryPassword)
+			}			
+      		
+      		addFilter("lwjgl") {artifact, file -> 
+      			artifact.name == "lwjgl"
+      		}
+      		addFilter("lwjgl-windows") {artifact, file ->
+      			artifact.name == "lwjgl-windows"
+      		}      		
+      		addFilter("lwjgl-macosx") {artifact, file ->
+      			artifact.name == "lwjgl-macosx"
+      		}
+      		addFilter("lwjgl-linux") {artifact, file ->
+      			artifact.name == "lwjgl-linux"
+      		}
+
+      		pom("lwjgl", defaultPom);
+      		pom("lwjgl-windows", defaultPom).artifactId = "lwjgl-platform"
+      		pom("lwjgl-macosx", defaultPom).artifactId = "lwjgl-platform"
+      		pom("lwjgl-linux", defaultPom).artifactId = "lwjgl-platform"
+		}
+    }
+}
+
+task zipNativesWindows(type: Zip) {
+    from "release/native"    
+    include "*.dll"
+    archiveName "lwjgl-natives-windows.jar"
+    destinationDir file("release/jar")
+}
+task zipNativesLinux(type: Zip) {
+    from "release/native"    
+    include "*.so"
+    archiveName "lwjgl-natives-linux.jar"
+    destinationDir file("release/jar")
+}
+task zipNativesMacOSX(type: Zip) {
+    from "release/native"    
+    include "*.dylib"
+    archiveName "lwjgl-natives-macosx.jar"
+    destinationDir file("release/jar")
+}
+uploadArchives.dependsOn(zipNativesWindows)
+uploadArchives.dependsOn(zipNativesLinux)
+uploadArchives.dependsOn(zipNativesMacOSX)

--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ if(hasProperty("release")) {
 
 artifacts {
   archives file: file("release/jar/lwjgl.jar"), name: "lwjgl", type: "jar"
-  archives file: file("release/src.jar"), name: "lwjgl", type: "jar", classifier: "sources"
+  archives file: file("release/jar/src.jar"), name: "lwjgl", type: "jar", classifier: "sources"
   archives file: file("release/jar/javadoc.jar"), name: "lwjgl", type: "jar", classifier: "javadoc"
   archives file: file("build.gradle"), name: "lwjgl-platform", type: "pom"
   archives file: file("release/jar/lwjgl-natives-windows.jar"), name: "lwjgl-platform", type: "jar", classifier: "natives-windows"

--- a/build.gradle
+++ b/build.gradle
@@ -37,9 +37,11 @@ if(hasProperty("release")) {
 artifacts {
   archives file: file("release/jar/lwjgl.jar"), name: "lwjgl", type: "jar"
   archives file: file("release/src.jar"), name: "lwjgl", type: "jar", classifier: "sources"
-  archives file: file("release/jar/lwjgl-natives-windows.jar"), name: "lwjgl-windows", type: "jar", classifier: "natives-windows"
-  archives file: file("release/jar/lwjgl-natives-macosx.jar"), name: "lwjgl-macosx", type: "jar", classifier: "natives-osx"
-  archives file: file("release/jar/lwjgl-natives-linux.jar"), name: "lwjgl-linux", type: "jar", classifier: "natives-linux"
+  archives file: file("release/jar/javadoc.jar"), name: "lwjgl", type: "jar", classifier: "javadoc"
+  archives file: file("build.gradle"), name: "lwjgl-platform", type: "pom"
+  archives file: file("release/jar/lwjgl-natives-windows.jar"), name: "lwjgl-platform", type: "jar", classifier: "natives-windows"
+  archives file: file("release/jar/lwjgl-natives-macosx.jar"), name: "lwjgl-platform", type: "jar", classifier: "natives-osx"
+  archives file: file("release/jar/lwjgl-natives-linux.jar"), name: "lwjgl-platform", type: "jar", classifier: "natives-linux"
 }
 
 if(isReleaseBuild) {
@@ -71,6 +73,13 @@ Closure defaultPom = {
 		       distribution 'repo'
 		   }
 		}
+
+    developers {
+      developer {
+        id "spasi"
+        name "Ioannis Tsakpinis"
+      }    
+    }
 	}
 }
 
@@ -78,28 +87,34 @@ uploadArchives {
 	repositories {
 		mavenDeployer {
 			repository(url: repositoryUrl) {
-            	authentication(userName: repositoryUser, password: repositoryPassword)
-			}			
-      		
-      		addFilter("lwjgl") {artifact, file -> 
-      			artifact.name == "lwjgl"
-      		}
-      		addFilter("lwjgl-windows") {artifact, file ->
-      			artifact.name == "lwjgl-windows"
-      		}      		
-      		addFilter("lwjgl-macosx") {artifact, file ->
-      			artifact.name == "lwjgl-macosx"
-      		}
-      		addFilter("lwjgl-linux") {artifact, file ->
-      			artifact.name == "lwjgl-linux"
-      		}
+        authentication(userName: repositoryUser, password: repositoryPassword)
+			}
 
-      		pom("lwjgl", defaultPom);
-      		pom("lwjgl-windows", defaultPom).artifactId = "lwjgl-platform"
-      		pom("lwjgl-macosx", defaultPom).artifactId = "lwjgl-platform"
-      		pom("lwjgl-linux", defaultPom).artifactId = "lwjgl-platform"
+      if(isReleaseBuild) {
+        beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
+      }		
+      		
+  		addFilter("lwjgl") {artifact, file -> 
+  			artifact.name == "lwjgl"
+  		} 
+      addFilter("lwjgl-platform") {artifact, file -> 
+        artifact.name == "lwjgl-platform"
+      }     		
+
+  		pom("lwjgl", defaultPom).name = "LWJGL"
+  		def platformpom = pom("lwjgl-platform", defaultPom)
+      platformpom.packaging = "pom"
+      platformpom.name = "LWJGL Platform"
 		}
-    }
+  }
+}
+
+task copyJavadocs(type: Copy) {
+  from "release/doc/javadoc.zip"
+  destinationDir file("release/jar")
+  rename { String fileName ->
+    fileName.replace(".zip", ".jar")
+  }
 }
 
 task zipNativesWindows(type: Zip) {
@@ -120,6 +135,13 @@ task zipNativesMacOSX(type: Zip) {
     archiveName "lwjgl-natives-macosx.jar"
     destinationDir file("release/jar")
 }
-uploadArchives.dependsOn(zipNativesWindows)
+
+signArchives.mustRunAfter(copyJavadocs)
+signArchives.mustRunAfter(zipNativesLinux)
+signArchives.mustRunAfter(zipNativesWindows)
+signArchives.mustRunAfter(zipNativesMacOSX)
+
+uploadArchives.dependsOn(copyJavadocs)
 uploadArchives.dependsOn(zipNativesLinux)
+uploadArchives.dependsOn(zipNativesWindows)
 uploadArchives.dependsOn(zipNativesMacOSX)

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ apply plugin: "maven"
 apply plugin: "signing"
 
 project.group = "org.lwjgl"
-project.version = "3.0.0a"
+project.version = "3.0.0b"
 
 def isDevBuild
 def isCiBuild

--- a/build.gradle
+++ b/build.gradle
@@ -109,6 +109,14 @@ uploadArchives {
   }
 }
 
+task copySources(type: Copy) {
+  from "release/src.zip"
+  destinationDir file("release/jar")
+  rename { String fileName ->
+    fileName.replace(".zip", ".jar")
+  }
+}
+
 task copyJavadocs(type: Copy) {
   from "release/doc/javadoc.zip"
   destinationDir file("release/jar")
@@ -135,7 +143,7 @@ task zipNativesMacOSX(type: Zip) {
     archiveName "lwjgl-natives-macosx.jar"
     destinationDir file("release/jar")
 }
-
+copyJavadocs.dependsOn(copySources)
 signArchives.mustRunAfter(copyJavadocs)
 signArchives.mustRunAfter(zipNativesLinux)
 signArchives.mustRunAfter(zipNativesWindows)

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ if(hasProperty("release")) {
     println "Performing release build"
 } else if (hasProperty("snapshot")) {
     isCiBuild = true
-    version += "-SNAPSHOT"
+    project.version += "-SNAPSHOT"
     repositoryUrl = "https://oss.sonatype.org/content/repositories/snapshots/"
     repositoryUser = sonatypeUsername
 	repositoryPassword = sonatypePassword

--- a/build.gradle
+++ b/build.gradle
@@ -143,12 +143,13 @@ task zipNativesMacOSX(type: Zip) {
     archiveName "lwjgl-natives-macosx.jar"
     destinationDir file("release/jar")
 }
-copyJavadocs.dependsOn(copySources)
+signArchives.mustRunAfter(copySources)
 signArchives.mustRunAfter(copyJavadocs)
 signArchives.mustRunAfter(zipNativesLinux)
 signArchives.mustRunAfter(zipNativesWindows)
 signArchives.mustRunAfter(zipNativesMacOSX)
 
+uploadArchives.dependsOn(copySources)
 uploadArchives.dependsOn(copyJavadocs)
 uploadArchives.dependsOn(zipNativesLinux)
 uploadArchives.dependsOn(zipNativesWindows)


### PR DESCRIPTION
Builds on top of the Ant `release` task. Any Gradle 2.x version will do. I didn't want to add the Gradle wrapper to the repo as it dumps a ton of files into the root. It's a quicky, so i'll likely clean it up. E.g. the build file currently pollutes the `release` directory.

### Generated artifacts
The artifacts that are generated are compatible with the old 2.x artifacts already in Central.

```
<dependency>
   <groupId>org.lwjgl</groupId>
   <artifactId>lwjgl</artifactId>
   <version>3.0.0a</version>
</dependency>
```

The natives are cleanly separated into separate artifacts as well, just like before:

```
<dependency>
   <groupId>org.lwjgl</groupId>
   <artifactId>lwjgl-platform</artifactId>
   <version>3.0.0a</version>
   <classifier>natives-windows</classifier>
</dependency>
```

```
<dependency>
   <groupId>org.lwjgl</groupId>
   <artifactId>lwjgl-platform</artifactId>
   <version>3.0.0a</version>
   <classifier>natives-linux</classifier>
</dependency>
```

```
<dependency>
   <groupId>org.lwjgl</groupId>
   <artifactId>lwjgl-platform</artifactId>
   <version>3.0.0a</version>
   <classifier>natives-osx</classifier>
</dependency>
```

### Deploying to the local repo
```
ant release
gradle uploadArchives
```
Puts artifacts in the local Maven repository.

### Deploying to SonaType
Since everything Maven is terrible, you'll need to do some setup first. [Create a SonaType account](http://central.sonatype.org/pages/ossrh-guide.html). You should already have one. Note down the credentials (user/password).

The version you publish is defined in line 5 of `build.gradle` (`project.version`). The `-SNAPSHOT` suffix will be automatically attached if you release snapshots.

#### Publishing Snapshots
```
ant release
gradle -Psnapshot -PsonatypeUsername=<yourusername> -PsonatypePassword=<yourpassword> uploadArchives
```

After that, your users can use snapshot builds by adding the SonaType snapshot repository to their Maven/Gradle.

**Gradle**
```
repositories {
    mavenCentral()
    mavenLocal()
    maven {
        url "https://oss.sonatype.org/content/repositories/snapshots"
    }
}
```

**Maven**
```
<repository>
         <id>snapshots-repo</id>
         <url>https://oss.sonatype.org/content/repositories/snapshots</url>
         <releases><enabled>false</enabled></releases>
         <snapshots><enabled>true</enabled></snapshots>
</repository>
```

#### Publishing Releases
You'll need a GPG key pair, and also register it with some keyserver. [Here's a guide](http://blog.sonatype.com/2010/01/how-to-generate-pgp-signatures-with-maven/#.VYs14hMrLMU). You should already have this for your 2.x Maven Central releases.

First, tag your last commit in Git. Next, make sure the `project.version` is set properly in the `build.gradle`file. Then do this:

```
ant release
gradlew -Prelease -PsonatypeUsername=<username> -PsonatypePassword=<password> -Psigning.keyId=<key-id> -Psigning.password=<key-password> -Psigning.secretKeyRingFile=<path/to/your/keyring.gpg uploadArchives
```

This will sign and publish your release artifacts to SonaType. You then have to login to https://oss.sonatype.org/#welcome and close and release the thing. Go to Staging Repositories, scroll down, select your thing, click Close. Wait until its closed (refresh), then select the thingy again and press release. Your artifacts will then be synched with Maven Central.

If something went wrong before you synched to Maven Central, fear not. Just drop the thing in SonaType and start from scratch.

Once everything is published, increase the `project.version` in the `build.gradle` to your next release version.

I'm happy to do the releases for you if you want, but that would require the sonatype credentials and the gpg key.