### PR TITLE
Fix setDebugStreamConsumer for Windows

### DIFF
--- a/modules/core/src/main/java/org/lwjgl/system/Configuration.java
+++ b/modules/core/src/main/java/org/lwjgl/system/Configuration.java
@@ -307,7 +307,12 @@ public enum Configuration {
 				if ( count == 0 )
 					return;
 
-				consumer.accept(new String(buf, 0, count - 1, charset));
+				if (buf[count - 1] == '\n')
+					count--;
+				if (buf[count - 1] == '\r')
+					count--;
+
+				consumer.accept(new String(buf, 0, count, charset));
 				this.reset();
 			}
 		};


### PR DESCRIPTION
Windows uses CRLF as line separator instead of only CR or LF. This led to only LF getting trimmed and CR remaining which resulted in log messages getting overwritten by the next message.

(Unfortunately, I amended the commit and force pushed instead of rebasing so I have to create a new PR.)