### PR TITLE
Use ASM to generate classes at runtime; map jclass to Class; add JNI …

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -486,7 +486,6 @@
 		<lwjgl.javac srcdir="${src.tests}" destdir="${bin.tests}" taskname="javac: Tests">
 			<classpath>
 				<pathelement path="${bin.core}"/>
-				<pathelement path="${lib}/javassist.jar"/>
 				<pathelement path="${lib}/asm.jar"/>
 				<pathelement path="${lib}/testng.jar"/>
 			</classpath>
@@ -546,7 +545,6 @@
 	<target name="tests" description="Runs the LWJGL test suite" depends="compile-tests, compile-native, -init-runtime">
 		<testng outputDir="${bin.html.tests}" classpathref="runtime.classpath" taskname="Tests">
 			<classpath>
-				<pathelement path="${lib}/javassist.jar"/>
 				<pathelement path="${lib}/asm.jar"/>
 				<pathelement path="${lib}/jcommander.jar"/>
 			</classpath>
@@ -579,7 +577,6 @@
 
 		<java classname="${class}" classpathref="runtime.classpath" fork="true" failonerror="${failonerror}" spawn="${spawn}" taskname="Demo">
 			<classpath>
-				<pathelement path="${lib}/javassist.jar"/>
 				<pathelement path="${lib}/asm.jar"/>
 				<pathelement path="${lib}/testng.jar"/>
 			</classpath>

--- a/build.xml
+++ b/build.xml
@@ -487,6 +487,7 @@
 			<classpath>
 				<pathelement path="${bin.core}"/>
 				<pathelement path="${lib}/javassist.jar"/>
+				<pathelement path="${lib}/asm.jar"/>
 				<pathelement path="${lib}/testng.jar"/>
 			</classpath>
 
@@ -546,6 +547,7 @@
 		<testng outputDir="${bin.html.tests}" classpathref="runtime.classpath" taskname="Tests">
 			<classpath>
 				<pathelement path="${lib}/javassist.jar"/>
+				<pathelement path="${lib}/asm.jar"/>
 				<pathelement path="${lib}/jcommander.jar"/>
 			</classpath>
 
@@ -578,6 +580,7 @@
 		<java classname="${class}" classpathref="runtime.classpath" fork="true" failonerror="${failonerror}" spawn="${spawn}" taskname="Demo">
 			<classpath>
 				<pathelement path="${lib}/javassist.jar"/>
+				<pathelement path="${lib}/asm.jar"/>
 				<pathelement path="${lib}/testng.jar"/>
 			</classpath>
 

--- a/modules/core/src/test/java/org/lwjgl/demo/system/tinycc/CallbackTest.java
+++ b/modules/core/src/test/java/org/lwjgl/demo/system/tinycc/CallbackTest.java
@@ -228,7 +228,7 @@ public final class CallbackTest {
 				throw new IllegalStateException("Compilation failed.");
 
 			tcc_add_symbol(tcc, "getEnv", ThreadLocalUtil.GET_JNI_ENV);
-			addSymbol(tcc, block, 2, "callback", FindClass(method.getDeclaringClass().getName().replace('.', '/')));
+			addSymbol(tcc, block, 2, "callback", ClassToPointer(method.getDeclaringClass()));
 			addSymbol(tcc, block, 3, "method", FromReflectedMethod(method));
 		}
 

--- a/modules/core/src/test/java/org/lwjgl/demo/system/tinycc/ClassUtils.java
+++ b/modules/core/src/test/java/org/lwjgl/demo/system/tinycc/ClassUtils.java
@@ -6,7 +6,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 
 /**
- * Utility methods to define a {@link Class} within the JVM and instantiate a class without calling any constructor.
+ * Utility methods to define a {@link Class} within the JVM.
  */
 class ClassUtils {
 

--- a/modules/core/src/test/java/org/lwjgl/demo/system/tinycc/ClassUtils.java
+++ b/modules/core/src/test/java/org/lwjgl/demo/system/tinycc/ClassUtils.java
@@ -1,0 +1,153 @@
+package org.lwjgl.demo.system.tinycc;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+/**
+ * Utility methods to define a {@link Class} within the JVM and instantiate a class without calling any constructor.
+ */
+class ClassUtils {
+
+    /**
+     * The "defineAnonymousClass" method in the Unsafe class to use the HotSpot anonymous class feature.
+     */
+    private static final MethodHandle defineAnonymousClass;
+
+    /**
+     * The "defineClass" method in the {@link ClassLoader} to define classes normally.
+     */
+    private static final MethodHandle defineClass;
+
+    static {
+        try {
+            Method defineClassMethod = ClassLoader.class.getDeclaredMethod("defineClass", String.class, byte[].class, int.class, int.class);
+            defineClassMethod.setAccessible(true);
+            defineClass = MethodHandles.lookup().unreflect(defineClassMethod);
+            MethodHandle defineAnonymousClassMH;
+            try {
+                Class<?> unsafeClass = ClassLoader.getSystemClassLoader().loadClass("sun.misc.Unsafe");
+                Field theUnsafeField = unsafeClass.getDeclaredField("theUnsafe");
+                theUnsafeField.setAccessible(true);
+                Object unsafe = theUnsafeField.get(null);
+                try {
+                    /*
+                     * Check if "defineAnonymousClass" is in the sun.misc.Unsafe class.
+                     */
+                    Method defineAnonymousClassMethod = unsafeClass.getDeclaredMethod("defineAnonymousClass", Class.class, byte[].class, Object[].class);
+                    defineAnonymousClassMH = MethodHandles.lookup().unreflect(defineAnonymousClassMethod).bindTo(unsafe);
+                } catch (NoSuchMethodException e) {
+                    /* No defineAnonymousClass */
+                    defineAnonymousClassMH = null;
+                }
+            } catch (ClassNotFoundException e) {
+                /* No Unsafe :-( */
+                defineAnonymousClassMH = null;
+            }
+            defineAnonymousClass = defineAnonymousClassMH;
+        } catch (Exception e) {
+            throw new AssertionError("Could not find method: ClassLoader.defineClass");
+        }
+    }
+
+    /**
+     * Define a class as an anonymous class (if supported by the JVM).
+     * <p>
+     * See <a href="https://blogs.oracle.com/jrose/entry/anonymous_classes_in_the_vm">anonymous classes in the VM</a> for more information.
+     * 
+     * @param hostClass
+     *            the host class
+     * @param bytecode
+     *            the bytecode of the defined anonymous class
+     * @param constantPoolPatch
+     *            the constant pool patch; may be <code>null</code>
+     * @return the defined {@link Class}
+     */
+    private static <T> Class<T> defineAnonymousClass(Class<?> hostClass, byte[] bytecode, Object[] constantPoolPatch) {
+        if (defineAnonymousClass == null) {
+            throw new RuntimeException("Anonymous classes not supported", null);
+        }
+        try {
+            Class<T> clazz = (Class<T>) defineAnonymousClass.invokeExact(hostClass, bytecode, constantPoolPatch);
+            return clazz;
+        } catch (Throwable e) {
+            throw new RuntimeException("Could not define anonymous class in JVM", e);
+        }
+    }
+
+    /**
+     * Define the class of the given <code>name</code> whose code is stored in the given <code>definition</code> byte array in the JVM via the given {@link ClassLoader}.
+     * 
+     * @param cl
+     *            the {@link ClassLoader} used to define the class
+     * @param name
+     *            the name of the class (either API name or internal name; conversion is done automatically)
+     * @param definition
+     *            the definition as a byte array
+     * @param offset
+     *            the offset into the given byte array
+     * @param length
+     *            the number of bytes to take from the byte array
+     * @return the defined {@link Class}
+     */
+    private static <T> Class<T> defineClass(ClassLoader cl, String name, byte[] definition, int offset, int length) {
+        String apiName = name.replace('/', '.');
+        try {
+            Class<T> ret = (Class<T>) defineClass.invokeExact(cl, apiName, definition, offset, length);
+            return ret;
+        } catch (Throwable e) {
+            throw new RuntimeException("Could not define class in JVM: " + name, e);
+        }
+    }
+
+    /**
+     * Define the class of the given <code>name</code> whose code is stored in the given <code>definition</code> byte array in the JVM via the given {@link ClassLoader}.
+     * <p>
+     * If <a href="https://blogs.oracle.com/jrose/entry/anonymous_classes_in_the_vm">HotSpot anonymous classes</a> is supported and the <code>hostClass</code> is not
+     * <code>null</code>, that host will define the lifecycle and visibility of the anonymous class. In that case, the new class will not be defined via the given or any other
+     * {@link ClassLoader} but will use a JVM-internal mechanism instead.
+     * 
+     * @see #defineClass(ClassLoader, Class, String, byte[], Object[])
+     * 
+     * @param cl
+     *            the {@link ClassLoader} used to define the class
+     * @param hostClass
+     *            the host class whose linkage properties are shared with the generated class (if anonymous classes are used (feature of Hotspot)); may be <code>null</code>
+     * @param name
+     *            the name of the class (either API name or internal name; conversion is done automatically)
+     * @param definition
+     *            the definition as a byte array
+     * @return the defined {@link Class}
+     */
+    public static <T> Class<T> defineClass(ClassLoader cl, Class<?> hostClass, String name, byte[] definition) {
+        return defineClass(cl, hostClass, name, definition, null);
+    }
+
+    /**
+     * Define the class of the given <code>name</code> whose code is stored in the given <code>definition</code> byte array in the JVM via the given {@link ClassLoader}.
+     * <p>
+     * If <a href="https://blogs.oracle.com/jrose/entry/anonymous_classes_in_the_vm">HotSpot anonymous classes</a> is supported and the <code>hostClass</code> is not
+     * <code>null</code>, that host will define the lifecycle and visibility of the anonymous class. In that case, the new class will not be defined via the given or any other
+     * {@link ClassLoader} but will use a JVM-internal mechanism instead.
+     * 
+     * @param cl
+     *            the {@link ClassLoader} used to define the class
+     * @param hostClass
+     *            the host {@link Class} (ignored if anonymous classes are unsupported)
+     * @param name
+     *            the name
+     * @param definition
+     *            the definition as a byte array
+     * @param constantPoolPatch
+     *            not used yet
+     * @return the defined {@link Class}
+     */
+    public static <T> Class<T> defineClass(ClassLoader cl, Class<?> hostClass, String name, byte[] definition, Object[] constantPoolPatch) {
+        if (defineAnonymousClass != null && hostClass != null) {
+            return defineAnonymousClass(hostClass, definition, constantPoolPatch);
+        }
+        return defineClass(cl, name, definition, 0, definition.length);
+    }
+
+}

--- a/modules/core/src/test/java/org/lwjgl/demo/system/tinycc/HelloTinyCC.java
+++ b/modules/core/src/test/java/org/lwjgl/demo/system/tinycc/HelloTinyCC.java
@@ -135,10 +135,7 @@ public final class HelloTinyCC {
 				.signature(stack.UTF8("()I"))
 				.fnPtr(func);
 
-			RegisterNatives(
-				FindClass("org/lwjgl/demo/system/tinycc/HelloTinyCC$JNITest"),
-				methods
-			);
+			RegisterNatives(JNITest.class, methods);
 
 			System.out.println("JNITest.getPointerSize() = " + JNITest.getPointerSize());
 		} finally {

--- a/modules/core/src/test/java/org/lwjgl/demo/system/tinycc/PerfTest.java
+++ b/modules/core/src/test/java/org/lwjgl/demo/system/tinycc/PerfTest.java
@@ -10,8 +10,6 @@ import org.lwjgl.system.MemoryStack;
 import org.lwjgl.system.jni.JNINativeMethod;
 import org.lwjgl.system.tinycc.ErrorCallback;
 
-import java.lang.invoke.MethodHandle;
-
 import static org.lwjgl.glfw.GLFW.*;
 import static org.lwjgl.opengl.GL30.*;
 import static org.lwjgl.system.JNITinyHeader.*;
@@ -120,10 +118,7 @@ public final class PerfTest {
 				.signature(stack.UTF8("(II)V"))
 				.fnPtr(testExtern_p);
 
-			if ( RegisterNatives(
-				FindClass("org/lwjgl/demo/system/tinycc/PerfTest$JNITest"),
-				methods
-			) != 0 )
+			if ( RegisterNatives(JNITest.class, methods) != 0 )
 				throw new IllegalStateException("Failed to register JNI natives");
 
 			long t = 0;

--- a/modules/templates/src/main/kotlin/org/lwjgl/system/jni/JNITypes.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/system/jni/JNITypes.kt
@@ -36,7 +36,7 @@ val jdoubleArray = NativeType("jdoubleArray", TypeMapping("jdoubleArray", Double
 
 val jsize = typedef(jint, "jsize")
 
-val jclass = "jclass".opaque_p
+val jclass = NativeType("jclass", TypeMapping("jclass", Class::class, Class::class))
 val jmethodID = "jmethodID".opaque_p
 val jfieldID = "jfieldID".opaque_p
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/system/jni/templates/JNINativeInterface.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/system/jni/templates/JNINativeInterface.kt
@@ -79,7 +79,7 @@ val JNINativeInterface = "JNINativeInterface".nativeClass(JNI_PACKAGE, prefix = 
 	)
 
 	Code(
-		nativeCall = "\treturn (jlong)(intptr_t)(*__env)->NewGlobalRef(__env, (*__env)->FindClass(__env, name));"
+		nativeCall = "\treturn (*__env)->FindClass(__env, name);"
 	)..jclass(
 		"FindClass",
 		"""
@@ -120,6 +120,16 @@ val JNINativeInterface = "JNINativeInterface".nativeClass(JNI_PACKAGE, prefix = 
 		),
 
 		returnDoc = "a class object from a fully-qualified name, or #NULL if the class cannot be found"
+	)
+
+	Code(
+		nativeCall = "\tUNUSED_PARAM(__env); return (jlong)(intptr_t)klass;"
+	)..opaque_p(
+		"ClassToPointer",
+		"Helper function to convert a Class to a long pointer",
+
+		JNI_ENV,
+		jclass.IN("klass", "")
 	)
 
 	jmethodID(

--- a/modules/templates/src/main/kotlin/org/lwjgl/system/jni/templates/JNINativeInterface.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/system/jni/templates/JNINativeInterface.kt
@@ -100,14 +100,6 @@ val JNINativeInterface = "JNINativeInterface".nativeClass(JNI_PACKAGE, prefix = 
 		The array type signature of the array class {@code java.lang.Object[]} is:
 		${codeBlock("""
 "[Ljava/lang/Object;"""")}
-
-		${note(
-			"""
-			The {@code jclass} returned by {@code FindClass} is a local reference and cannot be returned directly from the JNI function. For this reason LWJGL
-			passes it to #NewGlobalRef() and that reference is returned instead. Users of this method must call #DeleteGlobalRef() when the {@code jclass} is
-			no longer used.
-			"""
-		)}
 		""",
 
 		JNI_ENV,
@@ -123,10 +115,18 @@ val JNINativeInterface = "JNINativeInterface".nativeClass(JNI_PACKAGE, prefix = 
 	)
 
 	Code(
-		nativeCall = "\tUNUSED_PARAM(__env); return (jlong)(intptr_t)klass;"
+		nativeCall = "\treturn (jlong)(intptr_t)(*__env)->NewGlobalRef(__env, klass);"
 	)..opaque_p(
 		"ClassToPointer",
-		"Helper function to convert a Class to a long pointer",
+		"""
+		Converts a Class object to a long.
+		${note(
+        """
+        The long returned by this method will be a global reference. Users of this method must call #DeleteGlobalRef() when the value returned by
+        this method is no longer used.
+        """
+    )}
+		""",
 
 		JNI_ENV,
 		jclass.IN("klass", "")

--- a/update-dependencies.xml
+++ b/update-dependencies.xml
@@ -10,7 +10,6 @@
 	<import file="${config}/build-definitions.xml" id="defs"/>
 
 	<!-- *********************************** -->
-	<property name="javassist" value="3.22.0-CR1"/>
 	<property name="asm" value="5.2"/>
 	<property name="testng" value="6.10"/>
 	<property name="jcommander" value="1.60"/>
@@ -73,7 +72,6 @@
 
 	<!-- Downloads the Java dependencies. -->
 	<target name="-lib-download" unless="lib-uptodate">
-		<update-mvn name="Javassist" group="org/javassist" artifact="javassist" version="${javassist}" dest="${lib}"/>
 		<update-mvn name="ASM" group="org/ow2/asm" artifact="asm" version="${asm}" dest="${lib}"/>
 		<update-mvn name="JCommander" group="com/beust" artifact="jcommander" version="${jcommander}" dest="${lib}"/>
 		<update-mvn name="TestNG" group="org/testng" artifact="testng" version="${testng}" dest="${lib}"/>

--- a/update-dependencies.xml
+++ b/update-dependencies.xml
@@ -11,6 +11,7 @@
 
 	<!-- *********************************** -->
 	<property name="javassist" value="3.22.0-CR1"/>
+	<property name="asm" value="5.2"/>
 	<property name="testng" value="6.10"/>
 	<property name="jcommander" value="1.60"/>
 	<property name="kotlinc-version" value="1.1-beta"/>
@@ -73,6 +74,7 @@
 	<!-- Downloads the Java dependencies. -->
 	<target name="-lib-download" unless="lib-uptodate">
 		<update-mvn name="Javassist" group="org/javassist" artifact="javassist" version="${javassist}" dest="${lib}"/>
+		<update-mvn name="ASM" group="org/ow2/asm" artifact="asm" version="${asm}" dest="${lib}"/>
 		<update-mvn name="JCommander" group="com/beust" artifact="jcommander" version="${jcommander}" dest="${lib}"/>
 		<update-mvn name="TestNG" group="org/testng" artifact="testng" version="${testng}" dest="${lib}"/>
 


### PR DESCRIPTION
…ClassToPointer function

Why ASM?
- ASM is 3x faster than Javassist in the current use-case
- the ASM jar is smaller
- the code required to generate a class is less

Why map jclass to Class?
- no need to go through JNI just to lookup a Class by name
- in some cases, we already have the Class instance and need not look it up again by name
- more importantly, this allows to define classes as very light-weight HotSpot Anonymous Classes (those cannot be looked-up by name)

Why ClassToPointer?
- some methods seem to need the jclass as a long (in the ClassbackTest)
- we always already have a reference to the actual Class object, only conversion to long is needed