### PR TITLE
Rename org.lwjgl.openal.Util to org.lwjgl.openal.ALUtil

### DIFF
--- a/modules/core/src/main/java/org/lwjgl/openal/ALUtil.java
+++ b/modules/core/src/main/java/org/lwjgl/openal/ALUtil.java
@@ -8,9 +8,9 @@ import static org.lwjgl.openal.AL10.*;
 import static org.lwjgl.openal.ALC10.*;
 
 /** Simple OpenAL utility class. */
-public final class Util {
+public final class ALUtil {
 
-	private Util() {
+	private ALUtil() {
 	}
 
 	public static void checkALCError(ALDevice device) {

--- a/modules/core/src/test/java/org/lwjgl/demo/openal/ALCDemo.java
+++ b/modules/core/src/test/java/org/lwjgl/demo/openal/ALCDemo.java
@@ -27,7 +27,7 @@ import com.sun.media.sound.WaveFileReader;
 import static org.lwjgl.openal.AL10.*;
 import static org.lwjgl.openal.ALC10.*;
 import static org.lwjgl.openal.ALC11.*;
-import static org.lwjgl.openal.Util.*;
+import static org.lwjgl.openal.ALUtil.*;
 import static org.testng.Assert.*;
 
 public class ALCDemo {


### PR DESCRIPTION
For the sake of consistency I would propose to rename org.lwjgl.openal.Util to org.lwjgl.openal.ALUtil, but it may break existing code that is using the org.lwjgl.openal.Util class.