### PR TITLE
Conditionally skip StackTest.testOOME() at runtime. Closes #275

### DIFF
--- a/modules/core/src/test/java/org/lwjgl/system/StackTest.java
+++ b/modules/core/src/test/java/org/lwjgl/system/StackTest.java
@@ -4,8 +4,10 @@
  */
 package org.lwjgl.system;
 
+import org.testng.SkipException;
 import org.testng.annotations.Test;
 
+import static org.lwjgl.system.Checks.*;
 import static org.lwjgl.system.MemoryStack.*;
 import static org.testng.Assert.*;
 
@@ -77,6 +79,8 @@ public class StackTest {
 
 	@Test(expectedExceptions = OutOfMemoryError.class)
 	public void testOOME() {
+		if (!CHECKS) throw new SkipException("This test may not run with checks disabled.");
+
 		MemoryStack stack = new MemoryStack(8);
 
 		stack.push();


### PR DESCRIPTION
I only recently read about TestNG's `SkipException`, which allows us to skip a test without disabling it. Additionally we may specify why the test was skipped.
This solves the exact problem I described in #275 and is way easier to maintain and implement for individual test cases.

Btw: Sorry for the mess of mentions created in the issues discussion. I'm still getting used to git and github.