### PR TITLE
Update license URL across all files & tweak license

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright (c) 2012-2016 Lightweight Java Game Library Project
+Copyright (c) 2012-present Lightweight Java Game Library
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -12,7 +12,7 @@ met:
   notice, this list of conditions and the following disclaimer in the
   documentation and/or other materials provided with the distribution.
 
-- Neither the name of 'Light Weight Java Game Library' nor the names of
+- Neither the name Lightweight Java Game Library nor the names of
   its contributors may be used to endorse or promote products derived
   from this software without specific prior written permission.
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 project.buildDir = 'bin/MAVEN'
 

--- a/build.xml
+++ b/build.xml
@@ -1,6 +1,6 @@
 <!--
 Copyright LWJGL. All rights reserved.
-License terms: http://lwjgl.org/license.php
+License terms: https://www.lwjgl.org/license
 -->
 <project name="LWJGL" basedir="." default="all" xmlns:if="ant:if" xmlns:unless="ant:unless">
 
@@ -523,7 +523,7 @@ License terms: http://lwjgl.org/license.php
 		    failonerror="true"
 		>
 			<doctitle><![CDATA[<h1>Lightweight Java Game Library</h1>]]></doctitle>
-			<bottom><![CDATA[<i>Copyright LWJGL. All Rights Reserved. <a href="http://lwjgl.org/license.php">License terms</a>.</i>]]></bottom>
+			<bottom><![CDATA[<i>Copyright LWJGL. All Rights Reserved. <a href="https://www.lwjgl.org/license">License terms</a>.</i>]]></bottom>
 
 			<classpath>
 				<pathelement path="${src.core}"/>
@@ -670,7 +670,7 @@ License terms: http://lwjgl.org/license.php
 				failonerror="true"
 			>
 				<doctitle><![CDATA[<h1>LWJGL - @{title}</h1>]]></doctitle>
-				<bottom><![CDATA[<i>Copyright LWJGL. All Rights Reserved. <a href="http://lwjgl.org/license.php">License terms</a>.</i>]]></bottom>
+				<bottom><![CDATA[<i>Copyright LWJGL. All Rights Reserved. <a href="https://www.lwjgl.org/license">License terms</a>.</i>]]></bottom>
 
 				<classpath>
 					<pathelement path="${src.core}"/>

--- a/config/build-assets.xml
+++ b/config/build-assets.xml
@@ -1,6 +1,6 @@
 <!--
 Copyright LWJGL. All rights reserved.
-License terms: http://lwjgl.org/license.php
+License terms: https://www.lwjgl.org/license
 
 Binary assets used in demos are not committed to the git repository.
 This script downloads such assets from S3.

--- a/config/build-bindings.xml
+++ b/config/build-bindings.xml
@@ -1,6 +1,6 @@
 <!--
 Copyright LWJGL. All rights reserved.
-License terms: http://lwjgl.org/license.php
+License terms: https://www.lwjgl.org/license
 
 Defines which library bindings will be build with LWJGL.
 

--- a/config/build-definitions.xml
+++ b/config/build-definitions.xml
@@ -1,6 +1,6 @@
 <!--
 Copyright LWJGL. All rights reserved.
-License terms: http://lwjgl.org/license.php
+License terms: https://www.lwjgl.org/license
 
 Defines global properties and useful macros.
 

--- a/config/ide/netbeans/nbproject/licenseheader.txt
+++ b/config/ide/netbeans/nbproject/licenseheader.txt
@@ -2,7 +2,7 @@
 ${licenseFirst}
 </#if>
 ${licensePrefix}Copyright LWJGL. All rights reserved.
-${licensePrefix}License terms: http://lwjgl.org/license.php
+${licensePrefix}License terms: https://www.lwjgl.org/license
 <#if licenseLast??>
 ${licenseLast}
 </#if>

--- a/config/javadoc.css
+++ b/config/javadoc.css
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 
 /* Javadoc style sheet - Compatible only with JDK 9 + HTML5 */

--- a/config/linux/build.xml
+++ b/config/linux/build.xml
@@ -1,6 +1,6 @@
 <!--
 Copyright LWJGL. All rights reserved.
-License terms: http://lwjgl.org/license.php
+License terms: https://www.lwjgl.org/license
 -->
 <project name="native-linux" basedir="../.." xmlns:if="ant:if" xmlns:unless="ant:unless">
 	<import file="../build-definitions.xml"/>

--- a/config/macosx/build.xml
+++ b/config/macosx/build.xml
@@ -1,6 +1,6 @@
 <!--
 Copyright LWJGL. All rights reserved.
-License terms: http://lwjgl.org/license.php
+License terms: https://www.lwjgl.org/license
 -->
 <project name="native-macosx" basedir="../.." xmlns:if="ant:if" xmlns:unless="ant:unless">
 	<import file="../build-definitions.xml"/>

--- a/config/windows/build.xml
+++ b/config/windows/build.xml
@@ -1,6 +1,6 @@
 <!--
 Copyright LWJGL. All rights reserved.
-License terms: http://lwjgl.org/license.php
+License terms: https://www.lwjgl.org/license
 -->
 <project name="native-windows" basedir="../.." xmlns:if="ant:if" xmlns:unless="ant:unless">
 	<import file="../build-definitions.xml"/>

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 #
 # Copyright LWJGL. All rights reserved.
-# License terms: http://lwjgl.org/license.php
+# License terms: https://www.lwjgl.org/license
 #
 
 # MAJOR.MINOR.REVISION [0-9].[0-9].[0-9]+[ab]?

--- a/modules/core/src/main/c/system/common_tools.c
+++ b/modules/core/src/main/c/system/common_tools.c
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 #ifdef LWJGL_WINDOWS
 	__pragma(warning(disable : 4710))

--- a/modules/core/src/main/c/system/org_lwjgl_system_Callback.c
+++ b/modules/core/src/main/c/system/org_lwjgl_system_Callback.c
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 #ifdef LWJGL_WINDOWS
 	__pragma(warning(disable : 4710))

--- a/modules/core/src/main/c/system/org_lwjgl_system_MemoryAccess.c
+++ b/modules/core/src/main/c/system/org_lwjgl_system_MemoryAccess.c
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 #include "common_tools.h"
 DISABLE_WARNINGS()

--- a/modules/core/src/main/c/system/org_lwjgl_system_MemoryUtil.c
+++ b/modules/core/src/main/c/system/org_lwjgl_system_MemoryUtil.c
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 #include "common_tools.h"
 

--- a/modules/core/src/main/include/system/common_tools.h
+++ b/modules/core/src/main/include/system/common_tools.h
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 #ifndef __LWJGL_COMMON_TOOLS_H__
 #define __LWJGL_COMMON_TOOLS_H__

--- a/modules/core/src/main/include/system/linux/LinuxConfig.h
+++ b/modules/core/src/main/include/system/linux/LinuxConfig.h
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 
 #include <stddef.h>

--- a/modules/core/src/main/include/system/linux/LinuxLWJGL.h
+++ b/modules/core/src/main/include/system/linux/LinuxLWJGL.h
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 #ifndef _LINUX_LWJGL_INCLUDED
 	#define _LINUX_LWJGL_INCLUDED

--- a/modules/core/src/main/include/system/lwjgl_malloc.h
+++ b/modules/core/src/main/include/system/lwjgl_malloc.h
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 #ifndef __LWJGL_MALLOC_H__
 #define __LWJGL_MALLOC_H__

--- a/modules/core/src/main/include/system/macosx/MacOSXConfig.h
+++ b/modules/core/src/main/include/system/macosx/MacOSXConfig.h
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 
 #include <stddef.h>

--- a/modules/core/src/main/include/system/macosx/MacOSXLWJGL.h
+++ b/modules/core/src/main/include/system/macosx/MacOSXLWJGL.h
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 #ifndef _MACOSX_LWJGL_INCLUDED
 	#define _MACOSX_LWJGL_INCLUDED

--- a/modules/core/src/main/include/system/windows/WindowsConfig.h
+++ b/modules/core/src/main/include/system/windows/WindowsConfig.h
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 
 #define DISABLE_WARNINGS() \

--- a/modules/core/src/main/include/system/windows/WindowsLWJGL.h
+++ b/modules/core/src/main/include/system/windows/WindowsLWJGL.h
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 #ifndef _WINDOWS_LWJGL_INCLUDED
 	#define _WINDOWS_LWJGL_INCLUDED

--- a/modules/core/src/main/include/util/simd/intrinsics.h
+++ b/modules/core/src/main/include/util/simd/intrinsics.h
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 #ifndef __LWJGL_SIMD_INTRINSICS_H__
 #define __LWJGL_SIMD_INTRINSICS_H__

--- a/modules/core/src/main/java/org/lwjgl/BufferUtils.java
+++ b/modules/core/src/main/java/org/lwjgl/BufferUtils.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl;
 

--- a/modules/core/src/main/java/org/lwjgl/PointerBuffer.java
+++ b/modules/core/src/main/java/org/lwjgl/PointerBuffer.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl;
 

--- a/modules/core/src/main/java/org/lwjgl/Version.java
+++ b/modules/core/src/main/java/org/lwjgl/Version.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl;
 

--- a/modules/core/src/main/java/org/lwjgl/egl/EGL.java
+++ b/modules/core/src/main/java/org/lwjgl/egl/EGL.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.egl;
 

--- a/modules/core/src/main/java/org/lwjgl/glfw/Callbacks.java
+++ b/modules/core/src/main/java/org/lwjgl/glfw/Callbacks.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.glfw;
 

--- a/modules/core/src/main/java/org/lwjgl/glfw/EventLoop.java
+++ b/modules/core/src/main/java/org/lwjgl/glfw/EventLoop.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.glfw;
 

--- a/modules/core/src/main/java/org/lwjgl/nanovg/NanoVGGLConfig.java
+++ b/modules/core/src/main/java/org/lwjgl/nanovg/NanoVGGLConfig.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.nanovg;
 

--- a/modules/core/src/main/java/org/lwjgl/openal/AL.java
+++ b/modules/core/src/main/java/org/lwjgl/openal/AL.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.openal;
 

--- a/modules/core/src/main/java/org/lwjgl/openal/ALC.java
+++ b/modules/core/src/main/java/org/lwjgl/openal/ALC.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.openal;
 

--- a/modules/core/src/main/java/org/lwjgl/openal/ALUtil.java
+++ b/modules/core/src/main/java/org/lwjgl/openal/ALUtil.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.openal;
 

--- a/modules/core/src/main/java/org/lwjgl/opencl/CL.java
+++ b/modules/core/src/main/java/org/lwjgl/opencl/CL.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opencl;
 

--- a/modules/core/src/main/java/org/lwjgl/opengl/GL.java
+++ b/modules/core/src/main/java/org/lwjgl/opengl/GL.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl;
 

--- a/modules/core/src/main/java/org/lwjgl/opengl/GLChecks.java
+++ b/modules/core/src/main/java/org/lwjgl/opengl/GLChecks.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl;
 

--- a/modules/core/src/main/java/org/lwjgl/opengl/GLUtil.java
+++ b/modules/core/src/main/java/org/lwjgl/opengl/GLUtil.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl;
 

--- a/modules/core/src/main/java/org/lwjgl/opengles/GLES.java
+++ b/modules/core/src/main/java/org/lwjgl/opengles/GLES.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles;
 

--- a/modules/core/src/main/java/org/lwjgl/opengles/GLESChecks.java
+++ b/modules/core/src/main/java/org/lwjgl/opengles/GLESChecks.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles;
 

--- a/modules/core/src/main/java/org/lwjgl/package-info.java
+++ b/modules/core/src/main/java/org/lwjgl/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 
 /**
@@ -16,6 +16,6 @@
  *
  * <p>LWJGL is open source software and freely available at no charge.</p>
  *
- * @see <a href="http://www.lwjgl.org/">www.lwjgl.org</a>
+ * @see <a href="https://www.lwjgl.org/">www.lwjgl.org</a>
  */
 package org.lwjgl;

--- a/modules/core/src/main/java/org/lwjgl/system/APIUtil.java
+++ b/modules/core/src/main/java/org/lwjgl/system/APIUtil.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.system;
 

--- a/modules/core/src/main/java/org/lwjgl/system/Callback.java
+++ b/modules/core/src/main/java/org/lwjgl/system/Callback.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.system;
 

--- a/modules/core/src/main/java/org/lwjgl/system/CallbackI.java
+++ b/modules/core/src/main/java/org/lwjgl/system/CallbackI.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.system;
 

--- a/modules/core/src/main/java/org/lwjgl/system/Checks.java
+++ b/modules/core/src/main/java/org/lwjgl/system/Checks.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.system;
 

--- a/modules/core/src/main/java/org/lwjgl/system/Configuration.java
+++ b/modules/core/src/main/java/org/lwjgl/system/Configuration.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.system;
 

--- a/modules/core/src/main/java/org/lwjgl/system/FunctionProvider.java
+++ b/modules/core/src/main/java/org/lwjgl/system/FunctionProvider.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.system;
 

--- a/modules/core/src/main/java/org/lwjgl/system/FunctionProviderLocal.java
+++ b/modules/core/src/main/java/org/lwjgl/system/FunctionProviderLocal.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.system;
 

--- a/modules/core/src/main/java/org/lwjgl/system/Library.java
+++ b/modules/core/src/main/java/org/lwjgl/system/Library.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.system;
 

--- a/modules/core/src/main/java/org/lwjgl/system/MathUtil.java
+++ b/modules/core/src/main/java/org/lwjgl/system/MathUtil.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.system;
 

--- a/modules/core/src/main/java/org/lwjgl/system/MemoryAccess.java
+++ b/modules/core/src/main/java/org/lwjgl/system/MemoryAccess.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.system;
 

--- a/modules/core/src/main/java/org/lwjgl/system/MemoryManage.java
+++ b/modules/core/src/main/java/org/lwjgl/system/MemoryManage.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.system;
 

--- a/modules/core/src/main/java/org/lwjgl/system/MemoryStack.java
+++ b/modules/core/src/main/java/org/lwjgl/system/MemoryStack.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.system;
 

--- a/modules/core/src/main/java/org/lwjgl/system/MemoryTextUtil.java
+++ b/modules/core/src/main/java/org/lwjgl/system/MemoryTextUtil.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.system;
 

--- a/modules/core/src/main/java/org/lwjgl/system/MemoryUtil.java
+++ b/modules/core/src/main/java/org/lwjgl/system/MemoryUtil.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.system;
 

--- a/modules/core/src/main/java/org/lwjgl/system/NativeResource.java
+++ b/modules/core/src/main/java/org/lwjgl/system/NativeResource.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.system;
 

--- a/modules/core/src/main/java/org/lwjgl/system/Platform.java
+++ b/modules/core/src/main/java/org/lwjgl/system/Platform.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.system;
 

--- a/modules/core/src/main/java/org/lwjgl/system/Pointer.java
+++ b/modules/core/src/main/java/org/lwjgl/system/Pointer.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.system;
 

--- a/modules/core/src/main/java/org/lwjgl/system/SharedLibrary.java
+++ b/modules/core/src/main/java/org/lwjgl/system/SharedLibrary.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.system;
 

--- a/modules/core/src/main/java/org/lwjgl/system/SharedLibraryLoader.java
+++ b/modules/core/src/main/java/org/lwjgl/system/SharedLibraryLoader.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.system;
 

--- a/modules/core/src/main/java/org/lwjgl/system/Struct.java
+++ b/modules/core/src/main/java/org/lwjgl/system/Struct.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.system;
 

--- a/modules/core/src/main/java/org/lwjgl/system/StructBuffer.java
+++ b/modules/core/src/main/java/org/lwjgl/system/StructBuffer.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.system;
 

--- a/modules/core/src/main/java/org/lwjgl/system/ThreadLocalUtil.java
+++ b/modules/core/src/main/java/org/lwjgl/system/ThreadLocalUtil.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.system;
 

--- a/modules/core/src/main/java/org/lwjgl/system/linux/LinuxLibrary.java
+++ b/modules/core/src/main/java/org/lwjgl/system/linux/LinuxLibrary.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.system.linux;
 

--- a/modules/core/src/main/java/org/lwjgl/system/macosx/MacOSXLibrary.java
+++ b/modules/core/src/main/java/org/lwjgl/system/macosx/MacOSXLibrary.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.system.macosx;
 

--- a/modules/core/src/main/java/org/lwjgl/system/macosx/MacOSXLibraryBundle.java
+++ b/modules/core/src/main/java/org/lwjgl/system/macosx/MacOSXLibraryBundle.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.system.macosx;
 

--- a/modules/core/src/main/java/org/lwjgl/system/macosx/MacOSXLibraryDL.java
+++ b/modules/core/src/main/java/org/lwjgl/system/macosx/MacOSXLibraryDL.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.system.macosx;
 

--- a/modules/core/src/main/java/org/lwjgl/system/package-info.java
+++ b/modules/core/src/main/java/org/lwjgl/system/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 
 /**

--- a/modules/core/src/main/java/org/lwjgl/system/windows/WindowsLibrary.java
+++ b/modules/core/src/main/java/org/lwjgl/system/windows/WindowsLibrary.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.system.windows;
 

--- a/modules/core/src/main/java/org/lwjgl/system/windows/WindowsUtil.java
+++ b/modules/core/src/main/java/org/lwjgl/system/windows/WindowsUtil.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.system.windows;
 

--- a/modules/core/src/main/java/org/lwjgl/vulkan/DispatchableHandle.java
+++ b/modules/core/src/main/java/org/lwjgl/vulkan/DispatchableHandle.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.vulkan;
 

--- a/modules/core/src/main/java/org/lwjgl/vulkan/VK.java
+++ b/modules/core/src/main/java/org/lwjgl/vulkan/VK.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.vulkan;
 

--- a/modules/core/src/main/java/org/lwjgl/vulkan/VKUtil.java
+++ b/modules/core/src/main/java/org/lwjgl/vulkan/VKUtil.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.vulkan;
 

--- a/modules/core/src/main/java/org/lwjgl/vulkan/VkCommandBuffer.java
+++ b/modules/core/src/main/java/org/lwjgl/vulkan/VkCommandBuffer.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.vulkan;
 

--- a/modules/core/src/main/java/org/lwjgl/vulkan/VkDevice.java
+++ b/modules/core/src/main/java/org/lwjgl/vulkan/VkDevice.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.vulkan;
 

--- a/modules/core/src/main/java/org/lwjgl/vulkan/VkInstance.java
+++ b/modules/core/src/main/java/org/lwjgl/vulkan/VkInstance.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.vulkan;
 

--- a/modules/core/src/main/java/org/lwjgl/vulkan/VkPhysicalDevice.java
+++ b/modules/core/src/main/java/org/lwjgl/vulkan/VkPhysicalDevice.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.vulkan;
 

--- a/modules/core/src/main/java/org/lwjgl/vulkan/VkQueue.java
+++ b/modules/core/src/main/java/org/lwjgl/vulkan/VkQueue.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.vulkan;
 

--- a/modules/core/src/test/java/org/lwjgl/demo/egl/EGLDemo.java
+++ b/modules/core/src/test/java/org/lwjgl/demo/egl/EGLDemo.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.demo.egl;
 

--- a/modules/core/src/test/java/org/lwjgl/demo/glfw/Events.java
+++ b/modules/core/src/test/java/org/lwjgl/demo/glfw/Events.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.demo.glfw;
 

--- a/modules/core/src/test/java/org/lwjgl/demo/glfw/GLFWUtil.java
+++ b/modules/core/src/test/java/org/lwjgl/demo/glfw/GLFWUtil.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.demo.glfw;
 

--- a/modules/core/src/test/java/org/lwjgl/demo/glfw/Gears.java
+++ b/modules/core/src/test/java/org/lwjgl/demo/glfw/Gears.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.demo.glfw;
 

--- a/modules/core/src/test/java/org/lwjgl/demo/glfw/MultipleWindows.java
+++ b/modules/core/src/test/java/org/lwjgl/demo/glfw/MultipleWindows.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.demo.glfw;
 

--- a/modules/core/src/test/java/org/lwjgl/demo/glfw/Threads.java
+++ b/modules/core/src/test/java/org/lwjgl/demo/glfw/Threads.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.demo.glfw;
 

--- a/modules/core/src/test/java/org/lwjgl/demo/nanovg/Demo.java
+++ b/modules/core/src/test/java/org/lwjgl/demo/nanovg/Demo.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.demo.nanovg;
 

--- a/modules/core/src/test/java/org/lwjgl/demo/nanovg/ExampleFBO.java
+++ b/modules/core/src/test/java/org/lwjgl/demo/nanovg/ExampleFBO.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.demo.nanovg;
 

--- a/modules/core/src/test/java/org/lwjgl/demo/nanovg/ExampleGL2.java
+++ b/modules/core/src/test/java/org/lwjgl/demo/nanovg/ExampleGL2.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.demo.nanovg;
 

--- a/modules/core/src/test/java/org/lwjgl/demo/nanovg/ExampleGL3.java
+++ b/modules/core/src/test/java/org/lwjgl/demo/nanovg/ExampleGL3.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.demo.nanovg;
 

--- a/modules/core/src/test/java/org/lwjgl/demo/nuklear/Calculator.java
+++ b/modules/core/src/test/java/org/lwjgl/demo/nuklear/Calculator.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.demo.nuklear;
 

--- a/modules/core/src/test/java/org/lwjgl/demo/nuklear/Demo.java
+++ b/modules/core/src/test/java/org/lwjgl/demo/nuklear/Demo.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.demo.nuklear;
 

--- a/modules/core/src/test/java/org/lwjgl/demo/nuklear/GLFWDemo.java
+++ b/modules/core/src/test/java/org/lwjgl/demo/nuklear/GLFWDemo.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.demo.nuklear;
 

--- a/modules/core/src/test/java/org/lwjgl/demo/openal/ALCDemo.java
+++ b/modules/core/src/test/java/org/lwjgl/demo/openal/ALCDemo.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.demo.openal;
 

--- a/modules/core/src/test/java/org/lwjgl/demo/openal/EFXTest.java
+++ b/modules/core/src/test/java/org/lwjgl/demo/openal/EFXTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.demo.openal;
 

--- a/modules/core/src/test/java/org/lwjgl/demo/openal/EFXUtil.java
+++ b/modules/core/src/test/java/org/lwjgl/demo/openal/EFXUtil.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.demo.openal;
 

--- a/modules/core/src/test/java/org/lwjgl/demo/openal/HRTFDemo.java
+++ b/modules/core/src/test/java/org/lwjgl/demo/openal/HRTFDemo.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.demo.openal;
 

--- a/modules/core/src/test/java/org/lwjgl/demo/openal/OpenALInfo.java
+++ b/modules/core/src/test/java/org/lwjgl/demo/openal/OpenALInfo.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.demo.openal;
 

--- a/modules/core/src/test/java/org/lwjgl/demo/opencl/CLDemo.java
+++ b/modules/core/src/test/java/org/lwjgl/demo/opencl/CLDemo.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.demo.opencl;
 

--- a/modules/core/src/test/java/org/lwjgl/demo/opencl/CLGLInteropDemo.java
+++ b/modules/core/src/test/java/org/lwjgl/demo/opencl/CLGLInteropDemo.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.demo.opencl;
 

--- a/modules/core/src/test/java/org/lwjgl/demo/opencl/Mandelbrot.java
+++ b/modules/core/src/test/java/org/lwjgl/demo/opencl/Mandelbrot.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.demo.opencl;
 

--- a/modules/core/src/test/java/org/lwjgl/demo/opengl/AbstractGears.java
+++ b/modules/core/src/test/java/org/lwjgl/demo/opengl/AbstractGears.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 
 package org.lwjgl.demo.opengl;

--- a/modules/core/src/test/java/org/lwjgl/demo/ovr/HelloLibOVR.java
+++ b/modules/core/src/test/java/org/lwjgl/demo/ovr/HelloLibOVR.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.demo.ovr;
 

--- a/modules/core/src/test/java/org/lwjgl/demo/stb/EasyFont.java
+++ b/modules/core/src/test/java/org/lwjgl/demo/stb/EasyFont.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.demo.stb;
 

--- a/modules/core/src/test/java/org/lwjgl/demo/stb/FontDemo.java
+++ b/modules/core/src/test/java/org/lwjgl/demo/stb/FontDemo.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.demo.stb;
 

--- a/modules/core/src/test/java/org/lwjgl/demo/stb/Image.java
+++ b/modules/core/src/test/java/org/lwjgl/demo/stb/Image.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.demo.stb;
 

--- a/modules/core/src/test/java/org/lwjgl/demo/stb/Truetype.java
+++ b/modules/core/src/test/java/org/lwjgl/demo/stb/Truetype.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.demo.stb;
 

--- a/modules/core/src/test/java/org/lwjgl/demo/stb/TruetypeOversample.java
+++ b/modules/core/src/test/java/org/lwjgl/demo/stb/TruetypeOversample.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.demo.stb;
 

--- a/modules/core/src/test/java/org/lwjgl/demo/stb/Vorbis.java
+++ b/modules/core/src/test/java/org/lwjgl/demo/stb/Vorbis.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.demo.stb;
 

--- a/modules/core/src/test/java/org/lwjgl/demo/system/jawt/JAWTDemo.java
+++ b/modules/core/src/test/java/org/lwjgl/demo/system/jawt/JAWTDemo.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.demo.system.jawt;
 

--- a/modules/core/src/test/java/org/lwjgl/demo/system/jawt/LWJGLCanvas.java
+++ b/modules/core/src/test/java/org/lwjgl/demo/system/jawt/LWJGLCanvas.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.demo.system.jawt;
 

--- a/modules/core/src/test/java/org/lwjgl/demo/util/IOUtil.java
+++ b/modules/core/src/test/java/org/lwjgl/demo/util/IOUtil.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.demo.util;
 

--- a/modules/core/src/test/java/org/lwjgl/demo/util/lmdb/LMDBDemo.java
+++ b/modules/core/src/test/java/org/lwjgl/demo/util/lmdb/LMDBDemo.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.demo.util.lmdb;
 

--- a/modules/core/src/test/java/org/lwjgl/demo/util/lmdb/MTest.java
+++ b/modules/core/src/test/java/org/lwjgl/demo/util/lmdb/MTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.demo.util.lmdb;
 

--- a/modules/core/src/test/java/org/lwjgl/demo/util/nfd/HelloNFD.java
+++ b/modules/core/src/test/java/org/lwjgl/demo/util/nfd/HelloNFD.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.demo.util.nfd;
 

--- a/modules/core/src/test/java/org/lwjgl/demo/util/par/ParShapesDemo.java
+++ b/modules/core/src/test/java/org/lwjgl/demo/util/par/ParShapesDemo.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.demo.util.par;
 

--- a/modules/core/src/test/java/org/lwjgl/demo/util/tinyfd/HelloTinyFD.java
+++ b/modules/core/src/test/java/org/lwjgl/demo/util/tinyfd/HelloTinyFD.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.demo.util.tinyfd;
 

--- a/modules/core/src/test/java/org/lwjgl/demo/util/xxhash/XXHashDemo.java
+++ b/modules/core/src/test/java/org/lwjgl/demo/util/xxhash/XXHashDemo.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.demo.util.xxhash;
 

--- a/modules/core/src/test/java/org/lwjgl/demo/vulkan/HelloVulkan.java
+++ b/modules/core/src/test/java/org/lwjgl/demo/vulkan/HelloVulkan.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.demo.vulkan;
 

--- a/modules/core/src/test/java/org/lwjgl/opencl/CLTest.java
+++ b/modules/core/src/test/java/org/lwjgl/opencl/CLTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opencl;
 

--- a/modules/core/src/test/java/org/lwjgl/opencl/InfoUtil.java
+++ b/modules/core/src/test/java/org/lwjgl/opencl/InfoUtil.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opencl;
 

--- a/modules/core/src/test/java/org/lwjgl/system/MemoryUtilTest.java
+++ b/modules/core/src/test/java/org/lwjgl/system/MemoryUtilTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.system;
 

--- a/modules/core/src/test/java/org/lwjgl/system/StackTest.java
+++ b/modules/core/src/test/java/org/lwjgl/system/StackTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.system;
 

--- a/modules/core/src/test/java/org/lwjgl/system/dyncall/DynCallTest.java
+++ b/modules/core/src/test/java/org/lwjgl/system/dyncall/DynCallTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.system.dyncall;
 

--- a/modules/core/src/test/java/org/lwjgl/system/windows/LibraryTest.java
+++ b/modules/core/src/test/java/org/lwjgl/system/windows/LibraryTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.system.windows;
 

--- a/modules/core/src/test/java/org/lwjgl/system/windows/WindowsPlatformTest.java
+++ b/modules/core/src/test/java/org/lwjgl/system/windows/WindowsPlatformTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.system.windows;
 

--- a/modules/core/src/test/java/org/lwjgl/system/windows/WindowsTest.java
+++ b/modules/core/src/test/java/org/lwjgl/system/windows/WindowsTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.system.windows;
 

--- a/modules/core/src/test/java/org/lwjgl/util/par/ParTest.java
+++ b/modules/core/src/test/java/org/lwjgl/util/par/ParTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.util.par;
 

--- a/modules/core/src/test/java/org/lwjgl/util/simd/SSETest.java
+++ b/modules/core/src/test/java/org/lwjgl/util/simd/SSETest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.util.simd;
 

--- a/modules/generator/src/main/java/org/lwjgl/generator/util/TemplateFormatter.java
+++ b/modules/generator/src/main/java/org/lwjgl/generator/util/TemplateFormatter.java
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.generator.util;
 

--- a/modules/generator/src/main/java/org/lwjgl/generator/util/vulkan/ValidityGenerator.java
+++ b/modules/generator/src/main/java/org/lwjgl/generator/util/vulkan/ValidityGenerator.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.generator.util.vulkan;
 
@@ -61,7 +61,7 @@ public final class ValidityGenerator {
 
 			bw.write("/*\n" +
 				         " * Copyright LWJGL. All rights reserved.\n" +
-				         " * License terms: http://lwjgl.org/license.php\n" +
+				         " * License terms: https://www.lwjgl.org/license\n" +
 				         " * MACHINE GENERATED FILE, DO NOT EDIT\n" +
 				         " */\n");
 			bw.write("package org.lwjgl.vulkan\n\n");

--- a/modules/generator/src/main/java/org/lwjgl/generator/util/vulkan/VulkanFormatter.java
+++ b/modules/generator/src/main/java/org/lwjgl/generator/util/vulkan/VulkanFormatter.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.generator.util.vulkan;
 

--- a/modules/generator/src/main/java/org/lwjgl/system/ExcludeDoclet.java
+++ b/modules/generator/src/main/java/org/lwjgl/system/ExcludeDoclet.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.system;
 

--- a/modules/generator/src/main/java/org/lwjgl/system/JavadocPostProcess.java
+++ b/modules/generator/src/main/java/org/lwjgl/system/JavadocPostProcess.java
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.system;
 

--- a/modules/generator/src/main/kotlin/org/lwjgl/PointerBuffer.kt
+++ b/modules/generator/src/main/kotlin/org/lwjgl/PointerBuffer.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl
 

--- a/modules/generator/src/main/kotlin/org/lwjgl/generator/CallbackFunction.kt
+++ b/modules/generator/src/main/kotlin/org/lwjgl/generator/CallbackFunction.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.generator
 

--- a/modules/generator/src/main/kotlin/org/lwjgl/generator/Constants.kt
+++ b/modules/generator/src/main/kotlin/org/lwjgl/generator/Constants.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.generator
 

--- a/modules/generator/src/main/kotlin/org/lwjgl/generator/Functions.kt
+++ b/modules/generator/src/main/kotlin/org/lwjgl/generator/Functions.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.generator
 

--- a/modules/generator/src/main/kotlin/org/lwjgl/generator/Generator.kt
+++ b/modules/generator/src/main/kotlin/org/lwjgl/generator/Generator.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.generator
 

--- a/modules/generator/src/main/kotlin/org/lwjgl/generator/GeneratorTarget.kt
+++ b/modules/generator/src/main/kotlin/org/lwjgl/generator/GeneratorTarget.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.generator
 
@@ -12,7 +12,7 @@ import java.util.regex.Pattern
 
 val HEADER = """/*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  * MACHINE GENERATED FILE, DO NOT EDIT
  */
 """

--- a/modules/generator/src/main/kotlin/org/lwjgl/generator/GlobalTypes.kt
+++ b/modules/generator/src/main/kotlin/org/lwjgl/generator/GlobalTypes.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.generator
 

--- a/modules/generator/src/main/kotlin/org/lwjgl/generator/JNI.kt
+++ b/modules/generator/src/main/kotlin/org/lwjgl/generator/JNI.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.generator
 

--- a/modules/generator/src/main/kotlin/org/lwjgl/generator/JavaDoc.kt
+++ b/modules/generator/src/main/kotlin/org/lwjgl/generator/JavaDoc.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.generator
 

--- a/modules/generator/src/main/kotlin/org/lwjgl/generator/Modifiers.kt
+++ b/modules/generator/src/main/kotlin/org/lwjgl/generator/Modifiers.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.generator
 

--- a/modules/generator/src/main/kotlin/org/lwjgl/generator/NativeClass.kt
+++ b/modules/generator/src/main/kotlin/org/lwjgl/generator/NativeClass.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.generator
 

--- a/modules/generator/src/main/kotlin/org/lwjgl/generator/Parameters.kt
+++ b/modules/generator/src/main/kotlin/org/lwjgl/generator/Parameters.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.generator
 

--- a/modules/generator/src/main/kotlin/org/lwjgl/generator/StructMemberModifiers.kt
+++ b/modules/generator/src/main/kotlin/org/lwjgl/generator/StructMemberModifiers.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.generator
 

--- a/modules/generator/src/main/kotlin/org/lwjgl/generator/Structs.kt
+++ b/modules/generator/src/main/kotlin/org/lwjgl/generator/Structs.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.generator
 

--- a/modules/generator/src/main/kotlin/org/lwjgl/generator/Types.kt
+++ b/modules/generator/src/main/kotlin/org/lwjgl/generator/Types.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.generator
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/egl/EGLBinding.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/egl/EGLBinding.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.egl
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/egl/EGLTypes.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/egl/EGLTypes.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.egl
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/ANDROID_blob_cache.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/ANDROID_blob_cache.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.egl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/ANDROID_create_native_client_buffer.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/ANDROID_create_native_client_buffer.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.egl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/ANDROID_framebuffer_target.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/ANDROID_framebuffer_target.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.egl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/ANDROID_front_buffer_auto_refresh.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/ANDROID_front_buffer_auto_refresh.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.egl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/ANDROID_image_native_buffer.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/ANDROID_image_native_buffer.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.egl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/ANDROID_native_fence_sync.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/ANDROID_native_fence_sync.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.egl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/ANDROID_presentation_time.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/ANDROID_presentation_time.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.egl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/ANDROID_recordable.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/ANDROID_recordable.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.egl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/ANGLE_d3d_share_handle_client_buffer.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/ANGLE_d3d_share_handle_client_buffer.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.egl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/ANGLE_device_d3d.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/ANGLE_device_d3d.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.egl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/ANGLE_query_surface_pointer.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/ANGLE_query_surface_pointer.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.egl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/ANGLE_surface_d3d_texture_2d_share_handle.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/ANGLE_surface_d3d_texture_2d_share_handle.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.egl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/ANGLE_window_fixed_size.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/ANGLE_window_fixed_size.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.egl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/ARM_pixmap_multisample_discard.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/ARM_pixmap_multisample_discard.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.egl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/EGL10.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/EGL10.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.egl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/EGL11.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/EGL11.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.egl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/EGL12.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/EGL12.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.egl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/EGL13.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/EGL13.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.egl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/EGL14.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/EGL14.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.egl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/EGL15.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/EGL15.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.egl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/EXT_buffer_age.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/EXT_buffer_age.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.egl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/EXT_create_context_robustness.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/EXT_create_context_robustness.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.egl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/EXT_device_base.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/EXT_device_base.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.egl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/EXT_device_drm.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/EXT_device_drm.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.egl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/EXT_device_enumeration.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/EXT_device_enumeration.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.egl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/EXT_device_openwf.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/EXT_device_openwf.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.egl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/EXT_device_query.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/EXT_device_query.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.egl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/EXT_image_dma_buf_import.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/EXT_image_dma_buf_import.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.egl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/EXT_multiview_window.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/EXT_multiview_window.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.egl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/EXT_output_base.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/EXT_output_base.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.egl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/EXT_platform_base.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/EXT_platform_base.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.egl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/EXT_platform_device.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/EXT_platform_device.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.egl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/EXT_platform_wayland.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/EXT_platform_wayland.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.egl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/EXT_platform_x11.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/EXT_platform_x11.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.egl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/EXT_protected_surface.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/EXT_protected_surface.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.egl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/EXT_stream_consumer_egloutput.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/EXT_stream_consumer_egloutput.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.egl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/EXT_swap_buffers_with_damage.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/EXT_swap_buffers_with_damage.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.egl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/EXT_yuv_surface.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/EXT_yuv_surface.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.egl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/ExtensionFlags.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/ExtensionFlags.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.egl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/HI_clientpixmap.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/HI_clientpixmap.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.egl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/HI_colorformats.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/HI_colorformats.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.egl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/IMG_context_priority.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/IMG_context_priority.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.egl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/IMG_image_plan_attribs.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/IMG_image_plan_attribs.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.egl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/KHR_cl_event2.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/KHR_cl_event2.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.egl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/KHR_config_attribs.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/KHR_config_attribs.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.egl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/KHR_create_context.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/KHR_create_context.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.egl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/KHR_create_context_no_error.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/KHR_create_context_no_error.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.egl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/KHR_debug.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/KHR_debug.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.egl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/KHR_fence_sync.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/KHR_fence_sync.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.egl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/KHR_gl_colorspace.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/KHR_gl_colorspace.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.egl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/KHR_gl_image.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/KHR_gl_image.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.egl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/KHR_image.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/KHR_image.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.egl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/KHR_image_base.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/KHR_image_base.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.egl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/KHR_image_pixmap.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/KHR_image_pixmap.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.egl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/KHR_lock_surface3.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/KHR_lock_surface3.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.egl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/KHR_mutable_render_buffer.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/KHR_mutable_render_buffer.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.egl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/KHR_partial_update.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/KHR_partial_update.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.egl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/KHR_platform_android.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/KHR_platform_android.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.egl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/KHR_platform_gbm.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/KHR_platform_gbm.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.egl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/KHR_platform_wayland.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/KHR_platform_wayland.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.egl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/KHR_platform_x11.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/KHR_platform_x11.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.egl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/KHR_reusable_sync.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/KHR_reusable_sync.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.egl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/KHR_stream.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/KHR_stream.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.egl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/KHR_stream_consumer_gltexture.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/KHR_stream_consumer_gltexture.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.egl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/KHR_stream_cross_process_fd.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/KHR_stream_cross_process_fd.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.egl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/KHR_stream_fifo.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/KHR_stream_fifo.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.egl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/KHR_stream_producer_eglsurface.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/KHR_stream_producer_eglsurface.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.egl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/KHR_swap_buffers_with_damage.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/KHR_swap_buffers_with_damage.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.egl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/KHR_vg_parent_image.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/KHR_vg_parent_image.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.egl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/KHR_wait_sync.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/KHR_wait_sync.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.egl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/MESA_drm_image.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/MESA_drm_image.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.egl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/MESA_image_dma_buf_export.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/MESA_image_dma_buf_export.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.egl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/MESA_platform_gbm.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/MESA_platform_gbm.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.egl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/NOK_swap_region2.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/NOK_swap_region2.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.egl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/NOK_texture_from_pixmap.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/NOK_texture_from_pixmap.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.egl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/NV_3dvision_surface.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/NV_3dvision_surface.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.egl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/NV_coverage_sample.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/NV_coverage_sample.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.egl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/NV_coverage_sample_resolve.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/NV_coverage_sample_resolve.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.egl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/NV_cuda_event.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/NV_cuda_event.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.egl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/NV_depth_nonlinear.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/NV_depth_nonlinear.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.egl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/NV_device_cuda.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/NV_device_cuda.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.egl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/NV_native_query.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/NV_native_query.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.egl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/NV_post_sub_buffer.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/NV_post_sub_buffer.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.egl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/NV_robustness_video_memory_purge.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/NV_robustness_video_memory_purge.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.egl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/NV_stream_consumer_gltexture_yuv.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/NV_stream_consumer_gltexture_yuv.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.egl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/NV_stream_metadata.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/NV_stream_metadata.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.egl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/NV_stream_sync.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/NV_stream_sync.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.egl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/NV_sync.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/NV_sync.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.egl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/NV_system_time.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/NV_system_time.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.egl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/TIZEN_image_native_buffer.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/TIZEN_image_native_buffer.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.egl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/TIZEN_image_native_surface.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/egl/templates/TIZEN_image_native_surface.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.egl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/glfw/GLFWTypes.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/glfw/GLFWTypes.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.glfw
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/glfw/templates/GLFW.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/glfw/templates/GLFW.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.glfw.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/glfw/templates/GLFWNativeCocoa.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/glfw/templates/GLFWNativeCocoa.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.glfw.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/glfw/templates/GLFWNativeEGL.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/glfw/templates/GLFWNativeEGL.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.glfw.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/glfw/templates/GLFWNativeGLX.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/glfw/templates/GLFWNativeGLX.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.glfw.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/glfw/templates/GLFWNativeNSGL.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/glfw/templates/GLFWNativeNSGL.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.glfw.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/glfw/templates/GLFWNativeWGL.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/glfw/templates/GLFWNativeWGL.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.glfw.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/glfw/templates/GLFWNativeWin32.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/glfw/templates/GLFWNativeWin32.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.glfw.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/glfw/templates/GLFWNativeX11.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/glfw/templates/GLFWNativeX11.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.glfw.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/glfw/templates/GLFWVulkan.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/glfw/templates/GLFWVulkan.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.glfw.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/nanovg/NVGTypes.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/nanovg/NVGTypes.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.nanovg
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/nanovg/NVGTypesGL.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/nanovg/NVGTypesGL.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.nanovg
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/nanovg/templates/nanovg.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/nanovg/templates/nanovg.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.nanovg.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/nanovg/templates/nanovg_gl2.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/nanovg/templates/nanovg_gl2.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.nanovg.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/nanovg/templates/nanovg_gl3.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/nanovg/templates/nanovg_gl3.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.nanovg.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/nanovg/templates/nanovg_gles2.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/nanovg/templates/nanovg_gles2.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.nanovg.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/nanovg/templates/nanovg_gles3.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/nanovg/templates/nanovg_gles3.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.nanovg.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/nuklear/NuklearTypes.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/nuklear/NuklearTypes.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.nuklear
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/nuklear/templates/nuklear.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/nuklear/templates/nuklear.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.nuklear.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/openal/ALBinding.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/openal/ALBinding.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.openal
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/openal/ALCBinding.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/openal/ALCBinding.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.openal
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/openal/ALCTypes.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/openal/ALCTypes.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.openal
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/openal/ALTypes.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/openal/ALTypes.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.openal
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/openal/templates/AL10.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/openal/templates/AL10.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.openal.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/openal/templates/AL11.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/openal/templates/AL11.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.openal.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/openal/templates/ALC10.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/openal/templates/ALC10.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.openal.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/openal/templates/ALC11.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/openal/templates/ALC11.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.openal.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/openal/templates/ALC_ENUMERATE_ALL_EXT.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/openal/templates/ALC_ENUMERATE_ALL_EXT.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.openal.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/openal/templates/ALC_EXT_CAPTURE.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/openal/templates/ALC_EXT_CAPTURE.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.openal.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/openal/templates/ALC_EXT_DEDICATED.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/openal/templates/ALC_EXT_DEDICATED.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.openal.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/openal/templates/ALC_EXT_DEFAULT_FILTER_ORDER.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/openal/templates/ALC_EXT_DEFAULT_FILTER_ORDER.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.openal.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/openal/templates/ALC_EXT_EFX.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/openal/templates/ALC_EXT_EFX.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.openal.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/openal/templates/ALC_EXT_disconnect.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/openal/templates/ALC_EXT_disconnect.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.openal.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/openal/templates/ALC_EXT_thread_local_context.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/openal/templates/ALC_EXT_thread_local_context.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.openal.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/openal/templates/ALC_LOKI_audio_channel.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/openal/templates/ALC_LOKI_audio_channel.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.openal.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/openal/templates/ALC_SOFT_loopback.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/openal/templates/ALC_SOFT_loopback.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.openal.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/openal/templates/ALC_SOFT_pause_device.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/openal/templates/ALC_SOFT_pause_device.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.openal.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/openal/templates/AL_EXT_ALAW.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/openal/templates/AL_EXT_ALAW.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.openal.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/openal/templates/AL_EXT_BFORMAT.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/openal/templates/AL_EXT_BFORMAT.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.openal.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/openal/templates/AL_EXT_DOUBLE.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/openal/templates/AL_EXT_DOUBLE.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.openal.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/openal/templates/AL_EXT_EXPONENT_DISTANCE.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/openal/templates/AL_EXT_EXPONENT_DISTANCE.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.openal.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/openal/templates/AL_EXT_FLOAT32.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/openal/templates/AL_EXT_FLOAT32.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.openal.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/openal/templates/AL_EXT_IMA4.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/openal/templates/AL_EXT_IMA4.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.openal.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/openal/templates/AL_EXT_LINEAR_DISTANCE.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/openal/templates/AL_EXT_LINEAR_DISTANCE.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.openal.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/openal/templates/AL_EXT_MCFORMATS.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/openal/templates/AL_EXT_MCFORMATS.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.openal.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/openal/templates/AL_EXT_MULAW.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/openal/templates/AL_EXT_MULAW.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.openal.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/openal/templates/AL_EXT_MULAW_BFORMAT.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/openal/templates/AL_EXT_MULAW_BFORMAT.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.openal.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/openal/templates/AL_EXT_MULAW_MCFORMATS.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/openal/templates/AL_EXT_MULAW_MCFORMATS.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.openal.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/openal/templates/AL_EXT_OFFSET.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/openal/templates/AL_EXT_OFFSET.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.openal.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/openal/templates/AL_EXT_SOURCE_RADIUS.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/openal/templates/AL_EXT_SOURCE_RADIUS.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.openal.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/openal/templates/AL_EXT_STEREO_ANGLES.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/openal/templates/AL_EXT_STEREO_ANGLES.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.openal.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/openal/templates/AL_EXT_source_distance_model.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/openal/templates/AL_EXT_source_distance_model.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.openal.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/openal/templates/AL_EXT_static_buffer.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/openal/templates/AL_EXT_static_buffer.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.openal.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/openal/templates/AL_EXT_vorbis.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/openal/templates/AL_EXT_vorbis.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.openal.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/openal/templates/AL_LOKI_IMA_ADPCM.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/openal/templates/AL_LOKI_IMA_ADPCM.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.openal.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/openal/templates/AL_LOKI_WAVE_format.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/openal/templates/AL_LOKI_WAVE_format.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.openal.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/openal/templates/AL_LOKI_quadriphonic.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/openal/templates/AL_LOKI_quadriphonic.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.openal.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/openal/templates/AL_SOFT_HRTF.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/openal/templates/AL_SOFT_HRTF.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.openal.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/openal/templates/AL_SOFT_MSADPCM.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/openal/templates/AL_SOFT_MSADPCM.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.openal.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/openal/templates/AL_SOFT_block_alignment.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/openal/templates/AL_SOFT_block_alignment.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.openal.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/openal/templates/AL_SOFT_deferred_updates.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/openal/templates/AL_SOFT_deferred_updates.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.openal.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/openal/templates/AL_SOFT_direct_channels.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/openal/templates/AL_SOFT_direct_channels.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.openal.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/openal/templates/AL_SOFT_loop_points.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/openal/templates/AL_SOFT_loop_points.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.openal.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/openal/templates/AL_SOFT_source_latency.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/openal/templates/AL_SOFT_source_latency.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.openal.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/openal/templates/AL_SOFT_source_length.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/openal/templates/AL_SOFT_source_length.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.openal.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/openal/templates/ExtensionFlags.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/openal/templates/ExtensionFlags.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.openal.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opencl/CLBinding.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opencl/CLBinding.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opencl
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opencl/CLTypes.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opencl/CLTypes.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opencl
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/APPLE_ContextLoggingFunctions.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/APPLE_ContextLoggingFunctions.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opencl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/APPLE_biased_fixed_point_image_formats.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/APPLE_biased_fixed_point_image_formats.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opencl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/APPLE_command_queue_priority.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/APPLE_command_queue_priority.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opencl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/APPLE_command_queue_select_compute_units.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/APPLE_command_queue_select_compute_units.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opencl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/APPLE_fixed_alpha_channel_orders.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/APPLE_fixed_alpha_channel_orders.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opencl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/APPLE_gl_sharing.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/APPLE_gl_sharing.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opencl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/APPLE_query_kernel_names.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/APPLE_query_kernel_names.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opencl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/CL10.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/CL10.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opencl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/CL10GL.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/CL10GL.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opencl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/CL11.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/CL11.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opencl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/CL12.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/CL12.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opencl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/CL12GL.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/CL12GL.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opencl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/CL20.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/CL20.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opencl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/CL21.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/CL21.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opencl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/ExtensionFlags.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/ExtensionFlags.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opencl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/altera_compiler_mode.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/altera_compiler_mode.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opencl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/altera_device_temperature.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/altera_device_temperature.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opencl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/altera_live_object_tracking.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/altera_live_object_tracking.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opencl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/amd_bus_addressable_memory.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/amd_bus_addressable_memory.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opencl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/amd_device_attribute_query.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/amd_device_attribute_query.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opencl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/amd_device_board_name.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/amd_device_board_name.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opencl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/amd_device_persistent_memory.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/amd_device_persistent_memory.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opencl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/amd_device_profiling_timer_offset.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/amd_device_profiling_timer_offset.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opencl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/amd_device_topology.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/amd_device_topology.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opencl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/amd_offline_devices.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/amd_offline_devices.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opencl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/arm_printf.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/arm_printf.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opencl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/ext_atomic_counters_32.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/ext_atomic_counters_32.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opencl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/ext_atomic_counters_64.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/ext_atomic_counters_64.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opencl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/ext_device_fission.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/ext_device_fission.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opencl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/ext_migrate_memobject.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/ext_migrate_memobject.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opencl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/intel_accelerator.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/intel_accelerator.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opencl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/intel_advanced_motion_estimation.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/intel_advanced_motion_estimation.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opencl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/intel_device_partition_by_names.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/intel_device_partition_by_names.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opencl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/intel_egl_image_yuv.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/intel_egl_image_yuv.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opencl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/intel_motion_estimation.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/intel_motion_estimation.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opencl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/intel_simultaneous_sharing.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/intel_simultaneous_sharing.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opencl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/intel_subgroups.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/intel_subgroups.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opencl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/intel_thread_local_exec.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/intel_thread_local_exec.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opencl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/intel_va_api_media_sharing.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/intel_va_api_media_sharing.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opencl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/khr_depth_images.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/khr_depth_images.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opencl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/khr_egl_event.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/khr_egl_event.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opencl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/khr_egl_image.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/khr_egl_image.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opencl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/khr_fp16.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/khr_fp16.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opencl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/khr_fp64.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/khr_fp64.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opencl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/khr_gl_depth_images.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/khr_gl_depth_images.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opencl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/khr_gl_event.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/khr_gl_event.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opencl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/khr_gl_msaa_sharing.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/khr_gl_msaa_sharing.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opencl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/khr_gl_sharing.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/khr_gl_sharing.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opencl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/khr_icd.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/khr_icd.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opencl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/khr_image2d_from_buffer.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/khr_image2d_from_buffer.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opencl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/khr_initialize_memory.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/khr_initialize_memory.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opencl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/khr_mipmap_image.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/khr_mipmap_image.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opencl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/khr_priority_hints.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/khr_priority_hints.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opencl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/khr_spir.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/khr_spir.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opencl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/khr_terminate_context.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/khr_terminate_context.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opencl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/khr_throttle_hints.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/khr_throttle_hints.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opencl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/nv_device_attribute_query.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/nv_device_attribute_query.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opencl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/qcom_ext_host_ptr.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opencl/templates/qcom_ext_host_ptr.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opencl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/BufferObject.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/BufferObject.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/Deprecated.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/Deprecated.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/GLBinding.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/GLBinding.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/GLTypes.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/GLTypes.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/GLXBinding.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/GLXBinding.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/GLXTypes.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/GLXTypes.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/JavaDoc.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/JavaDoc.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/WGLBinding.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/WGLBinding.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/WGLTypes.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/WGLTypes.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/AMD_blend_minmax_factor.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/AMD_blend_minmax_factor.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/AMD_debug_output.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/AMD_debug_output.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/AMD_depth_clamp_separate.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/AMD_depth_clamp_separate.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/AMD_draw_buffers_blend.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/AMD_draw_buffers_blend.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/AMD_gpu_shader_int64.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/AMD_gpu_shader_int64.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/AMD_interleaved_elements.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/AMD_interleaved_elements.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/AMD_occlusion_query_event.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/AMD_occlusion_query_event.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/AMD_performance_monitor.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/AMD_performance_monitor.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/AMD_pinned_memory.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/AMD_pinned_memory.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/AMD_query_buffer_object.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/AMD_query_buffer_object.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/AMD_sample_positions.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/AMD_sample_positions.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/AMD_seamless_cubemap_per_texture.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/AMD_seamless_cubemap_per_texture.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/AMD_sparse_texture.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/AMD_sparse_texture.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/AMD_stencil_operation_extended.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/AMD_stencil_operation_extended.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/AMD_transform_feedback4.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/AMD_transform_feedback4.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/AMD_vertex_shader_tessellator.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/AMD_vertex_shader_tessellator.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_ES2_compatibility.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_ES2_compatibility.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_ES3_1_compatibility.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_ES3_1_compatibility.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_ES3_2_compatibility.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_ES3_2_compatibility.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_ES3_compatibility.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_ES3_compatibility.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_base_instance.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_base_instance.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_bindless_texture.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_bindless_texture.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_blend_func_extended.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_blend_func_extended.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_buffer_storage.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_buffer_storage.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_cl_event.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_cl_event.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_clear_buffer_object.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_clear_buffer_object.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_clear_texture.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_clear_texture.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_clip_control.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_clip_control.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_color_buffer_float.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_color_buffer_float.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_compressed_texture_pixel_storage.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_compressed_texture_pixel_storage.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_compute_shader.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_compute_shader.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_compute_variable_group_size.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_compute_variable_group_size.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_conditional_render_inverted.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_conditional_render_inverted.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_copy_buffer.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_copy_buffer.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_copy_image.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_copy_image.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_cull_distance.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_cull_distance.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_debug_output.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_debug_output.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_depth_buffer_float.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_depth_buffer_float.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_depth_clamp.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_depth_clamp.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_depth_texture.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_depth_texture.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_direct_state_access.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_direct_state_access.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_draw_buffers.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_draw_buffers.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_draw_buffers_blend.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_draw_buffers_blend.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_draw_elements_base_vertex.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_draw_elements_base_vertex.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_draw_indirect.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_draw_indirect.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_draw_instanced.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_draw_instanced.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_enhanced_layouts.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_enhanced_layouts.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_explicit_uniform_location.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_explicit_uniform_location.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_fragment_program.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_fragment_program.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_fragment_shader.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_fragment_shader.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_framebuffer_no_attachments.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_framebuffer_no_attachments.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_framebuffer_object.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_framebuffer_object.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_framebuffer_sRGB.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_framebuffer_sRGB.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_geometry_shader4.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_geometry_shader4.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_get_program_binary.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_get_program_binary.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_get_texture_sub_image.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_get_texture_sub_image.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_gl_spirv.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_gl_spirv.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_gpu_shader5.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_gpu_shader5.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_gpu_shader_fp64.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_gpu_shader_fp64.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_gpu_shader_int64.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_gpu_shader_int64.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_half_float_pixel.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_half_float_pixel.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_half_float_vertex.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_half_float_vertex.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_imaging.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_imaging.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_indirect_parameters.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_indirect_parameters.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_instanced_arrays.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_instanced_arrays.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_internalformat_query.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_internalformat_query.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_internalformat_query2.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_internalformat_query2.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_invalidate_subdata.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_invalidate_subdata.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_map_buffer_alignment.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_map_buffer_alignment.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_map_buffer_range.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_map_buffer_range.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_matrix_palette.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_matrix_palette.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_multi_bind.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_multi_bind.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_multi_draw_indirect.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_multi_draw_indirect.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_multisample.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_multisample.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_multitexture.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_multitexture.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_occlusion_query.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_occlusion_query.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_occlusion_query2.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_occlusion_query2.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_parallel_shader_compile.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_parallel_shader_compile.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_pipeline_statistics_query.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_pipeline_statistics_query.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_pixel_buffer_object.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_pixel_buffer_object.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_point_parameters.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_point_parameters.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_point_sprite.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_point_sprite.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_program_interface_query.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_program_interface_query.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_provoking_vertex.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_provoking_vertex.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_query_buffer_object.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_query_buffer_object.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_robustness.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_robustness.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_sample_locations.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_sample_locations.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_sample_shading.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_sample_shading.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_sampler_objects.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_sampler_objects.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_seamless_cube_map.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_seamless_cube_map.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_seamless_cubemap_per_texture.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_seamless_cubemap_per_texture.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_separate_shader_objects.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_separate_shader_objects.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_shader_atomic_counters.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_shader_atomic_counters.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_shader_image_load_store.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_shader_image_load_store.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_shader_objects.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_shader_objects.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_shader_storage_buffer_object.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_shader_storage_buffer_object.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_shader_subroutine.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_shader_subroutine.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_shading_language_100.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_shading_language_100.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_shading_language_include.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_shading_language_include.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_shadow.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_shadow.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_shadow_ambient.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_shadow_ambient.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_sparse_buffer.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_sparse_buffer.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_sparse_texture.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_sparse_texture.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_stencil_texturing.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_stencil_texturing.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_sync.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_sync.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_tessellation_shader.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_tessellation_shader.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_texture_barrier.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_texture_barrier.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_texture_border_clamp.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_texture_border_clamp.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_texture_buffer_object.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_texture_buffer_object.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_texture_buffer_range.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_texture_buffer_range.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_texture_compression.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_texture_compression.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_texture_compression_bptc.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_texture_compression_bptc.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_texture_compression_rgtc.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_texture_compression_rgtc.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_texture_cube_map.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_texture_cube_map.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_texture_cube_map_array.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_texture_cube_map_array.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_texture_env_combine.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_texture_env_combine.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_texture_env_dot3.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_texture_env_dot3.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_texture_filter_minmax.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_texture_filter_minmax.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_texture_float.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_texture_float.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_texture_gather.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_texture_gather.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_texture_mirror_clamp_to_edge.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_texture_mirror_clamp_to_edge.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_texture_mirrored_repeat.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_texture_mirrored_repeat.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_texture_multisample.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_texture_multisample.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_texture_rectangle.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_texture_rectangle.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_texture_rg.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_texture_rg.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_texture_rgb10_a2ui.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_texture_rgb10_a2ui.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_texture_storage.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_texture_storage.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_texture_storage_multisample.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_texture_storage_multisample.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_texture_swizzle.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_texture_swizzle.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_texture_view.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_texture_view.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_timer_query.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_timer_query.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_transform_feedback2.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_transform_feedback2.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_transform_feedback3.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_transform_feedback3.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_transform_feedback_instanced.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_transform_feedback_instanced.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_transform_feedback_overflow_query.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_transform_feedback_overflow_query.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_transpose_matrix.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_transpose_matrix.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_uniform_buffer_object.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_uniform_buffer_object.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_vertex_array_bgra.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_vertex_array_bgra.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_vertex_array_object.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_vertex_array_object.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_vertex_attrib_64bit.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_vertex_attrib_64bit.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_vertex_attrib_binding.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_vertex_attrib_binding.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_vertex_blend.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_vertex_blend.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_vertex_buffer_object.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_vertex_buffer_object.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_vertex_program.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_vertex_program.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_vertex_shader.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_vertex_shader.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_vertex_type_2_10_10_10_rev.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_vertex_type_2_10_10_10_rev.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_viewport_array.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_viewport_array.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_window_pos.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ARB_window_pos.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ATI_meminfo.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ATI_meminfo.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ATI_texture_compression_3dc.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ATI_texture_compression_3dc.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/CGL.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/CGL.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_422_pixels.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_422_pixels.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_abgr.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_abgr.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_bgra.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_bgra.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_bindable_uniform.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_bindable_uniform.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_blend_color.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_blend_color.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_blend_equation_separate.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_blend_equation_separate.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_blend_func_separate.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_blend_func_separate.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_blend_minmax.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_blend_minmax.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_blend_subtract.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_blend_subtract.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_clip_volume_hint.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_clip_volume_hint.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_compiled_vertex_array.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_compiled_vertex_array.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_debug_label.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_debug_label.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_debug_marker.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_debug_marker.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_depth_bounds_test.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_depth_bounds_test.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_direct_state_access.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_direct_state_access.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_draw_buffers2.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_draw_buffers2.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_draw_instanced.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_draw_instanced.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_framebuffer_blit.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_framebuffer_blit.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_framebuffer_multisample.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_framebuffer_multisample.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_framebuffer_multisample_blit_scaled.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_framebuffer_multisample_blit_scaled.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_framebuffer_object.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_framebuffer_object.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_framebuffer_sRGB.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_framebuffer_sRGB.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_geometry_shader4.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_geometry_shader4.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_gpu_program_parameters.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_gpu_program_parameters.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_gpu_shader4.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_gpu_shader4.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_packed_depth_stencil.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_packed_depth_stencil.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_packed_float.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_packed_float.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_pixel_buffer_object.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_pixel_buffer_object.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_point_parameters.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_point_parameters.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_polygon_offset_clamp.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_polygon_offset_clamp.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_provoking_vertex.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_provoking_vertex.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_raster_multisample.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_raster_multisample.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_secondary_color.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_secondary_color.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_separate_shader_objects.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_separate_shader_objects.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_shader_image_load_store.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_shader_image_load_store.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_shared_texture_palette.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_shared_texture_palette.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_stencil_clear_tag.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_stencil_clear_tag.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_stencil_two_side.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_stencil_two_side.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_stencil_wrap.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_stencil_wrap.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_texture_array.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_texture_array.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_texture_buffer_object.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_texture_buffer_object.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_texture_compression_latc.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_texture_compression_latc.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_texture_compression_rgtc.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_texture_compression_rgtc.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_texture_compression_s3tc.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_texture_compression_s3tc.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_texture_filter_anisotropic.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_texture_filter_anisotropic.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_texture_filter_minmax.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_texture_filter_minmax.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_texture_integer.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_texture_integer.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_texture_mirror_clamp.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_texture_mirror_clamp.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_texture_sRGB.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_texture_sRGB.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_texture_sRGB_decode.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_texture_sRGB_decode.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_texture_shared_exponent.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_texture_shared_exponent.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_texture_snorm.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_texture_snorm.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_texture_swizzle.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_texture_swizzle.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_timer_query.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_timer_query.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_transform_feedback.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_transform_feedback.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_vertex_attrib_64bit.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_vertex_attrib_64bit.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_window_rectangles.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_window_rectangles.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_x11_sync_object.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/EXT_x11_sync_object.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ExtensionFlags.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/ExtensionFlags.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/GL11.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/GL11.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/GL12.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/GL12.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/GL13.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/GL13.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/GL14.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/GL14.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/GL15.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/GL15.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/GL20.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/GL20.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/GL21.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/GL21.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/GL30.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/GL30.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/GL31.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/GL31.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/GL32.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/GL32.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/GL33.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/GL33.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/GL40.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/GL40.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/GL41.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/GL41.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/GL42.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/GL42.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/GL43.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/GL43.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/GL44.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/GL44.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/GL45.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/GL45.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/GLX.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/GLX.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/GLX_11.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/GLX_11.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/GLX_12.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/GLX_12.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/GLX_13.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/GLX_13.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/GLX_14.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/GLX_14.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/GLX_AMD_gpu_association.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/GLX_AMD_gpu_association.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/GLX_ARB_create_context.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/GLX_ARB_create_context.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/GLX_ARB_create_context_profile.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/GLX_ARB_create_context_profile.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/GLX_ARB_create_context_robustness.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/GLX_ARB_create_context_robustness.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/GLX_ARB_fbconfig_float.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/GLX_ARB_fbconfig_float.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/GLX_ARB_get_proc_address.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/GLX_ARB_get_proc_address.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/GLX_ARB_robustness_isolation.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/GLX_ARB_robustness_isolation.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/GLX_ARB_vertex_buffer_object.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/GLX_ARB_vertex_buffer_object.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/GLX_EXT_buffer_age.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/GLX_EXT_buffer_age.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/GLX_EXT_create_context_es_profile.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/GLX_EXT_create_context_es_profile.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/GLX_EXT_import_context.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/GLX_EXT_import_context.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/GLX_EXT_stereo_tree.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/GLX_EXT_stereo_tree.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/GLX_EXT_swap_control.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/GLX_EXT_swap_control.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/GLX_EXT_swap_control_tear.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/GLX_EXT_swap_control_tear.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/GLX_EXT_texture_from_pixmap.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/GLX_EXT_texture_from_pixmap.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/GLX_EXT_visual_info.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/GLX_EXT_visual_info.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/GLX_EXT_visual_rating.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/GLX_EXT_visual_rating.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/GLX_INTEL_swap_event.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/GLX_INTEL_swap_event.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/GLX_NV_copy_buffer.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/GLX_NV_copy_buffer.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/GLX_NV_delay_before_swap.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/GLX_NV_delay_before_swap.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/GLX_NV_swap_group.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/GLX_NV_swap_group.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/GLX_SGIX_fbconfig.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/GLX_SGIX_fbconfig.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/GLX_SGIX_pbuffer.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/GLX_SGIX_pbuffer.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/GLX_SGIX_swap_barrier.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/GLX_SGIX_swap_barrier.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/GLX_SGIX_swap_group.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/GLX_SGIX_swap_group.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/GLX_SGI_make_current_read.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/GLX_SGI_make_current_read.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/GLX_SGI_swap_control.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/GLX_SGI_swap_control.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/GLX_SGI_video_sync.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/GLX_SGI_video_sync.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/INTEL_conservative_rasterization.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/INTEL_conservative_rasterization.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/INTEL_framebuffer_CMAA.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/INTEL_framebuffer_CMAA.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/INTEL_map_texture.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/INTEL_map_texture.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/INTEL_performance_query.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/INTEL_performance_query.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/KHR_blend_equation_advanced.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/KHR_blend_equation_advanced.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/KHR_context_flush_control.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/KHR_context_flush_control.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/KHR_debug.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/KHR_debug.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/KHR_no_error.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/KHR_no_error.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/KHR_robustness.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/KHR_robustness.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/KHR_texture_compression_astc_ldr.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/KHR_texture_compression_astc_ldr.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NVX_conditional_render.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NVX_conditional_render.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NVX_gpu_memory_info.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NVX_gpu_memory_info.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_bindless_multi_draw_indirect.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_bindless_multi_draw_indirect.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_bindless_multi_draw_indirect_count.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_bindless_multi_draw_indirect_count.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_bindless_texture.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_bindless_texture.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_blend_equation_advanced.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_blend_equation_advanced.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_clip_space_w_scaling.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_clip_space_w_scaling.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_command_list.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_command_list.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_conditional_render.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_conditional_render.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_conservative_raster.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_conservative_raster.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_conservative_raster_dilate.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_conservative_raster_dilate.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_conservative_raster_pre_snap_triangles.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_conservative_raster_pre_snap_triangles.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_copy_depth_to_color.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_copy_depth_to_color.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_copy_image.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_copy_image.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_deep_texture3D.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_deep_texture3D.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_depth_buffer_float.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_depth_buffer_float.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_depth_clamp.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_depth_clamp.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_draw_texture.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_draw_texture.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_draw_vulkan_image.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_draw_vulkan_image.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_explicit_multisample.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_explicit_multisample.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_fence.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_fence.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_fill_rectangle.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_fill_rectangle.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_float_buffer.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_float_buffer.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_fog_distance.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_fog_distance.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_fragment_coverage_to_color.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_fragment_coverage_to_color.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_framebuffer_mixed_samples.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_framebuffer_mixed_samples.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_framebuffer_multisample_coverage.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_framebuffer_multisample_coverage.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_gpu_multicast.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_gpu_multicast.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_gpu_shader5.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_gpu_shader5.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_half_float.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_half_float.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_internalformat_sample_query.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_internalformat_sample_query.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_light_max_exponent.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_light_max_exponent.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_multisample_coverage.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_multisample_coverage.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_multisample_filter_hint.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_multisample_filter_hint.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_packed_depth_stencil.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_packed_depth_stencil.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_path_rendering.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_path_rendering.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_path_rendering_shared_edge.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_path_rendering_shared_edge.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_pixel_data_range.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_pixel_data_range.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_point_sprite.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_point_sprite.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_primitive_restart.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_primitive_restart.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_robustness_video_memory_purge.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_robustness_video_memory_purge.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_sample_locations.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_sample_locations.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_shader_buffer_load.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_shader_buffer_load.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_shader_buffer_store.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_shader_buffer_store.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_shader_thread_group.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_shader_thread_group.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_texgen_reflection.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_texgen_reflection.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_texture_barrier.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_texture_barrier.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_texture_multisample.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_texture_multisample.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_transform_feedback.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_transform_feedback.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_transform_feedback2.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_transform_feedback2.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_uniform_buffer_unified_memory.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_uniform_buffer_unified_memory.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_vertex_array_range.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_vertex_array_range.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_vertex_array_range2.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_vertex_array_range2.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_vertex_attrib_integer_64bit.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_vertex_attrib_integer_64bit.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_vertex_buffer_unified_memory.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_vertex_buffer_unified_memory.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_viewport_swizzle.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/NV_viewport_swizzle.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/OVR_multiview.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/OVR_multiview.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/WGL.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/WGL.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/WGL_AMD_gpu_association.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/WGL_AMD_gpu_association.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/WGL_ARB_buffer_region.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/WGL_ARB_buffer_region.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/WGL_ARB_create_context.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/WGL_ARB_create_context.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/WGL_ARB_create_context_profile.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/WGL_ARB_create_context_profile.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/WGL_ARB_create_context_robustness.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/WGL_ARB_create_context_robustness.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/WGL_ARB_extensions_string.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/WGL_ARB_extensions_string.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/WGL_ARB_make_current_read.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/WGL_ARB_make_current_read.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/WGL_ARB_pbuffer.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/WGL_ARB_pbuffer.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/WGL_ARB_pixel_format.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/WGL_ARB_pixel_format.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/WGL_ARB_pixel_format_float.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/WGL_ARB_pixel_format_float.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/WGL_ARB_render_texture.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/WGL_ARB_render_texture.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/WGL_ARB_robustness_isolation.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/WGL_ARB_robustness_isolation.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/WGL_ATI_pixel_format_float.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/WGL_ATI_pixel_format_float.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/WGL_EXT_create_context_es_profile.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/WGL_EXT_create_context_es_profile.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/WGL_EXT_depth_float.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/WGL_EXT_depth_float.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/WGL_EXT_extensions_string.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/WGL_EXT_extensions_string.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/WGL_EXT_swap_control.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/WGL_EXT_swap_control.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/WGL_NV_DX_interop.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/WGL_NV_DX_interop.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/WGL_NV_delay_before_swap.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/WGL_NV_delay_before_swap.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/WGL_NV_gpu_affinity.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/WGL_NV_gpu_affinity.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/WGL_NV_render_depth_texture.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/WGL_NV_render_depth_texture.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/WGL_NV_render_texture_rectangle.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/WGL_NV_render_texture_rectangle.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/WGL_NV_swap_group.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/WGL_NV_swap_group.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/WGL_NV_vertex_array_range.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/WGL_NV_vertex_array_range.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengl.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/BufferObject.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/BufferObject.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/GLESBinding.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/GLESBinding.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/GLESTypes.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/GLESTypes.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/AMD_compressed_3DC_texture.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/AMD_compressed_3DC_texture.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/AMD_compressed_ATC_texture.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/AMD_compressed_ATC_texture.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/AMD_performance_monitor.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/AMD_performance_monitor.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/AMD_program_binary_Z400.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/AMD_program_binary_Z400.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/ANGLE_depth_texture.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/ANGLE_depth_texture.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/ANGLE_framebuffer_blit.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/ANGLE_framebuffer_blit.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/ANGLE_framebuffer_multisample.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/ANGLE_framebuffer_multisample.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/ANGLE_instanced_arrays.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/ANGLE_instanced_arrays.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/ANGLE_pack_reverse_row_order.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/ANGLE_pack_reverse_row_order.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/ANGLE_program_binary.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/ANGLE_program_binary.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/ANGLE_texture_compression_dxt.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/ANGLE_texture_compression_dxt.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/ANGLE_texture_usage.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/ANGLE_texture_usage.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/ANGLE_translated_shader_source.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/ANGLE_translated_shader_source.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/APPLE_clip_distance.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/APPLE_clip_distance.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/APPLE_copy_texture_levels.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/APPLE_copy_texture_levels.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/APPLE_framebuffer_multisample.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/APPLE_framebuffer_multisample.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/APPLE_rgb_422.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/APPLE_rgb_422.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/APPLE_sync.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/APPLE_sync.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/APPLE_texture_format_BGRA8888.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/APPLE_texture_format_BGRA8888.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/APPLE_texture_max_level.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/APPLE_texture_max_level.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/APPLE_texture_packed_float.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/APPLE_texture_packed_float.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/ARM_mali_program_binary.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/ARM_mali_program_binary.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/ARM_mali_shader_binary.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/ARM_mali_shader_binary.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/ARM_shader_framebuffer_fetch.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/ARM_shader_framebuffer_fetch.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/DMP_program_binary.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/DMP_program_binary.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/DMP_shader_binary.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/DMP_shader_binary.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_YUV_target.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_YUV_target.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_base_instance.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_base_instance.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_blend_func_extended.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_blend_func_extended.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_blend_minmax.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_blend_minmax.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_buffer_storage.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_buffer_storage.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_clip_cull_distance.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_clip_cull_distance.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_color_buffer_half_float.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_color_buffer_half_float.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_copy_image.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_copy_image.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_debug_label.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_debug_label.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_debug_marker.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_debug_marker.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_discard_framebuffer.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_discard_framebuffer.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_disjoint_timer_query.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_disjoint_timer_query.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_draw_buffers.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_draw_buffers.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_draw_buffers_indexed.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_draw_buffers_indexed.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_draw_elements_base_vertex.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_draw_elements_base_vertex.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_draw_instanced.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_draw_instanced.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_geometry_shader.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_geometry_shader.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_instanced_arrays.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_instanced_arrays.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_map_buffer_range.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_map_buffer_range.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_multi_draw_arrays.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_multi_draw_arrays.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_multi_draw_indirect.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_multi_draw_indirect.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_multisample_compatibility.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_multisample_compatibility.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_multisampled_render_to_texture.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_multisampled_render_to_texture.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_multiview_draw_buffers.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_multiview_draw_buffers.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_occlusion_query_boolean.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_occlusion_query_boolean.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_polygon_offset_clamp.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_polygon_offset_clamp.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_primitive_bounding_box.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_primitive_bounding_box.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_protected_textures.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_protected_textures.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_pvrtc_sRGB.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_pvrtc_sRGB.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_raster_multisample.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_raster_multisample.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_read_format_bgra.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_read_format_bgra.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_render_snorm.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_render_snorm.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_robustness.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_robustness.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_sRGB.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_sRGB.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_sRGB_write_control.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_sRGB_write_control.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_separate_shader_objects.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_separate_shader_objects.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_shader_framebuffer_fetch.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_shader_framebuffer_fetch.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_shader_pixel_local_storage.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_shader_pixel_local_storage.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_shader_pixel_local_storage2.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_shader_pixel_local_storage2.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_shadow_samplers.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_shadow_samplers.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_sparse_texture.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_sparse_texture.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_tessellation_shader.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_tessellation_shader.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_texture_border_clamp.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_texture_border_clamp.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_texture_buffer.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_texture_buffer.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_texture_compression_dxt1.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_texture_compression_dxt1.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_texture_compression_s3tc.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_texture_compression_s3tc.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_texture_cube_map_array.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_texture_cube_map_array.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_texture_filter_anisotropic.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_texture_filter_anisotropic.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_texture_filter_minmax.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_texture_filter_minmax.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_texture_format_BGRA8888.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_texture_format_BGRA8888.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_texture_norm16.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_texture_norm16.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_texture_rg.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_texture_rg.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_texture_sRGB_R8.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_texture_sRGB_R8.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_texture_sRGB_RG8.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_texture_sRGB_RG8.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_texture_sRGB_decode.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_texture_sRGB_decode.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_texture_storage.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_texture_storage.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_texture_type_2_10_10_10_REV.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_texture_type_2_10_10_10_REV.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_texture_view.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_texture_view.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_unpack_subimage.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_unpack_subimage.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_window_rectangles.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/EXT_window_rectangles.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/ExtensionFlags.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/ExtensionFlags.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/FJ_shader_binary_GCCSO.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/FJ_shader_binary_GCCSO.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/GLES20.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/GLES20.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/GLES30.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/GLES30.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/GLES31.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/GLES31.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/GLES32.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/GLES32.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/IMG_framebuffer_multisample.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/IMG_framebuffer_multisample.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/IMG_multisampled_render_to_texture.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/IMG_multisampled_render_to_texture.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/IMG_program_binary.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/IMG_program_binary.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/IMG_read_format.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/IMG_read_format.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/IMG_shader_binary.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/IMG_shader_binary.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/IMG_texture_compression_pvrtc.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/IMG_texture_compression_pvrtc.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/IMG_texture_compression_pvrtc2.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/IMG_texture_compression_pvrtc2.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/IMG_texture_filter_cubic.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/IMG_texture_filter_cubic.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/INTEL_conservative_rasterization.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/INTEL_conservative_rasterization.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/INTEL_framebuffer_CMAA.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/INTEL_framebuffer_CMAA.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/INTEL_performance_query.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/INTEL_performance_query.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/KHR_blend_equation_advanced.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/KHR_blend_equation_advanced.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/KHR_context_flush_control.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/KHR_context_flush_control.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/KHR_debug.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/KHR_debug.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/KHR_no_error.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/KHR_no_error.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/KHR_robustness.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/KHR_robustness.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/KHR_texture_compression_astc_hdr.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/KHR_texture_compression_astc_hdr.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/NV_bindless_texture.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/NV_bindless_texture.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/NV_blend_equation_advanced.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/NV_blend_equation_advanced.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/NV_conditional_render.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/NV_conditional_render.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/NV_conservative_raster.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/NV_conservative_raster.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/NV_conservative_raster_pre_snap_triangles.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/NV_conservative_raster_pre_snap_triangles.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/NV_copy_buffer.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/NV_copy_buffer.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/NV_coverage_sample.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/NV_coverage_sample.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/NV_depth_nonlinear.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/NV_depth_nonlinear.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/NV_draw_buffers.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/NV_draw_buffers.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/NV_draw_instanced.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/NV_draw_instanced.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/NV_fbo_color_attachments.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/NV_fbo_color_attachments.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/NV_fence.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/NV_fence.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/NV_fill_rectangle.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/NV_fill_rectangle.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/NV_fragment_coverage_to_color.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/NV_fragment_coverage_to_color.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/NV_framebuffer_blit.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/NV_framebuffer_blit.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/NV_framebuffer_mixed_samples.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/NV_framebuffer_mixed_samples.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/NV_framebuffer_multisample.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/NV_framebuffer_multisample.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/NV_gpu_shader5.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/NV_gpu_shader5.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/NV_instanced_arrays.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/NV_instanced_arrays.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/NV_internalformat_sample_query.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/NV_internalformat_sample_query.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/NV_non_square_matrices.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/NV_non_square_matrices.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/NV_path_rendering.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/NV_path_rendering.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/NV_path_rendering_shared_edge.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/NV_path_rendering_shared_edge.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/NV_polygon_mode.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/NV_polygon_mode.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/NV_read_buffer.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/NV_read_buffer.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/NV_read_depth_stencil.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/NV_read_depth_stencil.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/NV_sRGB_formats.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/NV_sRGB_formats.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/NV_sample_locations.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/NV_sample_locations.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/NV_shadow_samplers_array.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/NV_shadow_samplers_array.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/NV_shadow_samplers_cube.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/NV_shadow_samplers_cube.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/NV_texture_array.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/NV_texture_array.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/NV_texture_border_clamp.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/NV_texture_border_clamp.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/NV_texture_compression_s3tc.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/NV_texture_compression_s3tc.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/NV_viewport_array.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/NV_viewport_array.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/NV_viewport_swizzle.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/NV_viewport_swizzle.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/OES_EGL_image.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/OES_EGL_image.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/OES_EGL_image_external.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/OES_EGL_image_external.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/OES_compressed_ETC1_RGB8_texture.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/OES_compressed_ETC1_RGB8_texture.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/OES_compressed_paletted_texture.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/OES_compressed_paletted_texture.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/OES_copy_image.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/OES_copy_image.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/OES_depth24.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/OES_depth24.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/OES_depth32.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/OES_depth32.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/OES_depth_texture_cube_map.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/OES_depth_texture_cube_map.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/OES_draw_buffers_indexed.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/OES_draw_buffers_indexed.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/OES_draw_elements_base_vertex.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/OES_draw_elements_base_vertex.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/OES_geometry_shader.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/OES_geometry_shader.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/OES_get_program_binary.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/OES_get_program_binary.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/OES_mapbuffer.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/OES_mapbuffer.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/OES_packed_depth_stencil.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/OES_packed_depth_stencil.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/OES_primitive_bounding_box.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/OES_primitive_bounding_box.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/OES_required_internalformat.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/OES_required_internalformat.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/OES_rgb8_rgba8.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/OES_rgb8_rgba8.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/OES_sample_shading.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/OES_sample_shading.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/OES_shader_multisample_interpolation.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/OES_shader_multisample_interpolation.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/OES_standard_derivatives.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/OES_standard_derivatives.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/OES_stencil1.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/OES_stencil1.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/OES_stencil4.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/OES_stencil4.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/OES_stencil8.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/OES_stencil8.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/OES_surfaceless_context.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/OES_surfaceless_context.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/OES_tessellation_shader.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/OES_tessellation_shader.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/OES_texture_3D.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/OES_texture_3D.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/OES_texture_border_clamp.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/OES_texture_border_clamp.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/OES_texture_buffer.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/OES_texture_buffer.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/OES_texture_compression_astc.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/OES_texture_compression_astc.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/OES_texture_cube_map_array.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/OES_texture_cube_map_array.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/OES_texture_float.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/OES_texture_float.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/OES_texture_storage_multisample_2d_array.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/OES_texture_storage_multisample_2d_array.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/OES_texture_view.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/OES_texture_view.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/OES_vertex_array_object.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/OES_vertex_array_object.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/OES_vertex_half_float.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/OES_vertex_half_float.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/OES_vertex_type_10_10_10_2.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/OES_vertex_type_10_10_10_2.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/OVR_multiview.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/OVR_multiview.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/OVR_multiview_multisampled_render_to_texture.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/OVR_multiview_multisampled_render_to_texture.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/QCOM_alpha_test.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/QCOM_alpha_test.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/QCOM_binning_control.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/QCOM_binning_control.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/QCOM_driver_control.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/QCOM_driver_control.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/QCOM_extended_get.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/QCOM_extended_get.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/QCOM_extended_get2.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/QCOM_extended_get2.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/QCOM_perfmon_global_mode.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/QCOM_perfmon_global_mode.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/QCOM_tiled_rendering.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/QCOM_tiled_rendering.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/QCOM_writeonly_rendering.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/QCOM_writeonly_rendering.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/VIV_shader_binary.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengles/templates/VIV_shader_binary.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.opengles.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/ovr/OVRTypes.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/ovr/OVRTypes.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.ovr
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/ovr/templates/OVR.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/ovr/templates/OVR.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.ovr.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/ovr/templates/OVRGL.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/ovr/templates/OVRGL.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.ovr.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/ovr/templates/OVR_ErrorCode.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/ovr/templates/OVR_ErrorCode.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.ovr.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/ovr/templates/OVR_Keys.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/ovr/templates/OVR_Keys.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.ovr.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/ovr/templates/OVR_Util.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/ovr/templates/OVR_Util.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.ovr.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/ovr/templates/OVR_Version.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/ovr/templates/OVR_Version.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.ovr.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/stb/STBTypes.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/stb/STBTypes.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.stb
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/stb/templates/stb_dxt.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/stb/templates/stb_dxt.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.stb.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/stb/templates/stb_easy_font.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/stb/templates/stb_easy_font.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.stb.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/stb/templates/stb_image.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/stb/templates/stb_image.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.stb.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/stb/templates/stb_image_resize.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/stb/templates/stb_image_resize.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.stb.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/stb/templates/stb_image_write.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/stb/templates/stb_image_write.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.stb.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/stb/templates/stb_perlin.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/stb/templates/stb_perlin.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.stb.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/stb/templates/stb_rect_pack.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/stb/templates/stb_rect_pack.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.stb.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/stb/templates/stb_truetype.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/stb/templates/stb_truetype.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.stb.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/stb/templates/stb_vorbis.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/stb/templates/stb_vorbis.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.stb.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/system/dyncall/DynCallTypes.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/system/dyncall/DynCallTypes.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.system.dyncall
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/system/dyncall/templates/DynCall.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/system/dyncall/templates/DynCall.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.system.dyncall.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/system/dyncall/templates/DynCallback.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/system/dyncall/templates/DynCallback.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.system.dyncall.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/system/dyncall/templates/DynLoad.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/system/dyncall/templates/DynLoad.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.system.dyncall.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/system/jawt/JAWTTypes.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/system/jawt/JAWTTypes.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.system.jawt
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/system/jawt/templates/jawt.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/system/jawt/templates/jawt.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.system.jawt.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/system/jemalloc/jemallocTypes.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/system/jemalloc/jemallocTypes.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.system.jemalloc
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/system/jemalloc/templates/jemalloc.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/system/jemalloc/templates/jemalloc.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.system.jemalloc.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/system/jemalloc/templates/macros.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/system/jemalloc/templates/macros.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.system.jemalloc.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/system/libc/templates/errno.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/system/libc/templates/errno.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.system.libc.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/system/libc/templates/stdlib.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/system/libc/templates/stdlib.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.system.libc.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/system/linux/LinuxTypes.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/system/linux/LinuxTypes.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.system.linux
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/system/linux/XTypes.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/system/linux/XTypes.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.system.linux
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/system/linux/templates/DynamicLinkLoader.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/system/linux/templates/DynamicLinkLoader.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.system.linux.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/system/linux/templates/X11.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/system/linux/templates/X11.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.system.linux.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/system/macosx/CGLTypes.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/system/macosx/CGLTypes.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.system.macosx
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/system/macosx/CoreFoundationTypes.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/system/macosx/CoreFoundationTypes.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.system.macosx
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/system/macosx/CoreGraphics.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/system/macosx/CoreGraphics.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.system.macosx
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/system/macosx/MacOSXTypes.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/system/macosx/MacOSXTypes.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.system.macosx
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/system/macosx/ObjCTypes.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/system/macosx/ObjCTypes.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.system.macosx
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/system/macosx/templates/CoreFoundation.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/system/macosx/templates/CoreFoundation.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.system.macosx.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/system/macosx/templates/DynamicLinkLoader.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/system/macosx/templates/DynamicLinkLoader.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.system.macosx.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/system/macosx/templates/LibC.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/system/macosx/templates/LibC.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.system.macosx.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/system/macosx/templates/LibSystem.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/system/macosx/templates/LibSystem.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.system.macosx.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/system/macosx/templates/ObjC.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/system/macosx/templates/ObjC.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.system.macosx.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/system/windows/WindowsTypes.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/system/windows/WindowsTypes.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.system.windows
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/system/windows/templates/GDI32.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/system/windows/templates/GDI32.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.system.windows.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/system/windows/templates/User32.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/system/windows/templates/User32.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.system.windows.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/system/windows/templates/WinBase.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/system/windows/templates/WinBase.kt
@@ -1,6 +1,6 @@
 /* 
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.system.windows.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/util/lmdb/LMDBTypes.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/util/lmdb/LMDBTypes.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.util.lmdb
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/util/lmdb/templates/lmdb.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/util/lmdb/templates/lmdb.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.util.lmdb.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/util/nfd/NFDTypes.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/util/nfd/NFDTypes.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.util.nfd
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/util/nfd/templates/nativefiledialog.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/util/nfd/templates/nativefiledialog.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.util.nfd.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/util/par/ParTypes.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/util/par/ParTypes.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.util.par
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/util/par/templates/par_shapes.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/util/par/templates/par_shapes.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.util.par.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/util/simd/SSETypes.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/util/simd/SSETypes.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.util.simd
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/util/simd/templates/SSE.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/util/simd/templates/SSE.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.util.simd.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/util/simd/templates/SSE3.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/util/simd/templates/SSE3.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.util.simd.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/util/tinyfd/TinyFDTypes.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/util/tinyfd/TinyFDTypes.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.util.tinyfd
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/util/tinyfd/templates/tinyfiledialogs.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/util/tinyfd/templates/tinyfiledialogs.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.util.tinyfd.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/util/xxhash/templates/xxhash.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/util/xxhash/templates/xxhash.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.util.xxhash.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/util/xxhash/xxHashTypes.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/util/xxhash/xxHashTypes.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.util.xxhash
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/vulkan/ExtensionTypes.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/vulkan/ExtensionTypes.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.vulkan
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/vulkan/VKBinding.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/vulkan/VKBinding.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.vulkan
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/vulkan/VKTypes.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/vulkan/VKTypes.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.vulkan
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/vulkan/ValidityProtos.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/vulkan/ValidityProtos.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  * MACHINE GENERATED FILE, DO NOT EDIT
  */
 package org.lwjgl.vulkan

--- a/modules/templates/src/main/kotlin/org/lwjgl/vulkan/ValidityStructs.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/vulkan/ValidityStructs.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  * MACHINE GENERATED FILE, DO NOT EDIT
  */
 package org.lwjgl.vulkan

--- a/modules/templates/src/main/kotlin/org/lwjgl/vulkan/templates/AMD_gcn_shader.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/vulkan/templates/AMD_gcn_shader.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.vulkan.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/vulkan/templates/AMD_rasterization_order.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/vulkan/templates/AMD_rasterization_order.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.vulkan.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/vulkan/templates/AMD_shader_ballot.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/vulkan/templates/AMD_shader_ballot.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.vulkan.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/vulkan/templates/AMD_shader_explicit_vertex_parameter.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/vulkan/templates/AMD_shader_explicit_vertex_parameter.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.vulkan.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/vulkan/templates/AMD_shader_trinary_minmax.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/vulkan/templates/AMD_shader_trinary_minmax.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.vulkan.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/vulkan/templates/EXT_debug_marker.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/vulkan/templates/EXT_debug_marker.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.vulkan.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/vulkan/templates/EXT_debug_report.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/vulkan/templates/EXT_debug_report.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.vulkan.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/vulkan/templates/ExtensionFlags.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/vulkan/templates/ExtensionFlags.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.vulkan.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/vulkan/templates/IMG_filter_cubic.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/vulkan/templates/IMG_filter_cubic.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.vulkan.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/vulkan/templates/KHR_display.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/vulkan/templates/KHR_display.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.vulkan.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/vulkan/templates/KHR_display_swapchain.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/vulkan/templates/KHR_display_swapchain.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.vulkan.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/vulkan/templates/KHR_sampler_mirror_clamp_to_edge.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/vulkan/templates/KHR_sampler_mirror_clamp_to_edge.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.vulkan.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/vulkan/templates/KHR_surface.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/vulkan/templates/KHR_surface.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.vulkan.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/vulkan/templates/KHR_swapchain.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/vulkan/templates/KHR_swapchain.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.vulkan.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/vulkan/templates/KHR_win32_surface.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/vulkan/templates/KHR_win32_surface.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.vulkan.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/vulkan/templates/KHR_xlib_surface.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/vulkan/templates/KHR_xlib_surface.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.vulkan.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/vulkan/templates/NV_dedicated_allocation.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/vulkan/templates/NV_dedicated_allocation.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.vulkan.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/vulkan/templates/NV_glsl_shader.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/vulkan/templates/NV_glsl_shader.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.vulkan.templates
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/vulkan/templates/VK10.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/vulkan/templates/VK10.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright LWJGL. All rights reserved.
- * License terms: http://lwjgl.org/license.php
+ * License terms: https://www.lwjgl.org/license
  */
 package org.lwjgl.vulkan.templates
 

--- a/update-dependencies.xml
+++ b/update-dependencies.xml
@@ -1,6 +1,6 @@
 <!--
 Copyright LWJGL. All rights reserved.
-License terms: http://lwjgl.org/license.php
+License terms: https://www.lwjgl.org/license
 
 Downloads LWJGL's library dependencies.
 -->


### PR DESCRIPTION
1) Updated all license URLs since [www.lwjgl.org](www.lwjgl.org) has moved to https and also uses [semantic URLs](https://en.wikipedia.org/wiki/Semantic_URL).

2) Tweaked BSD 3-Clause to avoid having to update the copyright year and fixed the copyright holder name to match the license on the website.

Fixes https://github.com/LWJGL/lwjgl3/issues/212