### PR TITLE
Add Eclipse IDE project files

### DIFF
--- a/config/ide/eclipse/.classpath
+++ b/config/ide/eclipse/.classpath
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry excluding="org/lwjgl/egl/|org/lwjgl/opengles/|org/lwjgl/glfw/GLFWNativeEGL.java" kind="src" path="modules/core/src/generated/java"/>
+	<classpathentry excluding="org/lwjgl/egl/|org/lwjgl/opengles/" kind="src" path="modules/core/src/main/java">
+		<attributes>
+			<attribute name="org.eclipse.jdt.launching.CLASSPATH_ATTR_LIBRARY_PATH_ENTRY" value="lwjgl3/libs"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry excluding="org/lwjgl/demo/ovr/" kind="src" path="modules/core/src/test/java"/>
+	<classpathentry excluding="org/lwjgl/system/|org/lwjgl/PointerBuffer.java" kind="src" path="modules/templates/src/main/java"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+	<classpathentry kind="lib" path="libs/testng.jar"/>
+	<classpathentry kind="output" path="bin/Tests"/>
+</classpath>

--- a/config/ide/eclipse/.classpath
+++ b/config/ide/eclipse/.classpath
@@ -1,14 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry excluding="org/lwjgl/egl/|org/lwjgl/opengles/|org/lwjgl/glfw/GLFWNativeEGL.java" kind="src" path="modules/core/src/generated/java"/>
-	<classpathentry excluding="org/lwjgl/egl/|org/lwjgl/opengles/" kind="src" path="modules/core/src/main/java">
+	<classpathentry kind="src" path="modules/core/src/generated/java"/>
+	<classpathentry kind="src" path="modules/core/src/main/java">
 		<attributes>
-			<attribute name="org.eclipse.jdt.launching.CLASSPATH_ATTR_LIBRARY_PATH_ENTRY" value="lwjgl3/libs"/>
+			<attribute name="org.eclipse.jdt.launching.CLASSPATH_ATTR_LIBRARY_PATH_ENTRY" value="libs"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry excluding="org/lwjgl/demo/ovr/" kind="src" path="modules/core/src/test/java"/>
-	<classpathentry excluding="org/lwjgl/system/|org/lwjgl/PointerBuffer.java" kind="src" path="modules/templates/src/main/java"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry kind="lib" path="libs/testng.jar"/>
-	<classpathentry kind="output" path="bin/Tests"/>
+	<classpathentry kind="output" path="bin/eclipse"/>
 </classpath>

--- a/config/ide/eclipse/.project
+++ b/config/ide/eclipse/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>lwjgl3</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>


### PR DESCRIPTION
These include the .project and .classpath files needed for Eclipse Java projects with a minimum working configuration.