### PR TITLE
Update bgfx to API version 23

### DIFF
--- a/modules/templates/src/main/kotlin/org/lwjgl/bgfx/templates/BGFX.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/bgfx/templates/BGFX.kt
@@ -16,7 +16,7 @@ val BGFX = "BGFX".nativeClass(packageName = BGFX_PACKAGE, prefix = "BGFX", prefi
 	IntConstant(
 		"API version",
 
-		"API_VERSION".."22"
+		"API_VERSION".."23"
 	)
 
 	val StateFlags = LongConstant(
@@ -495,15 +495,15 @@ val BGFX = "BGFX".nativeClass(packageName = BGFX_PACKAGE, prefix = "BGFX", prefi
 	val RendererType = EnumConstant(
 		"Renderer type. ({@code bgfx_renderer_type_t})",
 
-		"RENDERER_TYPE_NULL".enum,
+		"RENDERER_TYPE_NOOP".enum,
 		"RENDERER_TYPE_DIRECT3D9".enum,
 		"RENDERER_TYPE_DIRECT3D11".enum,
 		"RENDERER_TYPE_DIRECT3D12".enum,
+		"RENDERER_TYPE_GNM".enum,
 		"RENDERER_TYPE_METAL".enum,
 		"RENDERER_TYPE_OPENGLES".enum,
 		"RENDERER_TYPE_OPENGL".enum,
 		"RENDERER_TYPE_VULKAN".enum,
-		"RENDERER_TYPE_GNM".enum,
 
 		"RENDERER_TYPE_COUNT".enum
 	).javaDocLinks


### PR DESCRIPTION
I noticed the natives are already built with the latest version. The renderer type enum order has been [changed](https://github.com/bkaradzic/bgfx/commit/f1a8c5f19534302000a48e4e8fdf26776516c1b3), which fails the current demos if they request e.g. the Metal or GL renderers.

I opened an [issue](https://github.com/bkaradzic/bgfx/issues/939) to ask for a means to query the API version, so applications could error early if the bindings API doesn't match. I have a variant working here which uses an opaque variant of bgfx_get_interface(), but this feels a little... dirty.