### PR TITLE
Prevent NPE if Manifest#getAttributes returns null

### DIFF
--- a/modules/core/src/main/java/org/lwjgl/system/APIUtil.java
+++ b/modules/core/src/main/java/org/lwjgl/system/APIUtil.java
@@ -93,7 +93,7 @@ public final class APIUtil {
 			String classURL = url.toString();
 			if ( classURL.startsWith("jar:") ) {
 				try ( InputStream stream = new URL(classURL.substring(0, classURL.lastIndexOf("!") + 1) + '/' + JarFile.MANIFEST_NAME).openStream() ) {
-					return Optional.ofNullable(new Manifest(stream).getAttributes("org/lwjgl/").getValue(attributeName));
+					return Optional.ofNullable(new Manifest(stream).getAttributes("org/lwjgl/")).map(attr -> attr.getValue(attributeName));
 				} catch (Exception e) {
 					e.printStackTrace(APIUtil.DEBUG_STREAM);
 				}


### PR DESCRIPTION
On startup, lwjgl throws a NPE that's just caught and printed due to `new Manifest(stream).getAttributes("org/lwjgl/")` returning null in `APIUtil#apiGetManifestValue(String)`.

```
java.lang.NullPointerException
	at org.lwjgl.system.APIUtil.apiGetManifestValue(APIUtil.java:97)
	at org.lwjgl.Version.getVersion(Version.java:33)
	at org.lwjgl.system.Library.<clinit>(Library.java:35)
	at org.lwjgl.system.MemoryAccess.<clinit>(MemoryAccess.java:17)                                                                          1
	at org.lwjgl.system.ThreadLocalUtil$UnsafeState.<clinit>(ThreadLocalUtil.java:86)
	at org.lwjgl.system.ThreadLocalUtil.getInstance(ThreadLocalUtil.java:43)
	at org.lwjgl.system.ThreadLocalUtil.<clinit>(ThreadLocalUtil.java:20)
	at org.lwjgl.system.MemoryStack.stackPush(MemoryStack.java:577)
	at org.lwjgl.system.Callback.<clinit>(Callback.java:35)
```