### PR TITLE
Fixed String.format syntax error

### DIFF
--- a/modules/core/src/main/java/org/lwjgl/opengl/GL.java
+++ b/modules/core/src/main/java/org/lwjgl/opengl/GL.java
@@ -323,7 +323,7 @@ public final class GL {
 
 			int errorCode = callI(GetError);
 			if ( errorCode != GL_NO_ERROR )
-				apiLog(String.format("An OpenGL context was in an error state before the creation of its capabilities instance. Error: 0x%X" + errorCode));
+				apiLog(String.format("An OpenGL context was in an error state before the creation of its capabilities instance. Error: 0x%X", errorCode));
 
 			int majorVersion;
 			int minorVersion;


### PR DESCRIPTION
Small syntax error in the String.format output of the API log, causing an exception if there is an OpenGL context error before GL.createCapabilities();