### PR TITLE
Fix template name

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -174,7 +174,7 @@
 			<src path="${src.templates.kotlin}/org/lwjgl/ovr" if:true="${binding.ovr}"/>
 			<src path="${src.templates.kotlin}/org/lwjgl/stb" if:true="${binding.stb}"/>
 			<src path="${src.templates.kotlin}/org/lwjgl/vulkan" if:true="${binding.vulkan}"/>
-			<src path="${src.templates.kotlin}/org/lwjgl/vulkan/VKypes.kt" unless:true="${binding.vulkan}"/>
+			<src path="${src.templates.kotlin}/org/lwjgl/vulkan/VKTypes.kt" unless:true="${binding.vulkan}"/>
 			<src path="${src.templates.kotlin}/org/lwjgl/vulkan/ExtensionTypes.kt" unless:true="${binding.vulkan}"/>
 
 			<src path="${src.templates.kotlin}/org/lwjgl/system/dyncall"/>


### PR DESCRIPTION
I was trying to disable Vulkan bindings to reduce time needed for 'compile-templates'. Didn't work out for other reasons (Kotlin compile errors I do not understand), but nevertheless...