### PR TITLE
fix(generator): javadoc formatting bugs

### DIFF
--- a/modules/generator/src/main/kotlin/org/lwjgl/generator/JavaDoc.kt
+++ b/modules/generator/src/main/kotlin/org/lwjgl/generator/JavaDoc.kt
@@ -137,16 +137,16 @@ fun String.toJavaDoc(indentation: String = t, see: Array<String>? = null, since:
         StringBuilder(if (this.isEmpty()) "" else this.cleanup("$indentation * "))
             .apply {
                 if (see != null) {
-                    if (isNotEmpty()) append("\n$t *")
+                    if (isNotEmpty()) append("\n$indentation *")
                     see.forEach {
-                        if (isNotEmpty()) append("\n$t * ")
+                        if (isNotEmpty()) append("\n$indentation * ")
                         append("@see ")
                         append(it)
                     }
                 }
 
                 if (!since.isEmpty()) {
-                    if (isNotEmpty()) append("\n$t *\n$t * ")
+                    if (isNotEmpty()) append("\n$indentation *\n$indentation * ")
                     append("@since ")
                     append(since)
                 }


### PR DESCRIPTION
This fixes an issue that could cause javadoc to have the wrong indent in subclasses. Note that I use "could" here intentionally because LWJGL does not currently create subclasses with `@since` or `@see` tags. However, I decided to open this to "clean-up" the relevant code and to prevent this negatively impacting possible future additions to the library.

(There is no difference in the generated output. Hence I don't see the need to include a diff.)