### PR TITLE
Fix docs on MemoryUtil for method memASCII method

### DIFF
--- a/modules/core/src/main/java/org/lwjgl/system/MemoryUtil.java
+++ b/modules/core/src/main/java/org/lwjgl/system/MemoryUtil.java
@@ -1331,7 +1331,7 @@ public final class MemoryUtil {
 	 * @param text           the text to encode
 	 * @param nullTerminated if true, the text will be terminated with a '\0'.
 	 *
-	 * @return the encoded text or null
+	 * @return the number of bytes of the encoded string
 	 */
 	public static int memASCII(CharSequence text, boolean nullTerminated, ByteBuffer target) {
 		return memASCII(text, nullTerminated, target, target.position());


### PR DESCRIPTION
The `memASCII` method has incorrect javadoc return, it returns the number of bytes of the encoded string, but it says that it returns null or the `ByteBuffer`. This PR fixes that.