### PR TITLE
Update the JavaDoc generation

### DIFF
--- a/modules/generator/src/main/kotlin/org/lwjgl/generator/CallbackFunction.kt
+++ b/modules/generator/src/main/kotlin/org/lwjgl/generator/CallbackFunction.kt
@@ -182,13 +182,14 @@ fun String.callback(
     functionDoc: String,
     vararg signature: Parameter,
     returnDoc: String = "",
+    see: Array<String> = emptyArray(),
     since: String = "",
     init: (CallbackFunction.() -> Unit)? = null
 ): CallbackType {
     val callback = CallbackFunction(packageName, className, returns, *signature)
     if (init != null)
         callback.init()
-    callback.functionDoc = { it -> it.toJavaDoc(it.processDocumentation(functionDoc), it.signature.asSequence(), it.returns, returnDoc, since) }
+    callback.functionDoc = { it -> it.toJavaDoc(it.processDocumentation(functionDoc), it.signature.asSequence(), it.returns, returnDoc, see, since) }
     Generator.register(callback)
     Generator.register(CallbackInterface(callback))
     return CallbackType(callback, this)

--- a/modules/generator/src/main/kotlin/org/lwjgl/generator/Constants.kt
+++ b/modules/generator/src/main/kotlin/org/lwjgl/generator/Constants.kt
@@ -67,6 +67,7 @@ class ConstantBlock<T : Any>(
     var access: Access,
     val constantType: ConstantType<T>,
     val documentation: () -> String?,
+    val see: Array<String>,
     vararg val constants: Constant<T>
 ) {
 
@@ -164,7 +165,7 @@ class ConstantBlock<T : Any>(
         """
                         }
                     }
-            }, *rootBlock.toArray(emptyArray())).let {
+            }, see, *rootBlock.toArray(emptyArray())).let {
                 it.noPrefix = noPrefix
                 it.generate(writer)
             }
@@ -176,7 +177,7 @@ class ConstantBlock<T : Any>(
         println()
         val doc = documentation()
         if (doc != null)
-            println(doc.toJavaDoc())
+            println(doc.toJavaDoc(see = see))
 
         print("$t${access.modifier}static final ${constantType.javaType}")
 

--- a/modules/generator/src/main/kotlin/org/lwjgl/generator/Functions.kt
+++ b/modules/generator/src/main/kotlin/org/lwjgl/generator/Functions.kt
@@ -602,7 +602,7 @@ class Func(
             }.let { hiddenParameters ->
                 val documentation = nativeClass.processDocumentation("Unsafe version of: $javaDocLink")
                 println(if (hiddenParameters.any())
-                    nativeClass.toJavaDoc(documentation, hiddenParameters, returns.nativeType, "", "")
+                    nativeClass.toJavaDoc(documentation, hiddenParameters, returns.nativeType)
                 else
                     documentation.toJavaDoc()
                 )

--- a/modules/generator/src/main/kotlin/org/lwjgl/generator/GeneratorTarget.kt
+++ b/modules/generator/src/main/kotlin/org/lwjgl/generator/GeneratorTarget.kt
@@ -154,6 +154,8 @@ abstract class GeneratorTarget(
         }
 
     var documentation: String? = null
+    var see: Array<String> = emptyArray()
+    var since: String = ""
 
     internal val preamble = Preamble()
 
@@ -210,7 +212,7 @@ abstract class GeneratorTarget(
 
         val documentation = this@GeneratorTarget.documentation
         if (documentation != null)
-            println(processDocumentation(documentation).toJavaDoc(indentation = ""))
+            println(processDocumentation(documentation).toJavaDoc(indentation = "", see = see, since = since))
     }
 
     abstract fun PrintWriter.generateJava()

--- a/modules/generator/src/main/kotlin/org/lwjgl/generator/NativeClass.kt
+++ b/modules/generator/src/main/kotlin/org/lwjgl/generator/NativeClass.kt
@@ -615,8 +615,8 @@ class NativeClass(
 
     // DSL extensions
 
-    operator fun <T : Any> ConstantType<T>.invoke(documentation: String, vararg constants: Constant<T>, access: Access = Access.PUBLIC): ConstantBlock<T> {
-        val block = ConstantBlock(this@NativeClass, access, this, { processDocumentation(documentation) }, *constants)
+    operator fun <T : Any> ConstantType<T>.invoke(documentation: String, vararg constants: Constant<T>, see: Array<String> = emptyArray(), access: Access = Access.PUBLIC): ConstantBlock<T> {
+        val block = ConstantBlock(this@NativeClass, access, this, { processDocumentation(documentation) }, see, *constants)
         constantBlocks.add(block)
         return block
     }
@@ -642,10 +642,10 @@ class NativeClass(
     fun String.enum(documentation: String, expression: String) =
         Constant(this, EnumValueExpression({ if (documentation.isEmpty()) null else processDocumentation(documentation) }, expression))
 
-    operator fun NativeType.invoke(name: String, documentation: String, vararg parameters: Parameter, returnDoc: String = "", since: String = "", noPrefix: Boolean = false) =
-        ReturnValue(this)(name, documentation, *parameters, returnDoc = returnDoc, since = since, noPrefix = noPrefix)
+    operator fun NativeType.invoke(name: String, documentation: String, vararg parameters: Parameter, returnDoc: String = "", see: Array<String> = emptyArray(), since: String = "", noPrefix: Boolean = false) =
+        ReturnValue(this)(name, documentation, *parameters, returnDoc = returnDoc, see = see, since = since, noPrefix = noPrefix)
 
-    operator fun ReturnValue.invoke(name: String, documentation: String, vararg parameters: Parameter, returnDoc: String = "", since: String = "", noPrefix: Boolean = false): Func {
+    operator fun ReturnValue.invoke(name: String, documentation: String, vararg parameters: Parameter, returnDoc: String = "", see: Array<String> = emptyArray(), since: String = "", noPrefix: Boolean = false): Func {
         val func = Func(
             returns = this,
             simpleName = name,
@@ -656,6 +656,7 @@ class NativeClass(
                     parameters.asSequence().filter { it !== JNI_ENV && parameterFilter(it) },
                     this.nativeType,
                     returnDoc,
+                    see,
                     since
                 )
             },

--- a/modules/templates/src/main/kotlin/org/lwjgl/assimp/templates/Assimp.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/assimp/templates/Assimp.kt
@@ -497,40 +497,49 @@ val Assimp = "Assimp".nativeClass(packageName = ASSIMP_PACKAGE, prefix = "ai", p
     ).noPrefix()
 
     StringConstant(
-        """
-        """,
+        "",
 
         "AI_CONFIG_IMPORT_MD3_KEYFRAME".."IMPORT_MD3_KEYFRAME"
     ).noPrefix()
 
     StringConstant(
-        "@see \\#AI_CONFIG_IMPORT_GLOBAL_KEYFRAME",
+        "",
 
-        "AI_CONFIG_IMPORT_MD2_KEYFRAME".."IMPORT_MD2_KEYFRAME"
+        "AI_CONFIG_IMPORT_MD2_KEYFRAME".."IMPORT_MD2_KEYFRAME",
+
+        see = arrayOf("#AI_CONFIG_IMPORT_GLOBAL_KEYFRAME")
     ).noPrefix()
 
     StringConstant(
-        "@see \\#AI_CONFIG_IMPORT_GLOBAL_KEYFRAME",
+        "",
 
-        "AI_CONFIG_IMPORT_MDL_KEYFRAME".."IMPORT_MDL_KEYFRAME"
+        "AI_CONFIG_IMPORT_MDL_KEYFRAME".."IMPORT_MDL_KEYFRAME",
+
+        see = arrayOf("#AI_CONFIG_IMPORT_GLOBAL_KEYFRAME")
     ).noPrefix()
 
     StringConstant(
-        "@see \\#AI_CONFIG_IMPORT_GLOBAL_KEYFRAME",
+        "",
 
-        "AI_CONFIG_IMPORT_MDC_KEYFRAME".."IMPORT_MDC_KEYFRAME"
+        "AI_CONFIG_IMPORT_MDC_KEYFRAME".."IMPORT_MDC_KEYFRAME",
+
+        see = arrayOf("#AI_CONFIG_IMPORT_GLOBAL_KEYFRAME")
     ).noPrefix()
 
     StringConstant(
-        "@see \\#AI_CONFIG_IMPORT_GLOBAL_KEYFRAME",
+        "",
 
-        "AI_CONFIG_IMPORT_SMD_KEYFRAME".."IMPORT_SMD_KEYFRAME"
+        "AI_CONFIG_IMPORT_SMD_KEYFRAME".."IMPORT_SMD_KEYFRAME",
+
+        see = arrayOf("#AI_CONFIG_IMPORT_GLOBAL_KEYFRAME")
     ).noPrefix()
 
     StringConstant(
-        "@see \\#AI_CONFIG_IMPORT_GLOBAL_KEYFRAME",
+        "",
 
-        "AI_CONFIG_IMPORT_UNREAL_KEYFRAME".."IMPORT_UNREAL_KEYFRAME"
+        "AI_CONFIG_IMPORT_UNREAL_KEYFRAME".."IMPORT_UNREAL_KEYFRAME",
+
+        see = arrayOf("#AI_CONFIG_IMPORT_GLOBAL_KEYFRAME")
     ).noPrefix()
 
     StringConstant(
@@ -674,13 +683,11 @@ val Assimp = "Assimp".nativeClass(packageName = ASSIMP_PACKAGE, prefix = "ai", p
     ).noPrefix()
 
     StringConstant(
-        """
-        End of the imported time range. 
-        
-        @see \\#AI_CONFIG_IMPORT_LWS_ANIM_START
-        """,
+        "End of the imported time range.",
 
-        "AI_CONFIG_IMPORT_LWS_ANIM_END".."IMPORT_LWS_ANIM_END"
+        "AI_CONFIG_IMPORT_LWS_ANIM_END".."IMPORT_LWS_ANIM_END",
+
+        see = arrayOf("#AI_CONFIG_IMPORT_LWS_ANIM_START")
     ).noPrefix()
 
     StringConstant(


### PR DESCRIPTION
With this PR...
- more reliable `@see` and `@since` tag generation is added,
- JavaDoc lines will always begin with a star ("*"). (Note that this does include code blocks!), and
- less blank JavaDoc will be generated.

The changes have been made in order to enhance the readability and quality of generated documentation. However, this does come at the cost that code snippets may not be copied straight from code blocks any longer (what I consider bad practice anyways).

All differences in the generated code can seen [here](https://gist.github.com/TheMrMilchmann/ea6317759b53a1b7ba3703733e97420c).

This also fixes a bug that sometimes caused `@since` tags to not be generated properly ([current](https://github.com/LWJGL/lwjgl3-generated/blob/master/java/org/lwjgl/glfw/GLFW.java#L761) vs. [updated](https://gist.github.com/TheMrMilchmann/ea6317759b53a1b7ba3703733e97420c#file-diff-txt-L1587)).

(A piece of documentation on how commits should be titled would be nice. I hope that this is in compliance with the new format.)