### PR TITLE
Variable argument list callbacks

### DIFF
--- a/config/windows/build.xml
+++ b/config/windows/build.xml
@@ -95,6 +95,7 @@
 				<arg value="/I${src.include}\system\dyncall"/>
 				<arg value="/I${src.include}\system\jemalloc" if:true="${binding.jemalloc}"/>
 				<arg value="/I${src.include}\system\jemalloc\msvc_compat" if:true="${binding.jemalloc}"/>
+				<arg value="/wd4710"/>
 				<fileset dir=".">
 					<include name="${src.native}/system/*.c"/>
 					<exclude name="${src.native}/system/lwjgl_malloc.c"/>

--- a/modules/core/src/main/c/system/org_lwjgl_system_MemoryAccess.c
+++ b/modules/core/src/main/c/system/org_lwjgl_system_MemoryAccess.c
@@ -192,4 +192,16 @@ JNIEXPORT jobject JNICALL Java_org_lwjgl_system_MemoryAccess_newDirectByteBuffer
 	return (*env)->NewDirectByteBuffer(env, (void *)(intptr_t)address, capacity);
 }
 
+// vsnprintf(JIJJ)I
+JNIEXPORT jint JNICALL Java_org_lwjgl_system_MemoryAccess_vsnprintf(JNIEnv *env, jclass clazz,
+	jlong address, jint capacity, jlong format, jlong valist
+) {
+	UNUSED_PARAMS(env, clazz)
+#ifdef LWJGL_WINDOWS
+	return vsnprintf_s((char *)(intptr_t)address, capacity, _TRUNCATE, (const char *)(intptr_t)format, (va_list)valist);
+#else
+	return vsnprintf((char *)(intptr_t)address, capacity, (const char *)(intptr_t)format, *((va_list *)valist));
+#endif
+}
+
 EXTERN_C_EXIT

--- a/modules/core/src/main/java/org/lwjgl/system/APIUtil.java
+++ b/modules/core/src/main/java/org/lwjgl/system/APIUtil.java
@@ -440,4 +440,26 @@ public final class APIUtil {
 
 	// ----------------------------------------
 
+	/**
+	 * Uses the vsnprintf() C library function to format a null-terminated string with a {@code va_list} argument list. The result is stored at index
+	 * {@code [position(), position()+remaining()}) in {@code buffer}, as a null-terminated string.
+	 *
+	 * <p>Output is truncated if there is not enough space in {@code buffer}. In this case, this function returns the size which would
+	 * have been required to store the full string, excluding the null terminator.</p>
+	 *
+	 * <p>The current {@code position} and {@code limit} of the specified {@code buffer} are not affected by this operation.</p>
+	 *
+	 * @param buffer       the output buffer
+	 * @param formatString memory address of the format string
+	 * @param valist       memory address of the {@code va_list} argument list
+	 *
+	 * @return the number of characters written to {@code buffer}, excluding the null terminator, or a negative value in case of error
+	 */
+	public static int apiVPrintf(ByteBuffer buffer, long formatString, long valist) {
+		long address = memAddress(buffer, buffer.position());
+		return MemoryAccess.vsnprintf(address, buffer.remaining(), formatString, valist);
+	}
+
+	// ----------------------------------------
+
 }

--- a/modules/core/src/main/java/org/lwjgl/system/MemoryAccess.java
+++ b/modules/core/src/main/java/org/lwjgl/system/MemoryAccess.java
@@ -97,6 +97,9 @@ final class MemoryAccess {
 	// Returns a new direct ByteBuffer instance
 	static native ByteBuffer newDirectByteBuffer(long address, int capacity);
 
+	// The standard C vsnprintf function
+	static native int vsnprintf(long address, int capacity, long format, long valist);
+
 	/** Implements functionality for {@link MemoryUtil}. */
 	interface MemoryAccessor {
 

--- a/modules/core/src/main/java/org/lwjgl/system/MemoryUtil.java
+++ b/modules/core/src/main/java/org/lwjgl/system/MemoryUtil.java
@@ -1662,7 +1662,7 @@ public final class MemoryUtil {
 	 *
 	 * @param address the string memory address
 	 *
-	 * @return the decode {@link String} or null if the specified {@code address} is null
+	 * @return the decoded {@link String} or null if the specified {@code address} is null
 	 */
 	public static String memUTF8(long address) {
 		return address == NULL ? null : memUTF8(memByteBufferNT1(address));


### PR DESCRIPTION
This PR adds utility functions to handle `(const char* format, va_list arguments)` style callbacks.

Instead of trying to parse format strings and argument lists with Java, this calls vsnprintf() on the native side, with a user-provided memory buffer. I also added two convenience functions which use stack memory for buffer storage.

So far this has been tested with one of the callback functions in my bgfx binding branch, on Windows 32/64 bit and on OSX.

It's somewhat fiddly to properly handle vsnprintf() and pass around va_arg parameters in a cross-platform compatible fashion, so feel free to moan and/or reject my typecast rampage. ;)