### PR TITLE
Add nullability marker annotations

### DIFF
--- a/.idea/libraries/jsr305.xml
+++ b/.idea/libraries/jsr305.xml
@@ -1,0 +1,11 @@
+<component name="libraryTable">
+  <library name="jsr305">
+    <CLASSES>
+      <root url="jar://$PROJECT_DIR$/libs/jsr305.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$PROJECT_DIR$/libs/jsr305.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/modules/Core.iml
+++ b/.idea/modules/Core.iml
@@ -15,5 +15,6 @@
     <orderEntry type="library" scope="TEST" name="TestNG" level="project" />
     <orderEntry type="library" scope="TEST" name="JOML" level="project" />
     <orderEntry type="library" scope="RUNTIME" name="Ant Launcher" level="project" />
+    <orderEntry type="library" name="jsr305" level="project" />
   </component>
 </module>

--- a/build.xml
+++ b/build.xml
@@ -383,13 +383,16 @@
 
     <target name="compile" description="Compiles the Java source code" depends="generate, -init-compile">
         <lwjgl.javac destdir="${bin.core}" taskname="javac: Core">
+            <classpath>
+                <pathelement path="${lib}/jsr305.jar"/>
+            </classpath>
+
             <src>
                 <pathelement path="${src.core}"/>
                 <pathelement path="${src.generated.java}"/>
             </src>
 
             <include name="**/*.java"/>
-            <exclude name="**/package-info.java"/>
 
             <patternset refid="excluded.sources.withCore"/>
             <patternset refid="excluded.sources"/>
@@ -541,6 +544,7 @@
         <lwjgl.javac srcdir="${src.tests}" destdir="${bin.tests}" taskname="javac: Tests">
             <classpath>
                 <pathelement path="${bin.core}"/>
+                <pathelement path="${lib}/jsr305.jar"/>
                 <pathelement path="${lib}/testng.jar"/>
                 <pathelement path="${lib}/joml.jar"/>
             </classpath>
@@ -687,6 +691,7 @@
             <classpath>
                 <pathelement path="${src.core}"/>
                 <pathelement path="${src.generated.java}"/>
+                <pathelement path="${lib}/jsr305.jar"/>
             </classpath>
 
             <fileset dir="${src.core}">

--- a/doc/notes/3.1.6.md
+++ b/doc/notes/3.1.6.md
@@ -23,6 +23,9 @@ This build includes the following changes:
 
 #### Improvements
 
+- Added [JSR-305](https://jcp.org/en/jsr/detail?id=305) nullability annotations to the core and all bindings.
+    * Enables static analysis tools ([FindBugs](http://findbugs.sourceforge.net/), IDEs) to detect accesses that could cause `NullPointerException`. Eliminating those improves the quality of LWJGL applications.
+    * Enables better interopation with JVM-based languages that feature built-in null-safety. For example, see [Kotlin's JSR-305 support](https://kotlinlang.org/docs/reference/java-interop.html#jsr-305-support).
 - Added `Configuration` setting to disable function lookup checks.
 - lmdb: Databases are now binary compatible across 32 & 64-bit architectures. (#364)
     * `MDB_VL32` is enabled on 32-bit builds.

--- a/doc/notes/3.1.6.md
+++ b/doc/notes/3.1.6.md
@@ -43,6 +43,15 @@ This build includes the following changes:
 
 #### Breaking Changes
 
+- Several methods that previously accepted `null`/`NULL` and returned `null`, now require non-null input.
+    * Applies to: struct & callback creation methods and `memByteBuffer`/`memUTF8`/`stack.UTF8`/etc.
+    * Added corresponding methods with the `Safe` suffix that accept `null`/`NULL`, matching the old behavior.
+    * With this change the common case (non-null input) requires no code changes and is warning/error-free. The uncommon case (null input) is recognizable (the suffix) and must be handled properly to eliminate warnings/errors. 
+- Allocation methods that returned `null`/`NULL` on allocation failure, now throw `OutOfMemoryError` instead. This matches the behavior of `ByteBuffer.allocateDirect`.
+    * Applies to: struct allocation methods and `memAlloc`/`memCalloc`/etc.
+    * Does not apply to allocations via direct binding calls (e.g. `LibCStdlib.malloc`).
+- Getters of struct members that should never be `NULL`, throw `NullPointerException` instead of returning `null` when the struct instance is not initialized.
+    * Use `Struct::isNull` to test pointer members of untrusted struct instances.
 - glfw: `glfwInitHintString` has been renamed to `glfwWindowHintString`.
 - lmdb: Databases developed on 32-bit architectures must be recreated.
 - par_shapes: Changed `par_shapes_mesh::triangles` from `uint16_t/ShortBuffer` to `uint32_t/IntBuffer`. 

--- a/modules/core/src/main/java/org/lwjgl/PointerBuffer.java
+++ b/modules/core/src/main/java/org/lwjgl/PointerBuffer.java
@@ -6,6 +6,7 @@ package org.lwjgl;
 
 import org.lwjgl.system.*;
 
+import javax.annotation.*;
 import java.nio.*;
 
 import static org.lwjgl.system.MemoryUtil.*;
@@ -13,7 +14,7 @@ import static org.lwjgl.system.MemoryUtil.*;
 /** This class is a container for architecture-independent pointer data. Its interface mirrors the {@link LongBuffer} API for convenience. */
 public class PointerBuffer extends CustomBuffer<PointerBuffer> implements Comparable<PointerBuffer> {
 
-    protected PointerBuffer(long address, ByteBuffer container, int mark, int position, int limit, int capacity) {
+    protected PointerBuffer(long address, @Nullable ByteBuffer container, int mark, int position, int limit, int capacity) {
         super(address, container, mark, position, limit, capacity);
     }
 
@@ -64,7 +65,7 @@ public class PointerBuffer extends CustomBuffer<PointerBuffer> implements Compar
     }
 
     @Override
-    protected PointerBuffer newBufferInstance(long address, ByteBuffer container, int mark, int position, int limit, int capacity) {
+    protected PointerBuffer newBufferInstance(long address, @Nullable ByteBuffer container, int mark, int position, int limit, int capacity) {
         return new PointerBuffer(address, container, mark, position, limit, capacity);
     }
 

--- a/modules/core/src/main/java/org/lwjgl/openal/ALUtil.java
+++ b/modules/core/src/main/java/org/lwjgl/openal/ALUtil.java
@@ -4,6 +4,7 @@
  */
 package org.lwjgl.openal;
 
+import javax.annotation.*;
 import java.nio.*;
 import java.util.*;
 
@@ -22,6 +23,7 @@ public final class ALUtil {
      * @param deviceHandle the device to query
      * @param token        the information to query. One of:<br>{@link ALC11#ALC_ALL_DEVICES_SPECIFIER}, {@link ALC11#ALC_CAPTURE_DEVICE_SPECIFIER}
      */
+    @Nullable
     public static List<String> getStringList(long deviceHandle, int token) {
         long __result = nalcGetString(deviceHandle, token);
         if (__result == NULL) {

--- a/modules/core/src/main/java/org/lwjgl/opengl/GLUtil.java
+++ b/modules/core/src/main/java/org/lwjgl/opengl/GLUtil.java
@@ -6,6 +6,7 @@ package org.lwjgl.opengl;
 
 import org.lwjgl.system.*;
 
+import javax.annotation.*;
 import java.io.*;
 
 import static org.lwjgl.opengl.AMDDebugOutput.*;
@@ -26,6 +27,7 @@ public final class GLUtil {
      * Detects the best debug output functionality to use and creates a callback that prints information to {@link APIUtil#DEBUG_STREAM}. The callback
      * function is returned as a {@link Callback}, that should be {@link Callback#free freed} when no longer needed.
      */
+    @Nullable
     public static Callback setupDebugMessageCallback() {
         return setupDebugMessageCallback(APIUtil.DEBUG_STREAM);
     }
@@ -36,6 +38,7 @@ public final class GLUtil {
      *
      * @param stream the output {@link PrintStream}
      */
+    @Nullable
     public static Callback setupDebugMessageCallback(PrintStream stream) {
         GLCapabilities caps = GL.getCapabilities();
 

--- a/modules/core/src/main/java/org/lwjgl/package-info.java
+++ b/modules/core/src/main/java/org/lwjgl/package-info.java
@@ -18,4 +18,5 @@
  *
  * @see <a href="https://www.lwjgl.org/">www.lwjgl.org</a>
  */
+@org.lwjgl.system.NonnullDefault
 package org.lwjgl;

--- a/modules/core/src/main/java/org/lwjgl/system/APIUtil.java
+++ b/modules/core/src/main/java/org/lwjgl/system/APIUtil.java
@@ -9,6 +9,7 @@ import org.lwjgl.system.linux.*;
 import org.lwjgl.system.macosx.*;
 import org.lwjgl.system.windows.*;
 
+import javax.annotation.*;
 import java.io.*;
 import java.lang.reflect.*;
 import java.net.*;
@@ -69,7 +70,7 @@ public final class APIUtil {
      *
      * @param msg the message to print
      */
-    public static void apiLog(CharSequence msg) {
+    public static void apiLog(@Nullable CharSequence msg) {
         if (DEBUG) {
             DEBUG_STREAM.print("[LWJGL] ");
             DEBUG_STREAM.println(msg);
@@ -142,7 +143,8 @@ public final class APIUtil {
         }
     }
 
-    public static ByteBuffer apiGetMappedBuffer(ByteBuffer buffer, long mappedAddress, int capacity) {
+    @Nullable
+    public static ByteBuffer apiGetMappedBuffer(@Nullable ByteBuffer buffer, long mappedAddress, int capacity) {
         return buffer == null || memAddress(buffer) != mappedAddress || buffer.capacity() != capacity
             ? memByteBuffer(mappedAddress, capacity)
             : buffer;
@@ -173,15 +175,17 @@ public final class APIUtil {
         public final int minor;
 
         /** Returns the API revision. May be null. */
+        @Nullable
         public final String revision;
         /** Returns the API implementation-specific versioning information. May be null. */
+        @Nullable
         public final String implementation;
 
         public APIVersion(int major, int minor) {
             this(major, minor, null, null);
         }
 
-        public APIVersion(int major, int minor, String revision, String implementation) {
+        public APIVersion(int major, int minor, @Nullable String revision, @Nullable String implementation) {
             this.major = major;
             this.minor = minor;
             this.revision = revision;
@@ -207,6 +211,7 @@ public final class APIUtil {
      *
      * @param option the option to query
      */
+    @Nullable
     public static APIVersion apiParseVersion(Configuration<?> option) {
         APIVersion version;
 
@@ -245,7 +250,7 @@ public final class APIUtil {
      *
      * @return the parsed {@link APIVersion}
      */
-    public static APIVersion apiParseVersion(String version, String prefix) {
+    public static APIVersion apiParseVersion(String version, @Nullable String prefix) {
         String pattern = "([0-9]+)[.]([0-9]+)([.]\\S+)?\\s*(.+)?";
         if (prefix != null) {
             pattern = "(?:" + prefix + "\\s+)?" + pattern;
@@ -284,7 +289,7 @@ public final class APIUtil {
      *
      * @return the token map
      */
-    public static Map<Integer, String> apiClassTokens(BiPredicate<Field, Integer> filter, Map<Integer, String> target, Class<?>... tokenClasses) {
+    public static Map<Integer, String> apiClassTokens(@Nullable BiPredicate<Field, Integer> filter, @Nullable Map<Integer, String> target, Class<?>... tokenClasses) {
         if (target == null) {
             target = new HashMap<>(64);
         }

--- a/modules/core/src/main/java/org/lwjgl/system/APIUtil.java
+++ b/modules/core/src/main/java/org/lwjgl/system/APIUtil.java
@@ -138,7 +138,7 @@ public final class APIUtil {
     }
 
     private static void requiredFunctionMissing(String functionName) {
-        if (!Configuration.DISABLE_FUNCTION_CHECKS.get()) {
+        if (!Configuration.DISABLE_FUNCTION_CHECKS.get(false)) {
             throw new NullPointerException("A required function is missing: " + functionName);
         }
     }
@@ -146,7 +146,7 @@ public final class APIUtil {
     @Nullable
     public static ByteBuffer apiGetMappedBuffer(@Nullable ByteBuffer buffer, long mappedAddress, int capacity) {
         return buffer == null || memAddress(buffer) != mappedAddress || buffer.capacity() != capacity
-            ? memByteBuffer(mappedAddress, capacity)
+            ? memByteBufferSafe(mappedAddress, capacity)
             : buffer;
     }
 

--- a/modules/core/src/main/java/org/lwjgl/system/Callback.java
+++ b/modules/core/src/main/java/org/lwjgl/system/Callback.java
@@ -9,6 +9,7 @@ import org.lwjgl.*;
 import javax.annotation.*;
 import java.lang.reflect.*;
 
+import static org.lwjgl.system.Checks.*;
 import static org.lwjgl.system.MemoryStack.*;
 import static org.lwjgl.system.MemoryUtil.*;
 import static org.lwjgl.system.dyncall.DynCallback.*;
@@ -88,6 +89,9 @@ public abstract class Callback implements Pointer, NativeResource {
      * @param address the function address
      */
     protected Callback(long address) {
+        if (CHECKS) {
+            check(address);
+        }
         this.address = address;
     }
 
@@ -163,15 +167,16 @@ public abstract class Callback implements Pointer, NativeResource {
      * @param functionPointer a function pointer
      * @param <T>             the {@code CallbackI} instance type
      *
-     * @return the {@code CallbackI} instance, or null if the function pointer is {@code NULL}.
+     * @return the {@code CallbackI} instance
      */
-    @Nullable
     public static <T extends CallbackI> T get(long functionPointer) {
-        if (functionPointer == NULL) {
-            return null;
-        }
-
         return memGlobalRefToObject(dcbGetUserData(functionPointer));
+    }
+
+    /** Like {@link #get}, but returns {@code null} if {@code functionPointer} is {@code NULL}. */
+    @Nullable
+    public static <T extends CallbackI> T getSafe(long functionPointer) {
+        return functionPointer == NULL ? null : get(functionPointer);
     }
 
     /**

--- a/modules/core/src/main/java/org/lwjgl/system/Callback.java
+++ b/modules/core/src/main/java/org/lwjgl/system/Callback.java
@@ -6,6 +6,7 @@ package org.lwjgl.system;
 
 import org.lwjgl.*;
 
+import javax.annotation.*;
 import java.lang.reflect.*;
 
 import static org.lwjgl.system.MemoryStack.*;
@@ -164,6 +165,7 @@ public abstract class Callback implements Pointer, NativeResource {
      *
      * @return the {@code CallbackI} instance, or null if the function pointer is {@code NULL}.
      */
+    @Nullable
     public static <T extends CallbackI> T get(long functionPointer) {
         if (functionPointer == NULL) {
             return null;

--- a/modules/core/src/main/java/org/lwjgl/system/Checks.java
+++ b/modules/core/src/main/java/org/lwjgl/system/Checks.java
@@ -6,6 +6,7 @@ package org.lwjgl.system;
 
 import org.lwjgl.*;
 
+import javax.annotation.*;
 import java.nio.*;
 
 import static org.lwjgl.system.MemoryUtil.*;
@@ -62,13 +63,13 @@ public final class Checks {
     private Checks() {
     }
 
-    public static int lengthSafe(short[] array)             { return array == null ? 0 : array.length;}
-    public static int lengthSafe(int[] array)               { return array == null ? 0 : array.length;}
-    public static int lengthSafe(long[] array)              { return array == null ? 0 : array.length; }
-    public static int lengthSafe(float[] array)             { return array == null ? 0 : array.length;}
-    public static int lengthSafe(double[] array)            { return array == null ? 0 : array.length;}
-    public static int remainingSafe(Buffer buffer)          { return buffer == null ? 0 : buffer.remaining(); }
-    public static int remainingSafe(CustomBuffer<?> buffer) { return buffer == null ? 0 : buffer.remaining(); }
+    public static int lengthSafe(@Nullable short[] array)             { return array == null ? 0 : array.length;}
+    public static int lengthSafe(@Nullable int[] array)               { return array == null ? 0 : array.length;}
+    public static int lengthSafe(@Nullable long[] array)              { return array == null ? 0 : array.length; }
+    public static int lengthSafe(@Nullable float[] array)             { return array == null ? 0 : array.length;}
+    public static int lengthSafe(@Nullable double[] array)            { return array == null ? 0 : array.length;}
+    public static int remainingSafe(@Nullable Buffer buffer)          { return buffer == null ? 0 : buffer.remaining(); }
+    public static int remainingSafe(@Nullable CustomBuffer<?> buffer) { return buffer == null ? 0 : buffer.remaining(); }
 
     /**
      * Checks if any of the specified functions pointers is {@code NULL}.
@@ -188,62 +189,62 @@ public final class Checks {
         }
     }
 
-    public static void checkNTSafe(int[] buf) {
+    public static void checkNTSafe(@Nullable int[] buf) {
         if (buf != null) {
             checkNT(buf);
         }
     }
-    public static void checkNTSafe(int[] buf, int terminator) {
+    public static void checkNTSafe(@Nullable int[] buf, int terminator) {
         if (buf != null) {
             checkNT(buf, terminator);
         }
     }
-    public static void checkNTSafe(long[] buf) {
+    public static void checkNTSafe(@Nullable long[] buf) {
         if (buf != null) {
             checkNT(buf);
         }
     }
-    public static void checkNTSafe(float[] buf) {
+    public static void checkNTSafe(@Nullable float[] buf) {
         if (buf != null) {
             checkNT(buf);
         }
     }
-    public static void checkNT1Safe(ByteBuffer buf) {
+    public static void checkNT1Safe(@Nullable ByteBuffer buf) {
         if (buf != null) {
             checkNT1(buf);
         }
     }
-    public static void checkNT2Safe(ByteBuffer buf) {
+    public static void checkNT2Safe(@Nullable ByteBuffer buf) {
         if (buf != null) {
             checkNT2(buf);
         }
     }
-    public static void checkNTSafe(IntBuffer buf) {
+    public static void checkNTSafe(@Nullable IntBuffer buf) {
         if (buf != null) {
             checkNT(buf);
         }
     }
-    public static void checkNTSafe(IntBuffer buf, int terminator) {
+    public static void checkNTSafe(@Nullable IntBuffer buf, int terminator) {
         if (buf != null) {
             checkNT(buf, terminator);
         }
     }
-    public static void checkNTSafe(LongBuffer buf) {
+    public static void checkNTSafe(@Nullable LongBuffer buf) {
         if (buf != null) {
             checkNT(buf);
         }
     }
-    public static void checkNTSafe(FloatBuffer buf) {
+    public static void checkNTSafe(@Nullable FloatBuffer buf) {
         if (buf != null) {
             checkNT(buf);
         }
     }
-    public static void checkNTSafe(PointerBuffer buf) {
+    public static void checkNTSafe(@Nullable PointerBuffer buf) {
         if (buf != null) {
             checkNT(buf);
         }
     }
-    public static void checkNTSafe(PointerBuffer buf, long terminator) {
+    public static void checkNTSafe(@Nullable PointerBuffer buf, long terminator) {
         if (buf != null) {
             checkNT(buf, terminator);
         }
@@ -383,42 +384,42 @@ public final class Checks {
         check(buf, (int)size);
     }
 
-    public static void checkSafe(short[] buf, int size) {
+    public static void checkSafe(@Nullable short[] buf, int size) {
         if (buf != null) {
             check(buf, size);
         }
     }
-    public static void checkSafe(int[] buf, int size) {
+    public static void checkSafe(@Nullable int[] buf, int size) {
         if (buf != null) {
             check(buf, size);
         }
     }
-    public static void checkSafe(long[] buf, int size) {
+    public static void checkSafe(@Nullable long[] buf, int size) {
         if (buf != null) {
             check(buf, size);
         }
     }
-    public static void checkSafe(float[] buf, int size) {
+    public static void checkSafe(@Nullable float[] buf, int size) {
         if (buf != null) {
             check(buf, size);
         }
     }
-    public static void checkSafe(double[] buf, int size) {
+    public static void checkSafe(@Nullable double[] buf, int size) {
         if (buf != null) {
             check(buf, size);
         }
     }
-    public static void checkSafe(Buffer buf, int size) {
+    public static void checkSafe(@Nullable Buffer buf, int size) {
         if (buf != null) {
             check(buf, size);
         }
     }
-    public static void checkSafe(Buffer buf, long size) {
+    public static void checkSafe(@Nullable Buffer buf, long size) {
         if (buf != null) {
             check(buf, size);
         }
     }
-    public static void checkSafe(CustomBuffer<?> buf, int size) {
+    public static void checkSafe(@Nullable CustomBuffer<?> buf, int size) {
         if (buf != null) {
             check(buf, size);
         }

--- a/modules/core/src/main/java/org/lwjgl/system/Checks.java
+++ b/modules/core/src/main/java/org/lwjgl/system/Checks.java
@@ -102,6 +102,12 @@ public final class Checks {
         return pointer;
     }
 
+    private static void assertNT(boolean found) {
+        if (!found) {
+            throw new IllegalArgumentException("Missing termination");
+        }
+    }
+
     /** Ensures that the specified array is null-terminated. */
     public static void checkNT(int[] buf) {
         checkNT(buf, 0);
@@ -110,41 +116,31 @@ public final class Checks {
     /** Ensures that the specified array is terminated with the specified terminator. */
     public static void checkNT(int[] buf, int terminator) {
         check(buf, 1);
-        if (buf[buf.length - 1] != terminator) {
-            throw new IllegalArgumentException("Missing termination");
-        }
+        assertNT(buf[buf.length - 1] == terminator);
     }
 
     /** Ensures that the specified array is null-terminated. */
     public static void checkNT(long[] buf) {
         check(buf, 1);
-        if (buf[buf.length - 1] != NULL) {
-            throw new IllegalArgumentException("Missing termination");
-        }
+        assertNT(buf[buf.length - 1] == NULL);
     }
 
     /** Ensures that the specified array is null-terminated. */
     public static void checkNT(float[] buf) {
         check(buf, 1);
-        if (buf[buf.length - 1] != 0.0f) {
-            throw new IllegalArgumentException("Missing termination");
-        }
+        assertNT(buf[buf.length - 1] == 0.0f);
     }
 
     /** Ensures that the specified ByteBuffer is null-terminated (last byte equal to 0). */
     public static void checkNT1(ByteBuffer buf) {
         check(buf, 1);
-        if (buf.get(buf.limit() - 1) != 0) {
-            throw new IllegalArgumentException("Missing null termination");
-        }
+        assertNT(buf.get(buf.limit() - 1) == 0);
     }
 
     /** Ensures that the specified ByteBuffer is null-terminated (last 2 bytes equal to 0). */
     public static void checkNT2(ByteBuffer buf) {
         check(buf, 2);
-        if (buf.getShort(buf.limit() - 2) != 0) {
-            throw new IllegalArgumentException("Missing null termination");
-        }
+        assertNT(buf.get(buf.limit() - 2) == 0);
     }
 
     /** Ensures that the specified IntBuffer is null-terminated. */
@@ -155,25 +151,19 @@ public final class Checks {
     /** Ensures that the specified IntBuffer is terminated with the specified terminator. */
     public static void checkNT(IntBuffer buf, int terminator) {
         check(buf, 1);
-        if (buf.get(buf.limit() - 1) != terminator) {
-            throw new IllegalArgumentException("Missing termination");
-        }
+        assertNT(buf.get(buf.limit() - 1) == terminator);
     }
 
     /** Ensures that the specified LongBuffer is null-terminated. */
     public static void checkNT(LongBuffer buf) {
         check(buf, 1);
-        if (buf.get(buf.limit() - 1) != NULL) {
-            throw new IllegalArgumentException("Missing termination");
-        }
+        assertNT(buf.get(buf.limit() - 1) == NULL);
     }
 
     /** Ensures that the specified FloatBuffer is null-terminated. */
     public static void checkNT(FloatBuffer buf) {
         check(buf, 1);
-        if (buf.get(buf.limit() - 1) != 0.0f) {
-            throw new IllegalArgumentException("Missing termination");
-        }
+        assertNT(buf.get(buf.limit() - 1) == 0.0f);
     }
 
     /** Ensures that the specified PointerBuffer is null-terminated. */
@@ -184,9 +174,7 @@ public final class Checks {
     /** Ensures that the specified PointerBuffer is terminated with the specified terminator. */
     public static void checkNT(PointerBuffer buf, long terminator) {
         check(buf, 1);
-        if (buf.get(buf.limit() - 1) != terminator) {
-            throw new IllegalArgumentException("Missing termination");
-        }
+        assertNT(buf.get(buf.limit() - 1) == terminator);
     }
 
     public static void checkNTSafe(@Nullable int[] buf) {
@@ -250,6 +238,12 @@ public final class Checks {
         }
     }
 
+    private static void checkBuffer(int bufferSize, int minimumSize) {
+        if (bufferSize < minimumSize) {
+            throwIAE(bufferSize, minimumSize);
+        }
+    }
+
     /**
      * Helper method to ensure a array has enough capacity.
      *
@@ -259,9 +253,7 @@ public final class Checks {
      * @throws IllegalArgumentException
      */
     public static void check(byte[] buf, int size) {
-        if (buf.length < size) {
-            throwIAE(buf, size);
-        }
+        checkBuffer(buf.length, size);
     }
 
     /**
@@ -273,9 +265,7 @@ public final class Checks {
      * @throws IllegalArgumentException
      */
     public static void check(short[] buf, int size) {
-        if (buf.length < size) {
-            throwIAE(buf, size);
-        }
+        checkBuffer(buf.length, size);
     }
 
     /**
@@ -287,9 +277,7 @@ public final class Checks {
      * @throws IllegalArgumentException
      */
     public static void check(int[] buf, int size) {
-        if (buf.length < size) {
-            throwIAE(buf, size);
-        }
+        checkBuffer(buf.length, size);
     }
 
     /**
@@ -301,9 +289,7 @@ public final class Checks {
      * @throws IllegalArgumentException
      */
     public static void check(long[] buf, int size) {
-        if (buf.length < size) {
-            throwIAE(buf, size);
-        }
+        checkBuffer(buf.length, size);
     }
 
     /**
@@ -315,9 +301,7 @@ public final class Checks {
      * @throws IllegalArgumentException
      */
     public static void check(float[] buf, int size) {
-        if (buf.length < size) {
-            throwIAE(buf, size);
-        }
+        checkBuffer(buf.length, size);
     }
 
     /**
@@ -329,9 +313,7 @@ public final class Checks {
      * @throws IllegalArgumentException
      */
     public static void check(double[] buf, int size) {
-        if (buf.length < size) {
-            throwIAE(buf, size);
-        }
+        checkBuffer(buf.length, size);
     }
 
     /**
@@ -341,9 +323,7 @@ public final class Checks {
      * @param size the minimum number of characters
      */
     public static void check(CharSequence text, int size) {
-        if (text.length() < size) {
-            throwIAE(text, size);
-        }
+        checkBuffer(text.length(), size);
     }
 
     /**
@@ -355,9 +335,7 @@ public final class Checks {
      * @throws IllegalArgumentException
      */
     public static void check(Buffer buf, int size) {
-        if (buf.remaining() < size) {
-            throwIAE(buf, size);
-        }
+        checkBuffer(buf.remaining(), size);
     }
 
     /** @see #check(Buffer, int) */
@@ -374,9 +352,7 @@ public final class Checks {
      * @throws IllegalArgumentException
      */
     public static void check(CustomBuffer<?> buf, int size) {
-        if (buf.remaining() < size) {
-            throwIAE(buf, size);
-        }
+        checkBuffer(buf.remaining(), size);
     }
 
     /** @see #check(CustomBuffer, int) */
@@ -426,27 +402,21 @@ public final class Checks {
     }
 
     public static void check(Object[] array, int size) {
-        if (array.length < size) {
-            throwIAE(array, size);
+        checkBuffer(array.length, size);
+    }
+
+    private static void checkBufferGT(int bufferSize, int maximumSize) {
+        if (maximumSize < bufferSize) {
+            throwIAEGT(bufferSize, maximumSize);
         }
     }
 
     public static void checkGT(Buffer buf, int size) {
-        if (size < buf.remaining()) {
-            throwIAEGT(buf, size);
-        }
+        checkBufferGT(buf.remaining(), size);
     }
 
     public static void checkGT(CustomBuffer<?> buf, int size) {
-        if (size < buf.remaining()) {
-            throwIAEGT(buf, size);
-        }
-    }
-
-    public static void checkGT(StructBuffer<?, ?> buf, int size) {
-        if (size < buf.remaining()) {
-            throwIAEGT(buf, size);
-        }
+        checkBufferGT(buf.remaining(), size);
     }
 
     public static void check(int index, int size) {
@@ -457,52 +427,12 @@ public final class Checks {
 
     // Separate calls to help inline check.
 
-    private static void throwIAE(Buffer buf, int size) {
-        throw new IllegalArgumentException("Number of remaining buffer elements is " + buf.remaining() + ", must be at least " + size);
+    private static void throwIAE(int bufferSize, int minimumSize) {
+        throw new IllegalArgumentException("Number of remaining elements is " + bufferSize + ", must be at least " + minimumSize);
     }
 
-    private static void throwIAE(CustomBuffer<?> buf, int size) {
-        throw new IllegalArgumentException("Number of remaining buffer elements is " + buf.remaining() + ", must be at least " + size);
-    }
-
-    private static void throwIAE(Object[] array, int size) {
-        throw new IllegalArgumentException("Number of array elements is " + array.length + ", must be at least " + size);
-    }
-
-    private static void throwIAE(byte[] array, int size) {
-        throw new IllegalArgumentException("Number of array elements is " + array.length + ", must be at least " + size);
-    }
-
-    private static void throwIAE(short[] array, int size) {
-        throw new IllegalArgumentException("Number of array elements is " + array.length + ", must be at least " + size);
-    }
-
-    private static void throwIAE(int[] array, int size) {
-        throw new IllegalArgumentException("Number of array elements is " + array.length + ", must be at least " + size);
-    }
-
-    private static void throwIAE(long[] array, int size) {
-        throw new IllegalArgumentException("Number of array elements is " + array.length + ", must be at least " + size);
-    }
-
-    private static void throwIAE(float[] array, int size) {
-        throw new IllegalArgumentException("Number of array elements is " + array.length + ", must be at least " + size);
-    }
-
-    private static void throwIAE(double[] array, int size) {
-        throw new IllegalArgumentException("Number of array elements is " + array.length + ", must be at least " + size);
-    }
-
-    private static void throwIAE(CharSequence text, int size) {
-        throw new IllegalArgumentException("Number of characters is " + text.length() + ", must be at least " + size);
-    }
-
-    private static void throwIAEGT(Buffer buf, int size) {
-        throw new IllegalArgumentException("Number of remaining buffer elements is " + buf.remaining() + ", must be at most " + size + ".");
-    }
-
-    private static void throwIAEGT(CustomBuffer<?> buf, int size) {
-        throw new IllegalArgumentException("Number of remaining buffer elements is " + buf.remaining() + ", must be at most " + size + ".");
+    private static void throwIAEGT(int bufferSize, int maximumSize) {
+        throw new IllegalArgumentException("Number of remaining buffer elements is " + bufferSize + ", must be at most " + maximumSize);
     }
 
     private static void throwIOBE(int index, int size) {

--- a/modules/core/src/main/java/org/lwjgl/system/Configuration.java
+++ b/modules/core/src/main/java/org/lwjgl/system/Configuration.java
@@ -6,6 +6,7 @@ package org.lwjgl.system;
 
 import org.lwjgl.system.MemoryUtil.*;
 
+import javax.annotation.*;
 import java.io.*;
 import java.util.function.*;
 
@@ -345,6 +346,7 @@ public class Configuration<T> {
 
     private final String property;
 
+    @Nullable
     private T state;
 
     Configuration(String property, StateInit<? extends T> init) {
@@ -361,7 +363,7 @@ public class Configuration<T> {
      *
      * @param value the value to set
      */
-    public void set(T value) {
+    public void set(@Nullable T value) {
         this.state = value;
     }
 
@@ -370,6 +372,7 @@ public class Configuration<T> {
      *
      * <p>If the option value has not been set, null will be returned.</p>
      */
+    @Nullable
     public T get() {
         return state;
     }

--- a/modules/core/src/main/java/org/lwjgl/system/CustomBuffer.java
+++ b/modules/core/src/main/java/org/lwjgl/system/CustomBuffer.java
@@ -4,6 +4,7 @@
  */
 package org.lwjgl.system;
 
+import javax.annotation.*;
 import java.nio.*;
 
 import static org.lwjgl.system.MemoryUtil.*;
@@ -13,6 +14,7 @@ public abstract class CustomBuffer<SELF extends CustomBuffer<SELF>> implements P
 
     protected long address;
 
+    @Nullable
     protected ByteBuffer container;
 
     protected int
@@ -21,7 +23,7 @@ public abstract class CustomBuffer<SELF extends CustomBuffer<SELF>> implements P
         limit,
         capacity;
 
-    protected CustomBuffer(long address, ByteBuffer container, int mark, int position, int limit, int capacity) {
+    protected CustomBuffer(long address, @Nullable ByteBuffer container, int mark, int position, int limit, int capacity) {
         this.address = address;
         this.container = container;
 
@@ -369,7 +371,7 @@ public abstract class CustomBuffer<SELF extends CustomBuffer<SELF>> implements P
 
     protected abstract SELF self();
 
-    protected abstract SELF newBufferInstance(long address, ByteBuffer container, int mark, int position, int limit, int capacity);
+    protected abstract SELF newBufferInstance(long address, @Nullable ByteBuffer container, int mark, int position, int limit, int capacity);
 
     protected long nextGetIndex() {
         if (position >= limit) {

--- a/modules/core/src/main/java/org/lwjgl/system/CustomBuffer.java
+++ b/modules/core/src/main/java/org/lwjgl/system/CustomBuffer.java
@@ -7,6 +7,7 @@ package org.lwjgl.system;
 import javax.annotation.*;
 import java.nio.*;
 
+import static org.lwjgl.system.Checks.*;
 import static org.lwjgl.system.MemoryUtil.*;
 
 /** Base class of custom buffers with an API that mirrors {@code java.nio} for convenience. */
@@ -24,6 +25,9 @@ public abstract class CustomBuffer<SELF extends CustomBuffer<SELF>> implements P
         capacity;
 
     protected CustomBuffer(long address, @Nullable ByteBuffer container, int mark, int position, int limit, int capacity) {
+        if (CHECKS) {
+            check(address);
+        }
         this.address = address;
         this.container = container;
 

--- a/modules/core/src/main/java/org/lwjgl/system/MemoryAccess.java
+++ b/modules/core/src/main/java/org/lwjgl/system/MemoryAccess.java
@@ -5,6 +5,7 @@
 package org.lwjgl.system;
 
 import java.nio.*;
+import java.util.*;
 
 import static java.lang.Character.*;
 import static org.lwjgl.system.APIUtil.*;
@@ -56,7 +57,7 @@ final class MemoryAccess {
             return GetDirectBufferAddress(buffer);
         }
 
-        default ByteBuffer memByteBuffer(long address, int capacity)     { return NewDirectByteBuffer(address, capacity).order(ByteOrder.nativeOrder()); }
+        default ByteBuffer memByteBuffer(long address, int capacity)     { return Objects.requireNonNull(NewDirectByteBuffer(address, capacity)).order(ByteOrder.nativeOrder()); }
 
         default ShortBuffer memShortBuffer(long address, int capacity)   { return memByteBuffer(address, capacity << 1).asShortBuffer(); }
         default CharBuffer memCharBuffer(long address, int capacity)     { return memByteBuffer(address, capacity << 1).asCharBuffer(); }
@@ -141,7 +142,7 @@ final class MemoryAccess {
                 MAGIC_ADDRESS &= 0xFFFFFFFFL;
             }
 
-            ByteBuffer bb = NewDirectByteBuffer(MAGIC_ADDRESS, 0);
+            ByteBuffer bb = Objects.requireNonNull(NewDirectByteBuffer(MAGIC_ADDRESS, 0));
 
             long offset = 8L; // 8 byte aligned, cannot be at 0
             while (true) {
@@ -155,7 +156,7 @@ final class MemoryAccess {
         private static long getCapacityOffset() {
             int MAGIC_CAPACITY = 0x0D15EA5E;
 
-            ByteBuffer bb = NewDirectByteBuffer(-1L, MAGIC_CAPACITY);
+            ByteBuffer bb = Objects.requireNonNull(NewDirectByteBuffer(-1L, MAGIC_CAPACITY));
             bb.limit(0);
 
             long offset = 4L; // 4 byte aligned, cannot be at 0

--- a/modules/core/src/main/java/org/lwjgl/system/MemoryManage.java
+++ b/modules/core/src/main/java/org/lwjgl/system/MemoryManage.java
@@ -4,6 +4,7 @@
  */
 package org.lwjgl.system;
 
+import javax.annotation.*;
 import java.util.*;
 import java.util.Map.*;
 import java.util.concurrent.*;
@@ -198,6 +199,7 @@ final class MemoryManage {
 
             private final Object[] stackTrace;
 
+            @Nullable
             private StackTraceElement[] elements; // lazy init
 
             final long size;

--- a/modules/core/src/main/java/org/lwjgl/system/MemoryStack.java
+++ b/modules/core/src/main/java/org/lwjgl/system/MemoryStack.java
@@ -6,6 +6,7 @@ package org.lwjgl.system;
 
 import org.lwjgl.*;
 
+import javax.annotation.*;
 import java.nio.*;
 import java.util.*;
 
@@ -522,7 +523,7 @@ public class MemoryStack implements AutoCloseable {
     /**
      * Encodes the specified text on the stack using ASCII encoding and returns a ByteBuffer that points to the encoded text, including a null-terminator.
      *
-     * @param text the text to encode. If {@code text} is null, null is returned.
+     * @param text the text to encode
      */
     public ByteBuffer ASCII(CharSequence text) {
         return ASCII(text, true);
@@ -531,23 +532,31 @@ public class MemoryStack implements AutoCloseable {
     /**
      * Encodes the specified text on the stack using ASCII encoding and returns a ByteBuffer that points to the encoded text.
      *
-     * @param text           the text to encode. If {@code text} is null, null is returned.
+     * @param text           the text to encode
      * @param nullTerminated if true, a null-terminator is included at the end of the encoded text
      */
     public ByteBuffer ASCII(CharSequence text, boolean nullTerminated) {
-        if (text == null) {
-            return null;
-        }
-
         ByteBuffer encoded = malloc(memLengthASCII(text, nullTerminated));
         memASCII(text, nullTerminated, encoded);
         return encoded;
     }
 
+    /** Like {@link #ASCII(CharSequence) ASCII}, but returns {@code null} if {@code text} is {@code null}. */
+    @Nullable
+    public ByteBuffer ASCIISafe(@Nullable CharSequence text) {
+        return ASCIISafe(text, true);
+    }
+
+    /** Like {@link #ASCII(CharSequence, boolean) ASCII}, but returns {@code null} if {@code text} is {@code null}. */
+    @Nullable
+    public ByteBuffer ASCIISafe(@Nullable CharSequence text, boolean nullTerminated) {
+        return text == null ? null : ASCII(text, nullTerminated);
+    }
+
     /**
      * Encodes the specified text on the stack using UTF8 encoding and returns a ByteBuffer that points to the encoded text, including a null-terminator.
      *
-     * @param text the text to encode. If {@code text} is null, null is returned.
+     * @param text the text to encode
      */
     public ByteBuffer UTF8(CharSequence text) {
         return UTF8(text, true);
@@ -556,23 +565,31 @@ public class MemoryStack implements AutoCloseable {
     /**
      * Encodes the specified text on the stack using UTF8 encoding and returns a ByteBuffer that points to the encoded text.
      *
-     * @param text           the text to encode. If {@code text} is null, null is returned.
+     * @param text           the text to encode
      * @param nullTerminated if true, a null-terminator is included at the end of the encoded text
      */
     public ByteBuffer UTF8(CharSequence text, boolean nullTerminated) {
-        if (text == null) {
-            return null;
-        }
-
         ByteBuffer encoded = malloc(memLengthUTF8(text, nullTerminated));
         memUTF8(text, nullTerminated, encoded);
         return encoded;
     }
 
+    /** Like {@link #UTF8(CharSequence) UTF8}, but returns {@code null} if {@code text} is {@code null}. */
+    @Nullable
+    public ByteBuffer UTF8Safe(@Nullable CharSequence text) {
+        return UTF8Safe(text, true);
+    }
+
+    /** Like {@link #UTF8(CharSequence, boolean) UTF8}, but returns {@code null} if {@code text} is {@code null}. */
+    @Nullable
+    public ByteBuffer UTF8Safe(@Nullable CharSequence text, boolean nullTerminated) {
+        return text == null ? null : UTF8(text, nullTerminated);
+    }
+
     /**
      * Encodes the specified text on the stack using UTF16 encoding and returns a ByteBuffer that points to the encoded text, including a null-terminator.
      *
-     * @param text the text to encode. If {@code text} is null, null is returned.
+     * @param text the text to encode
      */
     public ByteBuffer UTF16(CharSequence text) {
         return UTF16(text, true);
@@ -581,17 +598,25 @@ public class MemoryStack implements AutoCloseable {
     /**
      * Encodes the specified text on the stack using UTF16 encoding and returns a ByteBuffer that points to the encoded text.
      *
-     * @param text           the text to encode. If {@code text} is null, null is returned.
+     * @param text           the text to encode
      * @param nullTerminated if true, a null-terminator is included at the end of the encoded text
      */
     public ByteBuffer UTF16(CharSequence text, boolean nullTerminated) {
-        if (text == null) {
-            return null;
-        }
-
         ByteBuffer encoded = malloc(2, memLengthUTF16(text, nullTerminated));
         memUTF16(text, nullTerminated, encoded);
         return encoded;
+    }
+
+    /** Like {@link #UTF16(CharSequence) UTF16}, but returns {@code null} if {@code text} is {@code null}. */
+    @Nullable
+    public ByteBuffer UTF16Safe(@Nullable CharSequence text) {
+        return UTF16Safe(text, true);
+    }
+
+    /** Like {@link #UTF16(CharSequence, boolean) UTF16}, but returns {@code null} if {@code text} is {@code null}. */
+    @Nullable
+    public ByteBuffer UTF16Safe(@Nullable CharSequence text, boolean nullTerminated) {
+        return text == null ? null : UTF16(text, nullTerminated);
     }
 
     // -----------------------------------------------------
@@ -784,5 +809,23 @@ public class MemoryStack implements AutoCloseable {
 
     /** Thread-local version of {@link #UTF16(CharSequence, boolean)}. */
     public static ByteBuffer stackUTF16(CharSequence text, boolean nullTerminated) { return stackGet().UTF16(text, nullTerminated); }
+
+    /** Thread-local version of {@link #ASCII(CharSequence)}. */
+    @Nullable public static ByteBuffer stackASCIISafe(@Nullable CharSequence text) { return stackGet().ASCIISafe(text); }
+
+    /** Thread-local version of {@link #ASCII(CharSequence, boolean)}. */
+    @Nullable public static ByteBuffer stackASCIISafe(@Nullable CharSequence text, boolean nullTerminated) { return stackGet().ASCIISafe(text, nullTerminated); }
+
+    /** Thread-local version of {@link #UTF8(CharSequence)}. */
+    @Nullable public static ByteBuffer stackUTF8Safe(@Nullable CharSequence text) { return stackGet().UTF8Safe(text); }
+
+    /** Thread-local version of {@link #UTF8(CharSequence, boolean)}. */
+    @Nullable public static ByteBuffer stackUTF8Safe(@Nullable CharSequence text, boolean nullTerminated) { return stackGet().UTF8Safe(text, nullTerminated); }
+
+    /** Thread-local version of {@link #UTF16(CharSequence)}. */
+    @Nullable public static ByteBuffer stackUTF16Safe(@Nullable CharSequence text) { return stackGet().UTF16Safe(text); }
+
+    /** Thread-local version of {@link #UTF16(CharSequence, boolean)}. */
+    @Nullable public static ByteBuffer stackUTF16Safe(@Nullable CharSequence text, boolean nullTerminated) { return stackGet().UTF16Safe(text, nullTerminated); }
 
 }

--- a/modules/core/src/main/java/org/lwjgl/system/NonnullDefault.java
+++ b/modules/core/src/main/java/org/lwjgl/system/NonnullDefault.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright LWJGL. All rights reserved.
+ * License terms: https://www.lwjgl.org/license
+ */
+package org.lwjgl.system;
+
+import javax.annotation.*;
+import javax.annotation.meta.*;
+import java.lang.annotation.*;
+
+@Documented
+@Nonnull
+@TypeQualifierDefault({ ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface NonnullDefault {}

--- a/modules/core/src/main/java/org/lwjgl/system/Pointer.java
+++ b/modules/core/src/main/java/org/lwjgl/system/Pointer.java
@@ -8,6 +8,8 @@ import org.lwjgl.*;
 
 import javax.annotation.*;
 
+import static org.lwjgl.system.Checks.*;
+
 /**
  * Pointer interface.
  *
@@ -46,6 +48,9 @@ public interface Pointer {
         private long address;
 
         protected Default(long address) {
+            if (CHECKS) {
+                check(address);
+            }
             this.address = address;
         }
 

--- a/modules/core/src/main/java/org/lwjgl/system/Pointer.java
+++ b/modules/core/src/main/java/org/lwjgl/system/Pointer.java
@@ -6,6 +6,8 @@ package org.lwjgl.system;
 
 import org.lwjgl.*;
 
+import javax.annotation.*;
+
 /**
  * Pointer interface.
  *
@@ -52,7 +54,7 @@ public interface Pointer {
             return address;
         }
 
-        public boolean equals(Object o) {
+        public boolean equals(@Nullable Object o) {
             if (this == o) {
                 return true;
             }

--- a/modules/core/src/main/java/org/lwjgl/system/SharedLibraryLoader.java
+++ b/modules/core/src/main/java/org/lwjgl/system/SharedLibraryLoader.java
@@ -6,6 +6,7 @@ package org.lwjgl.system;
 
 import org.lwjgl.*;
 
+import javax.annotation.*;
 import java.io.*;
 import java.net.*;
 import java.nio.channels.*;
@@ -25,6 +26,7 @@ import static org.lwjgl.system.APIUtil.*;
  */
 final class SharedLibraryLoader {
 
+    @Nullable
     private static Path extractPath;
 
     private SharedLibraryLoader() {

--- a/modules/core/src/main/java/org/lwjgl/system/SharedLibraryLoader.java
+++ b/modules/core/src/main/java/org/lwjgl/system/SharedLibraryLoader.java
@@ -75,16 +75,16 @@ final class SharedLibraryLoader {
         if (extractPath == null) {
             extractPath = extractedFile.getParent();
 
+            String newLibPath = extractPath.toAbsolutePath().toString();
+
             // Prepend the path in which the libraries were extracted to org.lwjgl.librarypath
             String libPath = Configuration.LIBRARY_PATH.get();
-            if (libPath == null || libPath.isEmpty()) {
-                libPath = extractPath.toAbsolutePath().toString();
-            } else {
-                libPath = extractPath.toAbsolutePath() + File.pathSeparator + libPath;
+            if (libPath != null && !libPath.isEmpty()) {
+                newLibPath += File.pathSeparator + libPath;
             }
 
-            System.setProperty(Configuration.LIBRARY_PATH.getProperty(), libPath);
-            Configuration.LIBRARY_PATH.set(libPath);
+            System.setProperty(Configuration.LIBRARY_PATH.getProperty(), newLibPath);
+            Configuration.LIBRARY_PATH.set(newLibPath);
         }
 
         extractFile(libURL, extractedFile);
@@ -100,14 +100,15 @@ final class SharedLibraryLoader {
      *
      * @return the extracted library
      */
-    private static Path getExtractedFile(Path libraryPath, String fileName) {
+    private static Path getExtractedFile(@Nullable Path libraryPath, String fileName) {
         // Reuse the lwjgl shared library location
         if (libraryPath != null && Files.isDirectory(libraryPath)) {
             return libraryPath.resolve(fileName);
         }
 
-        if (Configuration.SHARED_LIBRARY_EXTRACT_PATH.get() != null) {
-            return Paths.get(Configuration.SHARED_LIBRARY_EXTRACT_PATH.get(), fileName);
+        String override = Configuration.SHARED_LIBRARY_EXTRACT_PATH.get();
+        if (override != null) {
+            return Paths.get(override, fileName);
         }
 
         String version = Version.getVersion().replace(' ', '-');

--- a/modules/core/src/main/java/org/lwjgl/system/StackWalkUtil.java
+++ b/modules/core/src/main/java/org/lwjgl/system/StackWalkUtil.java
@@ -4,6 +4,7 @@
  */
 package org.lwjgl.system;
 
+import javax.annotation.*;
 import java.util.*;
 
 // Multi-release version: Java 8
@@ -54,6 +55,7 @@ final class StackWalkUtil {
         return false;
     }
 
+    @Nullable
     static Object stackWalkCheckPop(Class<?> after, Object pushedObj) {
         StackTraceElement[] stackTrace = Thread.currentThread().getStackTrace();
 

--- a/modules/core/src/main/java/org/lwjgl/system/Struct.java
+++ b/modules/core/src/main/java/org/lwjgl/system/Struct.java
@@ -6,6 +6,7 @@ package org.lwjgl.system;
 
 import org.lwjgl.*;
 
+import javax.annotation.*;
 import java.nio.*;
 import java.util.*;
 
@@ -21,9 +22,10 @@ public abstract class Struct extends Pointer.Default {
     }
 
     @SuppressWarnings({"unused", "FieldCanBeLocal"})
+    @Nullable
     private ByteBuffer container;
 
-    protected Struct(long address, ByteBuffer container) {
+    protected Struct(long address, @Nullable ByteBuffer container) {
         super(address);
         this.container = container;
     }

--- a/modules/core/src/main/java/org/lwjgl/system/StructBuffer.java
+++ b/modules/core/src/main/java/org/lwjgl/system/StructBuffer.java
@@ -4,6 +4,7 @@
  */
 package org.lwjgl.system;
 
+import javax.annotation.*;
 import java.nio.*;
 import java.util.*;
 import java.util.function.*;
@@ -18,7 +19,7 @@ public abstract class StructBuffer<T extends Struct, SELF extends StructBuffer<T
         this(memAddress(container), container, -1, 0, remaining, remaining);
     }
 
-    protected StructBuffer(long address, ByteBuffer container, int mark, int position, int limit, int capacity) {
+    protected StructBuffer(long address, @Nullable ByteBuffer container, int mark, int position, int limit, int capacity) {
         super(address, container, mark, position, limit, capacity);
     }
 
@@ -115,7 +116,8 @@ public abstract class StructBuffer<T extends Struct, SELF extends StructBuffer<T
 
     // --------------------------------------
 
-    @Override public Iterator<T> iterator() {
+    @Override
+    public Iterator<T> iterator() {
         return new Iterator<T>() {
             int cursor = position;
 
@@ -138,14 +140,16 @@ public abstract class StructBuffer<T extends Struct, SELF extends StructBuffer<T
         };
     }
 
-    @Override public void forEach(Consumer<? super T> action) {
+    @Override
+    public void forEach(Consumer<? super T> action) {
         Objects.requireNonNull(action);
         for (int i = position; i < limit; i++) {
             action.accept(get(i));
         }
     }
 
-    @Override public Spliterator<T> spliterator() {
+    @Override
+    public Spliterator<T> spliterator() {
         return new StructSpliterator();
     }
 
@@ -174,7 +178,9 @@ public abstract class StructBuffer<T extends Struct, SELF extends StructBuffer<T
 
             return false;
         }
+
         @Override
+        @Nullable
         public Spliterator<T> trySplit() {
             int lo = index,
                 mid = (lo + fence) >>> 1;

--- a/modules/core/src/main/java/org/lwjgl/system/package-info.java
+++ b/modules/core/src/main/java/org/lwjgl/system/package-info.java
@@ -29,4 +29,5 @@
  * <li>{@link org.lwjgl.system.Struct Struct} and {@link org.lwjgl.system.StructBuffer StructBuffer}, the base classes for struct types and struct buffers.</li>
  * </ul>
  */
+@NonnullDefault
 package org.lwjgl.system;

--- a/modules/core/src/main/java/org/lwjgl/vulkan/VK.java
+++ b/modules/core/src/main/java/org/lwjgl/vulkan/VK.java
@@ -7,6 +7,7 @@ package org.lwjgl.vulkan;
 import org.lwjgl.*;
 import org.lwjgl.system.*;
 
+import javax.annotation.*;
 import java.util.*;
 
 import static java.lang.Math.*;
@@ -24,8 +25,10 @@ import static org.lwjgl.vulkan.VK10.*;
  */
 public final class VK {
 
+    @Nullable
     private static FunctionProvider functionProvider;
 
+    @Nullable
     private static GlobalCommands globalCommands;
 
     static {
@@ -100,9 +103,16 @@ public final class VK {
         globalCommands = null;
     }
 
+    private static <T> T check(@Nullable T t) {
+        if (t == null) {
+            throw new IllegalStateException("Vulkan library has not been loaded.");
+        }
+        return t;
+    }
+
     /** Returns the {@link FunctionProvider} for the Vulkan shared library. */
     public static FunctionProvider getFunctionProvider() {
-        return functionProvider;
+        return check(functionProvider);
     }
 
     static class GlobalCommands {
@@ -136,9 +146,9 @@ public final class VK {
     }
 
     /** Returns the Vulkan global commands. */
-    static GlobalCommands getGlobalCommands() { return globalCommands; }
+    static GlobalCommands getGlobalCommands() { return check(globalCommands); }
 
-    static Set<String> getEnabledExtensionSet(int apiVersion, PointerBuffer extensionNames) {
+    static Set<String> getEnabledExtensionSet(int apiVersion, @Nullable PointerBuffer extensionNames) {
         Set<String> enabledExtensions = new HashSet<>(16);
 
         int majorVersion = VK_VERSION_MAJOR(apiVersion);
@@ -168,7 +178,8 @@ public final class VK {
         return enabledExtensions;
     }
 
-    static <T> T checkExtension(String extension, T functions) {
+    @Nullable
+    static <T> T checkExtension(String extension, @Nullable T functions) {
         if (functions != null) {
             return functions;
         }

--- a/modules/core/src/test/java/org/lwjgl/demo/assimp/HelloAssimp.java
+++ b/modules/core/src/test/java/org/lwjgl/demo/assimp/HelloAssimp.java
@@ -6,6 +6,8 @@ package org.lwjgl.demo.assimp;
 
 import org.lwjgl.assimp.*;
 
+import java.util.*;
+
 import static org.lwjgl.assimp.Assimp.*;
 
 public final class HelloAssimp {
@@ -24,7 +26,7 @@ public final class HelloAssimp {
         System.out.println("\nImport formats:");
 
         for (int i = 0; i < c; i++) {
-            AIImporterDesc desc = aiGetImportFormatDescription(i);
+            AIImporterDesc desc = Objects.requireNonNull(aiGetImportFormatDescription(i));
             System.out.println("\t" + (i + 1) + ". " + desc.mNameString() + " (" + desc.mFileExtensionsString() + ")");
         }
 
@@ -32,7 +34,7 @@ public final class HelloAssimp {
         System.out.println("\nExport formats:");
 
         for (int i = 0; i < c; i++) {
-            AIExportFormatDesc desc = aiGetExportFormatDescription(i);
+            AIExportFormatDesc desc = Objects.requireNonNull(aiGetExportFormatDescription(i));
             System.out.println("\t" + (i + 1) + ". " + desc.descriptionString() + " (" + desc.fileExtensionString() + ")");
         }
     }

--- a/modules/core/src/test/java/org/lwjgl/demo/glfw/Events.java
+++ b/modules/core/src/test/java/org/lwjgl/demo/glfw/Events.java
@@ -53,7 +53,7 @@ public final class Events {
             demo();
         } finally {
             glfwTerminate();
-            glfwSetErrorCallback(null).free();
+            Objects.requireNonNull(glfwSetErrorCallback(null)).free();
         }
     }
 
@@ -96,7 +96,7 @@ public final class Events {
 
             long primaryMonitor = glfwGetPrimaryMonitor();
 
-            PointerBuffer monitors = glfwGetMonitors();
+            PointerBuffer monitors = Objects.requireNonNull(glfwGetMonitors());
             for (int i = 0; i < monitors.remaining(); i++) {
                 long monitor = monitors.get(i);
 
@@ -122,8 +122,7 @@ public final class Events {
 
                 double MM_TO_INCH = 0.0393701;
 
-                GLFWVidMode mode = glfwGetVideoMode(monitor);
-
+                GLFWVidMode mode = Objects.requireNonNull(glfwGetVideoMode(monitor));
                 System.out.format("\tCurrent mode    : %d x %d @ %d Hz (%s, R%dG%dB%d)%n",
                     mode.width(), mode.height(),
                     mode.refreshRate(),
@@ -188,14 +187,13 @@ public final class Events {
                 throw new RuntimeException(e);
             }
 
-            ByteBuffer pixels = stbi_load_from_memory(png, w, h, comp, 0);
-
+            ByteBuffer pixels = Objects.requireNonNull(stbi_load_from_memory(png, w, h, comp, 0));
             try (GLFWImage img = GLFWImage.malloc().set(w.get(0), h.get(0), pixels)) {
                 cursor = glfwCreateCursor(img, 0, 8);
                 glfwSetCursor(window, cursor);
+            } finally {
+                stbi_image_free(pixels);
             }
-
-            stbi_image_free(pixels);
         }
 
         // Icons
@@ -210,14 +208,14 @@ public final class Events {
             }
 
             try (GLFWImage.Buffer icons = GLFWImage.malloc(2)) {
-                ByteBuffer pixels16 = stbi_load_from_memory(icon16, w, h, comp, 4);
+                ByteBuffer pixels16 = Objects.requireNonNull(stbi_load_from_memory(icon16, w, h, comp, 4));
                 icons
                     .position(0)
                     .width(w.get(0))
                     .height(h.get(0))
                     .pixels(pixels16);
 
-                ByteBuffer pixels32 = stbi_load_from_memory(icon32, w, h, comp, 4);
+                ByteBuffer pixels32 = Objects.requireNonNull(stbi_load_from_memory(icon32, w, h, comp, 4));
                 icons
                     .position(1)
                     .width(w.get(0))
@@ -319,8 +317,8 @@ public final class Events {
         }
 
         glfwFreeCallbacks(window);
-        glfwSetJoystickCallback(null).free();
-        glfwSetMonitorCallback(null).free();
+        Objects.requireNonNull(glfwSetJoystickCallback(null)).free();
+        Objects.requireNonNull(glfwSetMonitorCallback(null)).free();
 
         glfwDestroyCursor(cursor);
         glfwDestroyWindow(window);

--- a/modules/core/src/test/java/org/lwjgl/demo/glfw/Gears.java
+++ b/modules/core/src/test/java/org/lwjgl/demo/glfw/Gears.java
@@ -10,6 +10,7 @@ import org.lwjgl.opengl.*;
 import org.lwjgl.system.*;
 
 import java.nio.*;
+import java.util.*;
 
 import static org.lwjgl.demo.glfw.GLFWUtil.*;
 import static org.lwjgl.glfw.Callbacks.*;
@@ -106,8 +107,7 @@ public class Gears extends AbstractGears {
 
         long monitor = glfwGetPrimaryMonitor();
 
-        GLFWVidMode vidmode = glfwGetVideoMode(monitor);
-
+        GLFWVidMode vidmode = Objects.requireNonNull(glfwGetVideoMode(monitor));
         // Center window
         glfwSetWindowPos(
             window,
@@ -223,7 +223,7 @@ public class Gears extends AbstractGears {
         }
 
         glfwTerminate();
-        glfwSetErrorCallback(null).free();
+        Objects.requireNonNull(glfwSetErrorCallback(null)).free();
     }
 
 }

--- a/modules/core/src/test/java/org/lwjgl/demo/glfw/MultipleWindows.java
+++ b/modules/core/src/test/java/org/lwjgl/demo/glfw/MultipleWindows.java
@@ -32,7 +32,7 @@ public final class MultipleWindows {
             demo();
         } finally {
             glfwTerminate();
-            glfwSetErrorCallback(null).free();
+            Objects.requireNonNull(glfwSetErrorCallback(null)).free();
         }
     }
 
@@ -63,7 +63,7 @@ public final class MultipleWindows {
             glfwSetKeyCallback(handle, (windowHnd, key, scancode, action, mods) -> {
                 if (key == GLFW_KEY_ESCAPE && action == GLFW_RELEASE) {
                     Arrays.stream(windows)
-                        .filter(w -> w != null)
+                        .filter(Objects::nonNull)
                         .forEach(w -> glfwSetWindowShouldClose(w.handle, true));
                 }
             });

--- a/modules/core/src/test/java/org/lwjgl/demo/glfw/Threads.java
+++ b/modules/core/src/test/java/org/lwjgl/demo/glfw/Threads.java
@@ -7,6 +7,7 @@ package org.lwjgl.demo.glfw;
 import org.lwjgl.glfw.*;
 import org.lwjgl.opengl.*;
 
+import java.util.*;
 import java.util.concurrent.*;
 
 import static org.lwjgl.glfw.Callbacks.*;
@@ -87,7 +88,7 @@ public final class Threads {
         }
 
         glfwTerminate();
-        glfwSetErrorCallback(null).free();
+        Objects.requireNonNull(glfwSetErrorCallback(null)).free();
     }
 
     private static class GLFWThread extends Thread {

--- a/modules/core/src/test/java/org/lwjgl/demo/nanovg/Demo.java
+++ b/modules/core/src/test/java/org/lwjgl/demo/nanovg/Demo.java
@@ -1338,9 +1338,6 @@ class Demo {
 
     static void saveScreenShot(int w, int h, boolean premult, String name) {
         ByteBuffer image = memAlloc(w * h * 4);
-        if (image == null) {
-            return;
-        }
 
         // TODO: Make this work for GLES
         glReadPixels(0, 0, w, h, GL_RGBA, GL_UNSIGNED_BYTE, image);

--- a/modules/core/src/test/java/org/lwjgl/demo/nanovg/ExampleFBO.java
+++ b/modules/core/src/test/java/org/lwjgl/demo/nanovg/ExampleFBO.java
@@ -11,6 +11,7 @@ import org.lwjgl.opengl.*;
 import org.lwjgl.system.*;
 
 import java.nio.*;
+import java.util.*;
 
 import static java.lang.Math.*;
 import static org.lwjgl.glfw.Callbacks.*;
@@ -253,7 +254,7 @@ public final class ExampleFBO extends Demo {
 
         glfwFreeCallbacks(window);
         glfwTerminate();
-        glfwSetErrorCallback(null).free();
+        Objects.requireNonNull(glfwSetErrorCallback(null)).free();
     }
 
 }

--- a/modules/core/src/test/java/org/lwjgl/demo/nanovg/ExampleGL2.java
+++ b/modules/core/src/test/java/org/lwjgl/demo/nanovg/ExampleGL2.java
@@ -7,6 +7,8 @@ package org.lwjgl.demo.nanovg;
 import org.lwjgl.glfw.*;
 import org.lwjgl.opengl.*;
 
+import java.util.*;
+
 import static org.lwjgl.glfw.Callbacks.*;
 import static org.lwjgl.glfw.GLFW.*;
 import static org.lwjgl.nanovg.NanoVG.*;
@@ -148,7 +150,7 @@ public final class ExampleGL2 extends Demo {
 
         glfwFreeCallbacks(window);
         glfwTerminate();
-        glfwSetErrorCallback(null).free();
+        Objects.requireNonNull(glfwSetErrorCallback(null)).free();
     }
 
 }

--- a/modules/core/src/test/java/org/lwjgl/demo/nanovg/ExampleGL3.java
+++ b/modules/core/src/test/java/org/lwjgl/demo/nanovg/ExampleGL3.java
@@ -8,6 +8,8 @@ import org.lwjgl.glfw.*;
 import org.lwjgl.opengl.*;
 import org.lwjgl.system.*;
 
+import java.util.*;
+
 import static org.lwjgl.glfw.Callbacks.*;
 import static org.lwjgl.glfw.GLFW.*;
 import static org.lwjgl.nanovg.NanoVG.*;
@@ -189,7 +191,7 @@ public final class ExampleGL3 extends Demo {
 
         glfwFreeCallbacks(window);
         glfwTerminate();
-        glfwSetErrorCallback(null).free();
+        Objects.requireNonNull(glfwSetErrorCallback(null)).free();
     }
 
 }

--- a/modules/core/src/test/java/org/lwjgl/demo/openal/EFXUtil.java
+++ b/modules/core/src/test/java/org/lwjgl/demo/openal/EFXUtil.java
@@ -4,8 +4,6 @@
  */
 package org.lwjgl.demo.openal;
 
-import org.lwjgl.openal.*;
-
 import static org.lwjgl.openal.AL10.*;
 import static org.lwjgl.openal.EXTEfx.*;
 
@@ -182,7 +180,7 @@ public final class EFXUtil {
             }
 
         } else if (genError == AL_OUT_OF_MEMORY) {
-            throw new RuntimeException(AL10.alGetString(genError));
+            throw new RuntimeException(alGetString(AL_OUT_OF_MEMORY));
         }
 
         return supported;

--- a/modules/core/src/test/java/org/lwjgl/demo/openal/HRTFDemo.java
+++ b/modules/core/src/test/java/org/lwjgl/demo/openal/HRTFDemo.java
@@ -9,6 +9,7 @@ import org.lwjgl.openal.*;
 import org.lwjgl.stb.*;
 
 import java.nio.*;
+import java.util.*;
 
 import static java.lang.Math.*;
 import static org.lwjgl.openal.AL10.*;
@@ -60,7 +61,7 @@ public final class HRTFDemo {
             soundname = args[0];
         }
 
-		/* Enumerate available HRTFs, and reset the device using one. */
+        /* Enumerate available HRTFs, and reset the device using one. */
         int num_hrtf = alcGetInteger(device, ALC_NUM_HRTF_SPECIFIERS_SOFT);
         if (num_hrtf == 0) {
             System.out.println("No HRTFs found");
@@ -69,10 +70,10 @@ public final class HRTFDemo {
 
             System.out.println("Available HRTFs:");
             for (int i = 0; i < num_hrtf; i++) {
-                String name = alcGetStringiSOFT(device, ALC_HRTF_SPECIFIER_SOFT, i);
+                String name = Objects.requireNonNull(alcGetStringiSOFT(device, ALC_HRTF_SPECIFIER_SOFT, i));
                 System.out.format("    %d: %s\n", i, name);
 
-				/* Check if this is the HRTF the user requested. */
+                /* Check if this is the HRTF the user requested. */
                 if (hrtfname != null && name.equals(hrtfname)) {
                     index = i;
                 }
@@ -100,7 +101,7 @@ public final class HRTFDemo {
                 System.out.format("Failed to reset device: %s\n", alcGetString(device, alcGetError(device)));
             }
 
-			 /* Check if HRTF is enabled, and show which is being used. */
+            /* Check if HRTF is enabled, and show which is being used. */
             int hrtf_state = alcGetInteger(device, ALC_HRTF_SOFT);
             if (hrtf_state == 0) {
                 System.out.format("HRTF not enabled!\n");
@@ -109,14 +110,14 @@ public final class HRTFDemo {
                 System.out.format("HRTF enabled, using %s\n", name);
             }
 
-			/* Load the sound into a buffer. */
+            /* Load the sound into a buffer. */
             int buffer = alGenBuffers();
             try (STBVorbisInfo info = STBVorbisInfo.malloc()) {
                 ShortBuffer pcm = ALCDemo.readVorbis(soundname, 32 * 1024, info);
                 alBufferData(buffer, AL_FORMAT_MONO16, pcm, info.sample_rate());
             }
 
-			 /* Create the source to play the sound with. */
+            /* Create the source to play the sound with. */
             int source = alGenSources();
             alSourcei(source, AL_SOURCE_RELATIVE, AL_TRUE);
             alSource3f(source, AL_POSITION, 0.0f, 0.0f, -1.0f);
@@ -126,7 +127,7 @@ public final class HRTFDemo {
                 throw new IllegalStateException("Failed to setup sound source");
             }
 
-			/* Play the sound until it finishes. */
+            /* Play the sound until it finishes. */
             double angle = 0.0;
             alSourcePlay(source);
             int state;
@@ -137,16 +138,16 @@ public final class HRTFDemo {
                     e.printStackTrace();
                 }
 
-				/* Rotate the source around the listener by about 1/8th cycle per second.
+                /* Rotate the source around the listener by about 1/8th cycle per second.
                  * Only affects mono sounds.
-				 */
+                 */
                 angle += (Math.PI / 4 / 100);
                 alSource3f(source, AL_POSITION, (float)sin(angle), 0.0f, -(float)cos(angle));
 
                 state = alGetSourcei(source, AL_SOURCE_STATE);
             } while (alGetError() == AL_NO_ERROR && state == AL_PLAYING);
 
-		    /* All done. Delete resources, and close OpenAL. */
+            /* All done. Delete resources, and close OpenAL. */
             alDeleteSources(source);
             alDeleteBuffers(buffer);
 

--- a/modules/core/src/test/java/org/lwjgl/demo/openal/OpenALInfo.java
+++ b/modules/core/src/test/java/org/lwjgl/demo/openal/OpenALInfo.java
@@ -77,7 +77,7 @@ public class OpenALInfo {
         System.out.println("ALC version: " + majorVersion + "." + minorVersion);
 
         System.out.println("ALC extensions:");
-        String[] extensions = alcGetString(device, ALC_EXTENSIONS).split(" ");
+        String[] extensions = Objects.requireNonNull(alcGetString(device, ALC_EXTENSIONS)).split(" ");
         checkALCError(device);
         for (String extension : extensions) {
             if (extension.trim().isEmpty()) {
@@ -92,7 +92,7 @@ public class OpenALInfo {
         System.out.println("OpenAL renderer string: " + alGetString(AL_RENDERER));
         System.out.println("OpenAL version string: " + alGetString(AL_VERSION));
         System.out.println("AL extensions:");
-        String[] extensions = alGetString(AL_EXTENSIONS).split(" ");
+        String[] extensions = Objects.requireNonNull(alGetString(AL_EXTENSIONS)).split(" ");
         for (String extension : extensions) {
             if (extension.trim().isEmpty()) {
                 continue;
@@ -146,7 +146,7 @@ public class OpenALInfo {
     }
 
     private static void printDevices(int which, String kind) {
-        List<String> devices = ALUtil.getStringList(NULL, which);
+        List<String> devices = Objects.requireNonNull(ALUtil.getStringList(NULL, which));
         System.out.println("Available " + kind + " devices: ");
         for (String d : devices) {
             System.out.println("    " + d);

--- a/modules/core/src/test/java/org/lwjgl/demo/opencl/CLGLInteropDemo.java
+++ b/modules/core/src/test/java/org/lwjgl/demo/opencl/CLGLInteropDemo.java
@@ -127,7 +127,7 @@ public final class CLGLInteropDemo {
             throw new IllegalStateException("No OpenCL platform found that supports OpenGL context sharing.");
         }
 
-        Collections.sort(platforms, (p1, p2) -> {
+        platforms.sort((p1, p2) -> {
             // Prefer platforms that support GPU devices
             boolean gpu1 = !getDevices(p1, CL_DEVICE_TYPE_GPU).isEmpty();
             boolean gpu2 = !getDevices(p2, CL_DEVICE_TYPE_GPU).isEmpty();
@@ -224,7 +224,7 @@ public final class CLGLInteropDemo {
 
         CL.destroy();
         glfwTerminate();
-        glfwSetErrorCallback(null).free();
+        Objects.requireNonNull(glfwSetErrorCallback(null)).free();
 
         System.out.println("GAME OVER!");
     }

--- a/modules/core/src/test/java/org/lwjgl/demo/opencl/Mandelbrot.java
+++ b/modules/core/src/test/java/org/lwjgl/demo/opencl/Mandelbrot.java
@@ -267,13 +267,14 @@ public class Mandelbrot {
             vbo = glGenBuffers();
             glBindBuffer(GL_ARRAY_BUFFER, vbo);
 
-            glBufferData(GL_ARRAY_BUFFER, stackPush().floats(
-                0.0f, 0.0f, 0.0f, 0.0f,
-                1.0f, 0.0f, 1.0f, 0.0f,
-                0.0f, 1.0f, 0.0f, 1.0f,
-                1.0f, 1.0f, 1.0f, 1.0f
-            ), GL_STATIC_DRAW);
-            stackPop();
+            try (MemoryStack stack = stackPush()) {
+                glBufferData(GL_ARRAY_BUFFER, stack.floats(
+                    0.0f, 0.0f, 0.0f, 0.0f,
+                    1.0f, 0.0f, 1.0f, 0.0f,
+                    0.0f, 1.0f, 0.0f, 1.0f,
+                    1.0f, 1.0f, 1.0f, 1.0f
+                ), GL_STATIC_DRAW);
+            }
 
             vsh = glCreateShader(GL_VERTEX_SHADER);
             glShaderSource(vsh,

--- a/modules/core/src/test/java/org/lwjgl/demo/ovr/HelloLibOVR.java
+++ b/modules/core/src/test/java/org/lwjgl/demo/ovr/HelloLibOVR.java
@@ -24,13 +24,12 @@ public final class HelloLibOVR {
             System.out.println("OVRDetectResult.IsOculusServiceRunning = " + detect.IsOculusServiceRunning());
         }
 
-        OVRLogCallback callback;
+        OVRLogCallback callback = OVRLogCallback.create((userData, level, message) -> System.out.println("LibOVR [" + level + "] " + memASCII(message)));
         try (
             OVRInitParams initParams = OVRInitParams.calloc()
-                .LogCallback((userData, level, message) -> System.out.println("LibOVR [" + level + "] " + memASCII(message)))
+                .LogCallback(callback)
                 .Flags(ovrInit_Debug)
         ) {
-            callback = initParams.LogCallback();
             System.out.println("ovr_Initialize = " + ovr_Initialize(initParams));
         }
 

--- a/modules/core/src/test/java/org/lwjgl/demo/stb/FontDemo.java
+++ b/modules/core/src/test/java/org/lwjgl/demo/stb/FontDemo.java
@@ -10,6 +10,7 @@ import org.lwjgl.system.*;
 
 import java.io.*;
 import java.nio.*;
+import java.util.*;
 import java.util.regex.*;
 
 import static java.lang.Math.*;
@@ -242,7 +243,7 @@ abstract class FontDemo {
         });
 
         // Center window
-        GLFWVidMode vidmode = glfwGetVideoMode(monitor);
+        GLFWVidMode vidmode = Objects.requireNonNull(glfwGetVideoMode(monitor));
 
         glfwSetWindowPos(
             window,
@@ -285,7 +286,7 @@ abstract class FontDemo {
         glfwFreeCallbacks(window);
         glfwDestroyWindow(window);
         glfwTerminate();
-        glfwSetErrorCallback(null).free();
+        Objects.requireNonNull(glfwSetErrorCallback(null)).free();
     }
 
 }

--- a/modules/core/src/test/java/org/lwjgl/demo/stb/Image.java
+++ b/modules/core/src/test/java/org/lwjgl/demo/stb/Image.java
@@ -10,6 +10,7 @@ import org.lwjgl.system.*;
 
 import java.io.*;
 import java.nio.*;
+import java.util.*;
 
 import static java.lang.Math.*;
 import static org.lwjgl.demo.glfw.GLFWUtil.*;
@@ -59,6 +60,8 @@ public final class Image {
             // We don't need this for this demo, just testing the API.
             if (!stbi_info_from_memory(imageBuffer, w, h, comp)) {
                 throw new RuntimeException("Failed to read image information: " + stbi_failure_reason());
+            } else {
+                System.out.println("OK with reason: " + stbi_failure_reason());
             }
 
             System.out.println("Image width: " + w.get(0));
@@ -129,7 +132,7 @@ public final class Image {
         glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 2);
         glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 1);
 
-        GLFWVidMode vidmode = glfwGetVideoMode(glfwGetPrimaryMonitor());
+        GLFWVidMode vidmode = Objects.requireNonNull(glfwGetVideoMode(glfwGetPrimaryMonitor()));
 
         ww = max(800, min(w, vidmode.width() - 160));
         wh = max(600, min(h, vidmode.height() - 120));
@@ -331,7 +334,7 @@ public final class Image {
         glfwFreeCallbacks(window);
         glfwDestroyWindow(window);
         glfwTerminate();
-        glfwSetErrorCallback(null).free();
+        Objects.requireNonNull(glfwSetErrorCallback(null)).free();
     }
 
 }

--- a/modules/core/src/test/java/org/lwjgl/demo/stb/Vorbis.java
+++ b/modules/core/src/test/java/org/lwjgl/demo/stb/Vorbis.java
@@ -13,6 +13,7 @@ import org.lwjgl.system.windows.*;
 
 import java.io.*;
 import java.nio.*;
+import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.*;
 
@@ -143,7 +144,7 @@ public final class Vorbis implements AutoCloseable {
         }
 
         // Center window
-        GLFWVidMode vidmode = glfwGetVideoMode(monitor);
+        GLFWVidMode vidmode = Objects.requireNonNull(glfwGetVideoMode(monitor));
         glfwSetWindowPos(
             window,
             (vidmode.width() - framebufferW) / 2,
@@ -257,7 +258,7 @@ public final class Vorbis implements AutoCloseable {
         }
 
         glfwTerminate();
-        glfwSetErrorCallback(null).free();
+        Objects.requireNonNull(glfwSetErrorCallback(null)).free();
     }
 
     public static void main(String[] args) {

--- a/modules/core/src/test/java/org/lwjgl/demo/system/jawt/LWJGLCanvas.java
+++ b/modules/core/src/test/java/org/lwjgl/demo/system/jawt/LWJGLCanvas.java
@@ -38,7 +38,7 @@ public class LWJGLCanvas extends Canvas {
         awt = JAWT.calloc();
         awt.version(JAWT_VERSION_1_4);
         if (!JAWT_GetAWT(awt)) {
-            throw new RuntimeException("GetAWT failed");
+            throw new IllegalStateException("GetAWT failed");
         }
 
         gears = new AbstractGears();
@@ -54,19 +54,22 @@ public class LWJGLCanvas extends Canvas {
         // Get the drawing surface
         JAWTDrawingSurface ds = JAWT_GetDrawingSurface(awt.GetDrawingSurface(), this);
         if (ds == null) {
-            throw new RuntimeException("awt->GetDrawingSurface() failed");
+            throw new IllegalStateException("awt->GetDrawingSurface() failed");
         }
 
         try {
             // Lock the drawing surface
             int lock = JAWT_DrawingSurface_Lock(ds.Lock(), ds);
             if ((lock & JAWT_LOCK_ERROR) != 0) {
-                throw new RuntimeException("ds->Lock() failed");
+                throw new IllegalStateException("ds->Lock() failed");
             }
 
             try {
                 // Get the drawing surface info
                 JAWTDrawingSurfaceInfo dsi = JAWT_DrawingSurface_GetDrawingSurfaceInfo(ds.GetDrawingSurfaceInfo(), ds);
+                if (dsi == null) {
+                    throw new IllegalStateException("ds->GetDrawingSurfaceInfo() failed");
+                }
 
                 try {
                     // Get the platform-specific drawing info

--- a/modules/core/src/test/java/org/lwjgl/demo/util/lmdb/LMDBDemo.java
+++ b/modules/core/src/test/java/org/lwjgl/demo/util/lmdb/LMDBDemo.java
@@ -9,6 +9,7 @@ import org.lwjgl.system.*;
 import org.lwjgl.util.lmdb.*;
 
 import java.io.*;
+import java.util.*;
 
 import static org.lwjgl.demo.util.lmdb.LMDBUtil.*;
 import static org.lwjgl.system.MemoryStack.*;
@@ -80,7 +81,7 @@ public final class LMDBDemo {
             // no copy, LMDB updates dv.mv_data with a pointer to the database
             E(mdb_put(txn, dbi, kv, dv, MDB_RESERVE));
             // value is encoded directly to the memory-mapped file
-            memUTF8(value, false, dv.mv_data());
+            memUTF8(value, false, Objects.requireNonNull(dv.mv_data()));
 
             return null;
         });
@@ -94,7 +95,7 @@ public final class LMDBDemo {
             MDBVal dv = MDBVal.callocStack(stack);
 
             E(mdb_get(txn, dbi, kv, dv));
-            return memUTF8(dv.mv_data());
+            return memUTF8(Objects.requireNonNull(dv.mv_data()));
         });
     }
 

--- a/modules/core/src/test/java/org/lwjgl/demo/util/lmdb/MTest.java
+++ b/modules/core/src/test/java/org/lwjgl/demo/util/lmdb/MTest.java
@@ -50,16 +50,16 @@ public final class MTest {
     private static void print_p(MDBVal key, MDBVal data) {
         System.out.printf(
             "key: %X %s, data: %X %s\n",
-            memGetAddress(key.address() + MDBVal.MV_DATA), memASCII(key.mv_data()),
-            memGetAddress(data.address() + MDBVal.MV_DATA), memASCII(data.mv_data())
+            memGetAddress(key.address() + MDBVal.MV_DATA), memASCII(Objects.requireNonNull(key.mv_data())),
+            memGetAddress(data.address() + MDBVal.MV_DATA), memASCII(Objects.requireNonNull(data.mv_data()))
         );
     }
 
     private static void print(MDBVal key, MDBVal data) {
         System.out.printf(
             "key: %s, data: %s\n",
-            memASCII(key.mv_data()),
-            memASCII(data.mv_data())
+            memASCII(Objects.requireNonNull(key.mv_data())),
+            memASCII(Objects.requireNonNull(data.mv_data()))
         );
     }
 
@@ -162,20 +162,20 @@ public final class MTest {
         txn = pp.get(0);
         E(mdb_cursor_open(txn, dbi, pp));
         cursor = pp.get(0);
-        System.out.printf("Cursor next\n");
+        System.out.print("Cursor next\n");
         while ((rc = mdb_cursor_get(cursor, key, data, MDB_NEXT)) == 0) {
             print(key, data);
         }
         CHECK(rc, rc == MDB_NOTFOUND, "mdb_cursor_get");
-        System.out.printf("Cursor last\n");
+        System.out.print("Cursor last\n");
         E(mdb_cursor_get(cursor, key, data, MDB_LAST));
         print(key, data);
-        System.out.printf("Cursor prev\n");
+        System.out.print("Cursor prev\n");
         while ((rc = mdb_cursor_get(cursor, key, data, MDB_PREV)) == 0) {
             print(key, data);
         }
         CHECK(rc, rc == MDB_NOTFOUND, "mdb_cursor_get");
-        System.out.printf("Cursor last/prev\n");
+        System.out.print("Cursor last/prev\n");
         E(mdb_cursor_get(cursor, key, data, MDB_LAST));
         print(key, data);
         E(mdb_cursor_get(cursor, key, data, MDB_PREV));
@@ -184,7 +184,7 @@ public final class MTest {
         mdb_cursor_close(cursor);
         mdb_txn_abort(txn);
 
-        System.out.printf("Deleting with cursor\n");
+        System.out.print("Deleting with cursor\n");
         E(mdb_txn_begin(env, NULL, 0, pp));
         txn = pp.get(0);
         E(mdb_cursor_open(txn, dbi, pp));
@@ -197,7 +197,7 @@ public final class MTest {
             E(mdb_del(txn, dbi, key, null));
         }
 
-        System.out.printf("Restarting cursor in txn\n");
+        System.out.print("Restarting cursor in txn\n");
         for (int op = MDB_FIRST, i = 0; i <= 32; op = MDB_NEXT, i++) {
             if (RES(MDB_NOTFOUND, mdb_cursor_get(cur2, key, data, op))) {
                 break;
@@ -207,7 +207,7 @@ public final class MTest {
         mdb_cursor_close(cur2);
         E(mdb_txn_commit(txn));
 
-        System.out.printf("Restarting cursor outside txn\n");
+        System.out.print("Restarting cursor outside txn\n");
         E(mdb_txn_begin(env, NULL, 0, pp));
         txn = pp.get(0);
         E(mdb_cursor_open(txn, dbi, pp));

--- a/modules/core/src/test/java/org/lwjgl/demo/util/nfd/HelloNFD.java
+++ b/modules/core/src/test/java/org/lwjgl/demo/util/nfd/HelloNFD.java
@@ -11,6 +11,7 @@ import org.lwjgl.system.*;
 import org.lwjgl.util.nfd.*;
 
 import java.nio.*;
+import java.util.*;
 
 import static org.lwjgl.glfw.Callbacks.*;
 import static org.lwjgl.glfw.GLFW.*;
@@ -73,7 +74,7 @@ public final class HelloNFD {
         });
 
         // Center window
-        GLFWVidMode vidmode = glfwGetVideoMode(glfwGetPrimaryMonitor());
+        GLFWVidMode vidmode = Objects.requireNonNull(glfwGetVideoMode(glfwGetPrimaryMonitor()));
         glfwSetWindowPos(
             window,
             (vidmode.width() - 300) / 2,
@@ -100,7 +101,7 @@ public final class HelloNFD {
         glfwDestroyWindow(window);
         glfwTerminate();
 
-        glfwSetErrorCallback(null).free();
+        Objects.requireNonNull(glfwSetErrorCallback(null)).free();
     }
 
     private static void openSingle() {

--- a/modules/core/src/test/java/org/lwjgl/demo/util/par/ParShapesDemo.java
+++ b/modules/core/src/test/java/org/lwjgl/demo/util/par/ParShapesDemo.java
@@ -11,6 +11,7 @@ import org.lwjgl.system.*;
 import org.lwjgl.util.par.*;
 
 import java.nio.*;
+import java.util.*;
 
 import static org.lwjgl.glfw.Callbacks.*;
 import static org.lwjgl.glfw.GLFW.*;
@@ -171,10 +172,7 @@ public final class ParShapesDemo {
         });
 
         // center window
-        long monitor = glfwGetPrimaryMonitor();
-
-        GLFWVidMode vidmode = glfwGetVideoMode(monitor);
-
+        GLFWVidMode vidmode = Objects.requireNonNull(glfwGetVideoMode(glfwGetPrimaryMonitor()));
         glfwSetWindowPos(
             window,
             (vidmode.width() - width) / 2,
@@ -484,7 +482,7 @@ public final class ParShapesDemo {
 
         glfwFreeCallbacks(window);
         glfwTerminate();
-        glfwSetErrorCallback(null).free();
+        Objects.requireNonNull(glfwSetErrorCallback(null)).free();
 
         if (debugCB != null) {
             debugCB.free();

--- a/modules/core/src/test/java/org/lwjgl/demo/util/tinyfd/HelloTinyFD.java
+++ b/modules/core/src/test/java/org/lwjgl/demo/util/tinyfd/HelloTinyFD.java
@@ -10,6 +10,7 @@ import org.lwjgl.opengl.*;
 import org.lwjgl.system.*;
 
 import java.nio.*;
+import java.util.*;
 
 import static org.lwjgl.glfw.Callbacks.*;
 import static org.lwjgl.glfw.GLFW.*;
@@ -96,7 +97,7 @@ public final class HelloTinyFD {
         });
 
         // Center window
-        GLFWVidMode vidmode = glfwGetVideoMode(glfwGetPrimaryMonitor());
+        GLFWVidMode vidmode = Objects.requireNonNull(glfwGetVideoMode(glfwGetPrimaryMonitor()));
         glfwSetWindowPos(
             window,
             (vidmode.width() - 300) / 2,
@@ -127,7 +128,7 @@ public final class HelloTinyFD {
         glfwDestroyWindow(window);
         glfwTerminate();
 
-        glfwSetErrorCallback(null).free();
+        Objects.requireNonNull(glfwSetErrorCallback(null)).free();
     }
 
 }

--- a/modules/core/src/test/java/org/lwjgl/demo/util/xxhash/XXHashDemo.java
+++ b/modules/core/src/test/java/org/lwjgl/demo/util/xxhash/XXHashDemo.java
@@ -46,7 +46,7 @@ public final class XXHashDemo {
         String resource = "lwjgl32.png";
         try {
             // Allocate and free using the API
-            XXH64State state = XXH64_createState();
+            XXH64State state = Objects.requireNonNull(XXH64_createState());
             try {
                 hash64 = streamingHash(buffer, resource, state, SEED);
                 System.out.format("streaming 64-bit hash: 0x%X (%s, malloc)\n", hash64, resource);

--- a/modules/core/src/test/java/org/lwjgl/demo/util/yoga/HolyGrail.java
+++ b/modules/core/src/test/java/org/lwjgl/demo/util/yoga/HolyGrail.java
@@ -11,6 +11,7 @@ import org.lwjgl.system.*;
 import org.lwjgl.util.yoga.*;
 
 import java.nio.*;
+import java.util.*;
 
 import static org.lwjgl.glfw.Callbacks.*;
 import static org.lwjgl.glfw.GLFW.*;
@@ -64,10 +65,8 @@ public final class HolyGrail {
             throw new RuntimeException("Failed to create the GLFW window");
         }
 
-        long        monitor = glfwGetPrimaryMonitor();
-        GLFWVidMode vidmode = glfwGetVideoMode(monitor);
-
         // Center window
+        GLFWVidMode vidmode = Objects.requireNonNull(glfwGetVideoMode(glfwGetPrimaryMonitor()));
         glfwSetWindowPos(
             window,
             (vidmode.width() - width) / 2,
@@ -266,7 +265,7 @@ public final class HolyGrail {
         }
 
         glfwTerminate();
-        glfwSetErrorCallback(null).free();
+        Objects.requireNonNull(glfwSetErrorCallback(null)).free();
     }
 
     public static void main(String[] args) {

--- a/modules/core/src/test/java/org/lwjgl/demo/vulkan/HelloVulkan.java
+++ b/modules/core/src/test/java/org/lwjgl/demo/vulkan/HelloVulkan.java
@@ -10,6 +10,7 @@ import org.lwjgl.system.*;
 import org.lwjgl.vulkan.*;
 
 import java.nio.*;
+import java.util.*;
 
 import static org.lwjgl.glfw.Callbacks.*;
 import static org.lwjgl.glfw.GLFW.*;
@@ -299,13 +300,13 @@ public final class HelloVulkan {
                 type, memASCII(pLayerPrefix), messageCode, VkDebugReportCallbackEXT.getString(pMessage)
             );
 
-			/*
+            /*
              * false indicates that layer should not bail-out of an
-			 * API call that had validation failures. This may mean that the
-			 * app dies inside the driver due to invalid parameter(s).
-			 * That's what would happen without validation layers, so we'll
-			 * keep that behavior here.
-			 */
+             * API call that had validation failures. This may mean that the
+             * app dies inside the driver due to invalid parameter(s).
+             * That's what would happen without validation layers, so we'll
+             * keep that behavior here.
+             */
             return VK_FALSE;
         }
     );
@@ -454,20 +455,20 @@ public final class HelloVulkan {
 
             inst = new VkInstance(pp.get(0), inst_info);
 
-			/* Make initial call to query gpu_count, then second call for gpu info */
+            /* Make initial call to query gpu_count, then second call for gpu info */
             check(vkEnumeratePhysicalDevices(inst, ip, null));
 
             if (ip.get(0) > 0) {
                 PointerBuffer physical_devices = stack.mallocPointer(ip.get(0));
                 check(vkEnumeratePhysicalDevices(inst, ip, physical_devices));
 
-				/* For tri demo we just grab the first physical device */
+                /* For tri demo we just grab the first physical device */
                 gpu = new VkPhysicalDevice(physical_devices.get(0), inst);
             } else {
                 throw new IllegalStateException("vkEnumeratePhysicalDevices reported zero accessible devices.");
             }
 
-			/* Look for device extensions */
+            /* Look for device extensions */
             boolean swapchainExtFound = false;
             check(vkEnumerateDeviceExtensionProperties(gpu, (String)null, ip, null));
 
@@ -912,15 +913,15 @@ public final class HelloVulkan {
                 .height(height)
                 .depth(1);
 
-		    /* create image */
+            /* create image */
             check(vkCreateImage(device, image, null, lp));
             depth.image = lp.get(0);
 
-		    /* get memory requirements for this object */
+            /* get memory requirements for this object */
             VkMemoryRequirements mem_reqs = VkMemoryRequirements.mallocStack(stack);
             vkGetImageMemoryRequirements(device, depth.image, mem_reqs);
 
-		    /* select memory size and type */
+            /* select memory size and type */
             VkMemoryAllocateInfo mem_alloc = VkMemoryAllocateInfo.mallocStack(stack)
                 .sType(VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO)
                 .pNext(NULL)
@@ -931,11 +932,11 @@ public final class HelloVulkan {
                 mem_alloc);
             assert (pass);
 
-		    /* allocate memory */
+            /* allocate memory */
             check(vkAllocateMemory(device, mem_alloc, null, lp));
             depth.mem = lp.get(0);
 
-		    /* bind memory */
+            /* bind memory */
             check(vkBindImageMemory(device, depth.image, depth.mem, 0));
 
             demo_set_image_layout(depth.image, VK_IMAGE_ASPECT_DEPTH_BIT,
@@ -943,7 +944,7 @@ public final class HelloVulkan {
                 VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL,
                 0);
 
-		    /* create image view */
+            /* create image view */
             VkImageViewCreateInfo view = VkImageViewCreateInfo.callocStack(stack)
                 .sType(VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO)
                 .pNext(NULL)
@@ -1020,11 +1021,11 @@ public final class HelloVulkan {
             pass = memory_type_from_properties(mem_reqs.memoryTypeBits(), required_props, mem_alloc);
             assert (pass);
 
-	    /* allocate memory */
+            /* allocate memory */
             check(vkAllocateMemory(device, mem_alloc, null, lp));
             tex_obj.mem = lp.get(0);
 
-	    /* bind memory */
+            /* bind memory */
             check(vkBindImageMemory(device, tex_obj.image, tex_obj.mem, 0));
 
             if ((required_props & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT) != 0) {
@@ -1050,13 +1051,13 @@ public final class HelloVulkan {
 
             tex_obj.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
             demo_set_image_layout(tex_obj.image, VK_IMAGE_ASPECT_COLOR_BIT, VK_IMAGE_LAYOUT_PREINITIALIZED, tex_obj.imageLayout, VK_ACCESS_HOST_WRITE_BIT);
-		/* setting the image layout does not reference the actual memory so no need
-		 * to add a mem ref */
+            /* setting the image layout does not reference the actual memory so no need
+             * to add a mem ref */
         }
     }
 
     private void demo_destroy_texture_image(TextureObject tex_obj) {
-	    /* clean up staging resources */
+        /* clean up staging resources */
         vkDestroyImage(device, tex_obj.image, null);
         vkFreeMemory(device, tex_obj.mem, null);
     }
@@ -1093,13 +1094,13 @@ public final class HelloVulkan {
 
             for (int i = 0; i < DEMO_TEXTURE_COUNT; i++) {
                 if ((props.linearTilingFeatures() & VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT) != 0 && !USE_STAGING_BUFFER) {
-				    /* Device can texture using linear textures */
+                    /* Device can texture using linear textures */
                     demo_prepare_texture_image(
                         tex_colors[i], textures[i], VK_IMAGE_TILING_LINEAR,
                         VK_IMAGE_USAGE_SAMPLED_BIT,
                         VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
                 } else if ((props.optimalTilingFeatures() & VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT) != 0) {
-				    /* Must use staging buffer to copy linear texture to optimized */
+                    /* Must use staging buffer to copy linear texture to optimized */
                     TextureObject staging_texture = new TextureObject();
 
                     demo_prepare_texture_image(
@@ -1165,7 +1166,7 @@ public final class HelloVulkan {
 
                     demo_destroy_texture_image(staging_texture);
                 } else {
-				    /* Can't support VK_FORMAT_B8G8R8A8_UNORM !? */
+                    /* Can't support VK_FORMAT_B8G8R8A8_UNORM !? */
                     throw new IllegalStateException("No support for B8G8R8A8_UNORM as texture image format");
                 }
 
@@ -1187,7 +1188,7 @@ public final class HelloVulkan {
                     .borderColor(VK_BORDER_COLOR_FLOAT_OPAQUE_WHITE)
                     .unnormalizedCoordinates(false);
 
-				/* create sampler */
+                /* create sampler */
                 check(vkCreateSampler(device, sampler, null, lp));
                 textures[i].sampler = lp.get(0);
 
@@ -1210,7 +1211,7 @@ public final class HelloVulkan {
                     .baseArrayLayer(0)
                     .layerCount(1);
 
-		        /* create image view */
+                /* create image view */
                 view.image(textures[i].image);
                 check(vkCreateImageView(device, view, null, lp));
                 textures[i].view = lp.get(0);
@@ -1229,7 +1230,7 @@ public final class HelloVulkan {
 
     private void demo_prepare_vertices() {
         float[][] vb = {
-		    /*      position             texcoord */
+            /*      position             texcoord */
             {-1.0f, -1.0f, 0.25f, 0.0f, 0.0f},
             {1.0f, -1.0f, 0.25f, 1.0f, 0.0f},
             {0.0f, 1.0f, 1.0f, 0.5f, 1.0f},
@@ -1915,7 +1916,7 @@ public final class HelloVulkan {
         glfwFreeCallbacks(window);
         glfwDestroyWindow(window);
         glfwTerminate();
-        glfwSetErrorCallback(null).free();
+        Objects.requireNonNull(glfwSetErrorCallback(null)).free();
 
         memFree(extension_names);
 

--- a/modules/core/src/test/java/org/lwjgl/opencl/CLTest.java
+++ b/modules/core/src/test/java/org/lwjgl/opencl/CLTest.java
@@ -9,6 +9,7 @@ import org.lwjgl.system.*;
 import org.testng.*;
 import org.testng.annotations.*;
 
+import javax.annotation.*;
 import java.nio.*;
 import java.util.concurrent.*;
 
@@ -23,6 +24,7 @@ import static org.testng.Assert.*;
 @Test(singleThreaded = true)
 public class CLTest {
 
+    @Nullable
     private static CLContextCallback CONTEXT_CALLBACK;
 
     @BeforeClass

--- a/modules/core/src/test/java/org/lwjgl/system/BufferTest.java
+++ b/modules/core/src/test/java/org/lwjgl/system/BufferTest.java
@@ -17,22 +17,22 @@ import static org.testng.Assert.*;
 @Test
 public class BufferTest {
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
     public void testLargeBufferNIO() {
         // ByteBuffer.allocateDirect supports up to Integer.MAX_VALUE bytes
-        BufferUtils.createShortBuffer(0x3FFFFFFF + 1);
+        expectThrows(IllegalArgumentException.class, () -> BufferUtils.createShortBuffer(0x3FFFFFFF + 1));
     }
 
     public void testLargeBuffer() {
-        ShortBuffer buffer = memCallocShort(0x3FFFFFFF + 1);
-        if (buffer == null) {
+        try {
+            ShortBuffer buffer = memCallocShort(0x3FFFFFFF + 1);
+
+            buffer.put(buffer.limit() - 1, (short)0xBEEF);
+            assertEquals(buffer.get(buffer.limit() - 1), (short)0xBEEF);
+
+            memFree(buffer);
+        } catch (OutOfMemoryError e) {
             throw new SkipException("Large buffer allocation failed."); // 32-bit JVM
         }
-
-        buffer.put(buffer.limit() - 1, (short)0xBEEF);
-        assertEquals(buffer.get(buffer.limit() - 1), (short)0xBEEF);
-
-        memFree(buffer);
     }
 
     private static long fillBuffer(JNINativeMethod.Buffer buffer) {

--- a/modules/core/src/test/java/org/lwjgl/system/MemoryUtilTest.java
+++ b/modules/core/src/test/java/org/lwjgl/system/MemoryUtilTest.java
@@ -234,21 +234,23 @@ public class MemoryUtilTest {
         }
 
         // encode null returns null
-        assertNull(memUTF8((String)null));
-        assertNull(memUTF8(null, false));
+        assertNull(memUTF8Safe((String)null));
+        assertNull(memUTF8Safe(null, false));
 
         // decode null/NULL returns null
-        assertNull(memUTF8(NULL));
-        assertNull(memUTF8((ByteBuffer)null));
+        assertNull(memUTF8Safe(NULL));
+        assertNull(memUTF8Safe((ByteBuffer)null));
 
         // decode null/NULL with specific length/offset throws NPE
         try {
+            //noinspection ConstantConditions
             memUTF8(null, 0);
             fail();
         } catch (NullPointerException ignored) {
         }
 
         try {
+            //noinspection ConstantConditions
             memUTF8(null, 0, 0);
             fail();
         } catch (NullPointerException ignored) {

--- a/modules/core/src/test/java/org/lwjgl/system/StackTest.java
+++ b/modules/core/src/test/java/org/lwjgl/system/StackTest.java
@@ -22,13 +22,11 @@ public class StackTest {
         assertEquals(stack.getPointer(), size);
         assertEquals(stack.getFrameIndex(), 0);
 
-        stack.push();
-        {
-            stack.malloc(8);
-            assertEquals(stack.getPointer(), size - 8);
-            assertEquals(stack.getFrameIndex(), 1);
+        try (MemoryStack frame = stack.push()) {
+            frame.malloc(8);
+            assertEquals(frame.getPointer(), size - 8);
+            assertEquals(frame.getFrameIndex(), 1);
         }
-        stack.pop();
 
         assertEquals(stack.getPointer(), size);
         assertEquals(stack.getFrameIndex(), 0);
@@ -41,39 +39,27 @@ public class StackTest {
 
         assertEquals(stack.getPointer(), size);
 
-        stack.push();
-        try {
-            stack.malloc(1);
-            assertEquals(stack.getPointer(), size - 1);
-        } finally {
-            stack.pop();
+        try (MemoryStack frame = stack.push()) {
+            frame.malloc(1);
+            assertEquals(frame.getPointer(), size - 1);
         }
 
-        stack.push();
-        try {
-            stack.malloc(1);
-            stack.mallocShort(1);
-            assertEquals(stack.getPointer(), size - 4);
-        } finally {
-            stack.pop();
+        try (MemoryStack frame = stack.push()) {
+            frame.malloc(1);
+            frame.mallocShort(1);
+            assertEquals(frame.getPointer(), size - 4);
         }
 
-        stack.push();
-        try {
-            stack.malloc(1);
-            stack.mallocInt(1);
-            assertEquals(stack.getPointer(), size - 8);
-        } finally {
-            stack.pop();
+        try (MemoryStack frame = stack.push()) {
+            frame.malloc(1);
+            frame.mallocInt(1);
+            assertEquals(frame.getPointer(), size - 8);
         }
 
-        stack.push();
-        try {
-            stack.malloc(1);
-            stack.mallocLong(1);
-            assertEquals(stack.getPointer(), size - 16);
-        } finally {
-            stack.pop();
+        try (MemoryStack frame = stack.push()) {
+            frame.malloc(1);
+            frame.mallocLong(1);
+            assertEquals(frame.getPointer(), size - 16);
         }
     }
 
@@ -85,10 +71,10 @@ public class StackTest {
         expectThrows(OutOfMemoryError.class, () -> {
             MemoryStack stack = new MemoryStack(8);
 
-            stack.push();
-            stack.malloc(8);
-            stack.malloc(1);
-            stack.pop();
+            try (MemoryStack frame = stack.push()) {
+                frame.malloc(8);
+                frame.malloc(1);
+            }
         });
     }
 

--- a/modules/core/src/test/java/org/lwjgl/system/StackTest.java
+++ b/modules/core/src/test/java/org/lwjgl/system/StackTest.java
@@ -77,27 +77,29 @@ public class StackTest {
         }
     }
 
-    @Test(expectedExceptions = OutOfMemoryError.class)
     public void testOOME() {
         if (!CHECKS) {
             throw new SkipException("This test may not run with checks disabled.");
         }
 
-        MemoryStack stack = new MemoryStack(8);
+        expectThrows(OutOfMemoryError.class, () -> {
+            MemoryStack stack = new MemoryStack(8);
 
-        stack.push();
-        stack.malloc(8);
-        stack.malloc(1);
-        stack.pop();
+            stack.push();
+            stack.malloc(8);
+            stack.malloc(1);
+            stack.pop();
+        });
     }
 
-    @Test(expectedExceptions = StackOverflowError.class)
     public void testSOE() {
-        MemoryStack stack = MemoryStack.create();
+        expectThrows(StackOverflowError.class, () -> {
+            MemoryStack stack = MemoryStack.create();
 
-        // Test growing of the stack frame array,
-        // the Java stack should overflow before we have any issues
-        recursivePush(stack);
+            // Test growing of the stack frame array,
+            // the Java stack should overflow before we have any issues
+            recursivePush(stack);
+        });
     }
 
     private static void recursivePush(MemoryStack stack) {

--- a/modules/core/src/test/java/org/lwjgl/system/StructTest.java
+++ b/modules/core/src/test/java/org/lwjgl/system/StructTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright LWJGL. All rights reserved.
+ * License terms: https://www.lwjgl.org/license
+ */
+package org.lwjgl.system;
+
+import org.lwjgl.*;
+import org.lwjgl.system.jni.*;
+import org.testng.annotations.*;
+
+import static org.lwjgl.system.MemoryStack.*;
+import static org.testng.Assert.*;
+
+@Test
+public class StructTest {
+
+    public void testAllocation() {
+        JNINativeMethod.create();
+        JNINativeMethod.malloc().free();
+        JNINativeMethod.calloc().free();
+
+        try (MemoryStack stack = stackPush()) {
+            JNINativeMethod.mallocStack(stack);
+            JNINativeMethod.callocStack(stack);
+        }
+
+        expectThrows(IllegalArgumentException.class, () -> new JNINativeMethod(BufferUtils.createByteBuffer(4)));
+    }
+
+    public void testAllocationBuffer() {
+        JNINativeMethod.create(10);
+        JNINativeMethod.malloc(10).free();
+        JNINativeMethod.calloc(10).free();
+
+        try (MemoryStack stack = stackPush()) {
+            JNINativeMethod.mallocStack(10, stack);
+            JNINativeMethod.callocStack(10, stack);
+        }
+
+        assertEquals(new JNINativeMethod.Buffer(BufferUtils.createByteBuffer(4)).capacity(), 0);
+    }
+
+    public void testValidation() {
+        try (MemoryStack stack = stackPush()) {
+            JNINativeMethod s = JNINativeMethod.callocStack(stack);
+
+            assertTrue(s.isNull(JNINativeMethod.NAME));
+            expectThrows(NullPointerException.class, s::name);
+
+            expectThrows(NullPointerException.class, () -> JNINativeMethod.validate(s.address()));
+            s.name(stack.UTF8("myMethodName"));
+            expectThrows(NullPointerException.class, () -> JNINativeMethod.validate(s.address()));
+            s.signature(stack.UTF8("(I)I"));
+            expectThrows(NullPointerException.class, () -> JNINativeMethod.validate(s.address()));
+            s.fnPtr(0x12341234L);
+            JNINativeMethod.validate(s.address());
+
+            assertFalse(s.isNull(JNINativeMethod.NAME));
+            assertEquals(s.nameString(), "myMethodName");
+
+        }
+    }
+
+}

--- a/modules/core/src/test/java/org/lwjgl/util/par/ParTest.java
+++ b/modules/core/src/test/java/org/lwjgl/util/par/ParTest.java
@@ -7,6 +7,7 @@ package org.lwjgl.util.par;
 import org.testng.annotations.*;
 
 import java.nio.*;
+import java.util.*;
 
 import static org.lwjgl.system.MemoryUtil.*;
 import static org.lwjgl.util.par.ParShapes.*;
@@ -16,17 +17,11 @@ import static org.testng.Assert.*;
 public class ParTest {
 
     public void testCylindersAndSpheres() {
-        ParShapesMesh bad1 = par_shapes_create_cylinder(1, 1);
-        ParShapesMesh bad2 = par_shapes_create_cylinder(1, 3);
-        ParShapesMesh good = par_shapes_create_cylinder(3, 1);
+        assertEquals(par_shapes_create_cylinder(1, 1), null); // bad
+        assertEquals(par_shapes_create_cylinder(1, 3), null); // bad
+        par_shapes_free_mesh(Objects.requireNonNull(par_shapes_create_cylinder(3, 1))); // good
 
-        assertEquals(bad1, null);
-        assertEquals(bad2, null);
-        assertNotEquals(good, null);
-
-        par_shapes_free_mesh(good);
-
-        ParShapesMesh m = par_shapes_create_cylinder(5, 6);
+        ParShapesMesh m = Objects.requireNonNull(par_shapes_create_cylinder(5, 6));
         assertEquals(m.npoints(), 42);
         par_shapes_free_mesh(m);
 
@@ -34,32 +29,32 @@ public class ParTest {
 
         slices = 5;
         stacks = 6;
-        m = par_shapes_create_cylinder(slices, stacks);
+        m = Objects.requireNonNull(par_shapes_create_cylinder(slices, stacks));
         assertEquals(m.ntriangles(), slices * stacks * 2);
         par_shapes_free_mesh(m);
 
         slices = 5;
         stacks = 6;
-        m = par_shapes_create_parametric_sphere(slices, stacks);
+        m = Objects.requireNonNull(par_shapes_create_parametric_sphere(slices, stacks));
         assertEquals(m.ntriangles(), slices * 2 + (stacks - 2) * slices * 2);
         par_shapes_free_mesh(m);
 
         slices = 12;
         stacks = 13;
-        m = par_shapes_create_parametric_sphere(slices, stacks);
+        m = Objects.requireNonNull(par_shapes_create_parametric_sphere(slices, stacks));
         assertEquals(m.ntriangles(), slices * 2 + (stacks - 2) * slices * 2);
         par_shapes_free_mesh(m);
 
         slices = 16;
         stacks = 16;
-        m = par_shapes_create_parametric_sphere(slices, stacks);
+        m = Objects.requireNonNull(par_shapes_create_parametric_sphere(slices, stacks));
         assertEquals(m.ntriangles(), slices * 2 + (stacks - 2) * slices * 2);
         par_shapes_free_mesh(m);
     }
 
     public void testMerge() {
-        ParShapesMesh a = par_shapes_create_klein_bottle(10, 20);
-        ParShapesMesh b = par_shapes_create_plane(3, 3);
+        ParShapesMesh a = Objects.requireNonNull(par_shapes_create_klein_bottle(10, 20));
+        ParShapesMesh b = Objects.requireNonNull(par_shapes_create_plane(3, 3));
 
         int npts  = a.npoints();
         int ntris = a.ntriangles();
@@ -77,8 +72,8 @@ public class ParTest {
         ParShapesMesh a, b;
 
         // should support translation
-        a = par_shapes_create_cylinder(20, 3);
-        b = par_shapes_create_cylinder(4, 3);
+        a = Objects.requireNonNull(par_shapes_create_cylinder(20, 3));
+        b = Objects.requireNonNull(par_shapes_create_cylinder(4, 3));
 
         par_shapes_translate(a, 0.5f, 0.5f, 0.25f);
         par_shapes_merge(a, b);
@@ -88,8 +83,8 @@ public class ParTest {
 
         // should support rotation
 
-        a = par_shapes_create_cylinder(20, 3);
-        b = par_shapes_create_cylinder(4, 3);
+        a = Objects.requireNonNull(par_shapes_create_cylinder(20, 3));
+        b = Objects.requireNonNull(par_shapes_create_cylinder(4, 3));
 
         FloatBuffer axis1 = memAllocFloat(3);
         axis1
@@ -116,7 +111,7 @@ public class ParTest {
 
         // should support non-uniform scale
 
-        a = par_shapes_create_cylinder(15, 3);
+        a = Objects.requireNonNull(par_shapes_create_cylinder(15, 3));
 
         par_shapes_scale(a, 1.0f, 1.0f, 5.0f);
 
@@ -142,7 +137,7 @@ public class ParTest {
 
         ParShapesMesh a, b;
 
-        a = par_shapes_create_disk(1.0f, slices, center, normal);
+        a = Objects.requireNonNull(par_shapes_create_disk(1.0f, slices, center, normal));
 
         normal
             .put(0, 0.0f)
@@ -153,7 +148,7 @@ public class ParTest {
             .put(1, 0.0f)
             .put(2, 0.2f);
 
-        b = par_shapes_create_disk(0.2f, slices, center, normal);
+        b = Objects.requireNonNull(par_shapes_create_disk(0.2f, slices, center, normal));
 
         par_shapes_merge(a, b);
 
@@ -168,8 +163,8 @@ public class ParTest {
             .put(1, 0.0f)
             .put(2, 0.0f);
 
-        a = par_shapes_create_disk(2.0f, slices, center, normal);
-        b = par_shapes_create_rock(1, 2);
+        a = Objects.requireNonNull(par_shapes_create_disk(2.0f, slices, center, normal));
+        b = Objects.requireNonNull(par_shapes_create_rock(1, 2));
 
         FloatBuffer aabb = memAllocFloat(6);
         par_shapes_compute_aabb(b, aabb);
@@ -185,8 +180,8 @@ public class ParTest {
 
         // create a polyhedron on the Y plane
 
-        a = par_shapes_create_disk(2.0f, slices, center, normal);
-        b = par_shapes_create_dodecahedron();
+        a = Objects.requireNonNull(par_shapes_create_disk(2.0f, slices, center, normal));
+        b = Objects.requireNonNull(par_shapes_create_dodecahedron());
 
         par_shapes_translate(b, 0, 0.934f, 0);
 
@@ -233,10 +228,10 @@ public class ParTest {
 
         int tess = 30;
 
-        a = par_shapes_create_disk(2.5f, tess, O, J);
-        b = par_shapes_create_cylinder(tess, 3);
-        ParShapesMesh c = par_shapes_create_torus(15, tess, 0.1f);
-        ParShapesMesh d = par_shapes_create_disk(1, tess, top_center, J);
+        a = Objects.requireNonNull(par_shapes_create_disk(2.5f, tess, O, J));
+        b = Objects.requireNonNull(par_shapes_create_cylinder(tess, 3));
+        ParShapesMesh c = Objects.requireNonNull(par_shapes_create_torus(15, tess, 0.1f));
+        ParShapesMesh d = Objects.requireNonNull(par_shapes_create_disk(1, tess, top_center, J));
 
         par_shapes_rotate(c, (float)(Math.PI / tess), K);
         par_shapes_translate(c, 0, 0, 1);
@@ -304,8 +299,8 @@ public class ParTest {
             .put(1, 1.0f)
             .put(2, 0.0f);
 
-        ParShapesMesh mesh = par_shapes_create_lsystem(program, 5, 60);
-        ParShapesMesh disk = par_shapes_create_disk(10, 30, O, J);
+        ParShapesMesh mesh = Objects.requireNonNull(par_shapes_create_lsystem(program, 5, 60));
+        ParShapesMesh disk = Objects.requireNonNull(par_shapes_create_disk(10, 30, O, J));
 
         par_shapes_merge(mesh, disk);
 

--- a/modules/core/src/test/java/org/lwjgl/util/yoga/YogaNodeTest.java
+++ b/modules/core/src/test/java/org/lwjgl/util/yoga/YogaNodeTest.java
@@ -11,6 +11,8 @@ package org.lwjgl.util.yoga;
 import org.lwjgl.system.*;
 import org.testng.annotations.*;
 
+import java.util.*;
+
 import static org.lwjgl.system.MemoryStack.*;
 import static org.lwjgl.util.yoga.Yoga.*;
 import static org.lwjgl.util.yoga.YogaNode.*;
@@ -49,7 +51,7 @@ public class YogaNodeTest {
         assertEquals(0, (int)child1.getLayoutY());
         assertEquals(40, (int)child2.getLayoutY());
 
-        YGNodeGetBaselineFunc(child2.node).free();
+        Objects.requireNonNull(YGNodeGetBaselineFunc(child2.node)).free();
     }
 
     private static YGMeasureFunc getTestMeasureFunc(float testWidth, float testHeight) {

--- a/modules/generator/src/main/kotlin/org/lwjgl/generator/CallbackFunction.kt
+++ b/modules/generator/src/main/kotlin/org/lwjgl/generator/CallbackFunction.kt
@@ -70,17 +70,22 @@ import static org.lwjgl.system.MemoryUtil.*;
                 .toJavaDoc(indentation = "", see = see, since = since))
         print("""${access.modifier}abstract class $className extends Callback implements ${className}I {
 
-    /** Creates a {@code $className} instance from the specified function pointer. */
-    @Nullable
+    /**
+     * Creates a {@code $className} instance from the specified function pointer.
+     *
+     * @return the new {@code $className}
+     */
     public static $className create(long functionPointer) {
-        if (functionPointer == NULL) {
-            return null;
-        }
-
         ${className}I instance = Callback.get(functionPointer);
         return instance instanceof $className
             ? ($className)instance
             : new Container(functionPointer, instance);
+    }
+
+    /** Like {@link #create(long) create}, but returns {@code null} if {@code functionPointer} is {@link #NULL}. */
+    @Nullable
+    public static $className createSafe(long functionPointer) {
+        return functionPointer == NULL ? null : create(functionPointer);
     }
 
     /** Creates a {@code $className} instance that delegates to the specified {@code ${className}I} instance. */

--- a/modules/generator/src/main/kotlin/org/lwjgl/generator/CallbackFunction.kt
+++ b/modules/generator/src/main/kotlin/org/lwjgl/generator/CallbackFunction.kt
@@ -54,7 +54,9 @@ class CallbackFunction(
         print(HEADER)
         println("package $packageName;\n")
 
-        print("""import org.lwjgl.system.*;
+        print("""import javax.annotation.*;
+
+import org.lwjgl.system.*;
 
 import static org.lwjgl.system.MemoryUtil.*;
 
@@ -69,6 +71,7 @@ import static org.lwjgl.system.MemoryUtil.*;
         print("""${access.modifier}abstract class $className extends Callback implements ${className}I {
 
     /** Creates a {@code $className} instance from the specified function pointer. */
+    @Nullable
     public static $className create(long functionPointer) {
         if (functionPointer == NULL) {
             return null;

--- a/modules/generator/src/main/kotlin/org/lwjgl/generator/FunctionModifiers.kt
+++ b/modules/generator/src/main/kotlin/org/lwjgl/generator/FunctionModifiers.kt
@@ -179,3 +179,14 @@ class Construct(
 object Address : FunctionModifier {
     override val isSpecial = false
 }
+
+/** Marks a pointer or Java instance return type as non-nullable. */
+object Nonnull : FunctionModifier {
+    override val isSpecial = false
+
+    override fun validate(func: Func) {
+        if (func.returns.nativeType !is PointerType && func.returns.nativeType !is JObjectType)
+            throw IllegalArgumentException("The Nonnull modifier can only be applied on functions with pointer or Java instance return types.")
+    }
+
+}

--- a/modules/generator/src/main/kotlin/org/lwjgl/generator/Functions.kt
+++ b/modules/generator/src/main/kotlin/org/lwjgl/generator/Functions.kt
@@ -215,6 +215,12 @@ class Func(
             } else {
                 "$it $name"
             }
+        }.let {
+            if (nativeType.isReference && has(nullable)) {
+                "@Nullable $it"
+            } else {
+                it
+            }
         }
 
     private fun Parameter.asNativeMethodParam(nativeOnly: Boolean) =
@@ -637,6 +643,10 @@ class Func(
 
         printUnsafeJavadoc(constantMacro, nativeOnly)
 
+        if (returns.nativeType is JObjectType && !has(Nonnull)) {
+            println("$t@Nullable")
+        }
+
         val retType = returnsNativeMethodType
 
         if (nativeOnly) {
@@ -670,6 +680,9 @@ class Func(
         println()
 
         printUnsafeJavadoc(constantMacro)
+        if (returns.nativeType is JObjectType && !has(Nonnull)) {
+            println("$t@Nullable")
+        }
         print("$t${if (constantMacro) "private " else accessModifier}static $returnsNativeMethodType n$name(")
         printList(getNativeParams()) {
             if (it.isFunctionProvider)

--- a/modules/generator/src/main/kotlin/org/lwjgl/generator/Functions.kt
+++ b/modules/generator/src/main/kotlin/org/lwjgl/generator/Functions.kt
@@ -789,11 +789,16 @@ class Func(
 
         // Method signature
 
+        if (returns.nativeType.isReference && !has(Nonnull)) {
+            println("$t@Nullable")
+        }
+
         val retType = returnsJavaMethodType
 
         val retTypeAnnotation = returns.nativeType.annotation(retType, has(const))
-        if (retTypeAnnotation != null)
+        if (retTypeAnnotation != null) {
             println("$t$retTypeAnnotation")
+        }
 
         print("$t${if (constantMacro) "private " else accessModifier}static $retType $name(")
         printList(getNativeParams()) {
@@ -1382,11 +1387,16 @@ class Func(
 
         // Method signature
 
+        if (returns.nativeType.isReference && !has(Nonnull)) {
+            println("$t@Nullable")
+        }
+
         val retType = returns.transformDeclarationOrElse(transforms, returnsJavaMethodType, false, false)!!
 
         val retTypeAnnotation = returns.nativeType.annotation(retType, has(const))
-        if (retTypeAnnotation != null)
+        if (retTypeAnnotation != null) {
             println("$t$retTypeAnnotation")
+        }
 
         print("$t${if (constantMacro) "private " else accessModifier}static $retType $name(")
         printList(getParams { it !== JNI_ENV }) {

--- a/modules/generator/src/main/kotlin/org/lwjgl/generator/GeneratorTarget.kt
+++ b/modules/generator/src/main/kotlin/org/lwjgl/generator/GeneratorTarget.kt
@@ -358,7 +358,9 @@ fun packageInfo(
             print(HEADER)
             println()
             println(processDocumentation(documentation, forcePackage = true).toJavaDoc(indentation = "", see = see, since = since))
-            println("package $packageName;\n")
+            println("""@org.lwjgl.system.NonnullDefault
+package $packageName;
+""")
         }
     }
 

--- a/modules/generator/src/main/kotlin/org/lwjgl/generator/GlobalTypes.kt
+++ b/modules/generator/src/main/kotlin/org/lwjgl/generator/GlobalTypes.kt
@@ -4,7 +4,7 @@
  */
 package org.lwjgl.generator
 
-val void = NativeType("void", TypeMapping.VOID)
+val void = "void".void
 val opaque_p = "void".p
 val void_p = PointerType("void", PointerMapping.DATA)
 val void_pp = void_p.p

--- a/modules/generator/src/main/kotlin/org/lwjgl/generator/JNI.kt
+++ b/modules/generator/src/main/kotlin/org/lwjgl/generator/JNI.kt
@@ -57,6 +57,7 @@ object JNI : GeneratorTargetNative("org.lwjgl.system", "JNI") {
                 """
             )}
             """
+		javaImport("javax.annotation.*")
     }
 
     override fun PrintWriter.generateJava() {
@@ -84,7 +85,7 @@ object JNI : GeneratorTargetNative("org.lwjgl.system", "JNI") {
         sortedSignaturesArray.forEach {
             print("${t}public static native ${it.returnType.nativeMethodType} ${it.signature}(long $FUNCTION_ADDRESS")
             if (it.arguments.isNotEmpty())
-                print(it.arguments.asSequence().mapIndexed { i, param -> if (param is ArrayType) "${(param.mapping as PointerMapping).primitive}[] param$i" else "${param.nativeMethodType} param$i" }.joinToString(", ", prefix = ", "))
+                print(it.arguments.asSequence().mapIndexed { i, param -> if (param is ArrayType) "@Nullable ${(param.mapping as PointerMapping).primitive}[] param$i" else "${param.nativeMethodType} param$i" }.joinToString(", ", prefix = ", "))
             println(");")
         }
         println("\n}")

--- a/modules/generator/src/main/kotlin/org/lwjgl/generator/NativeClass.kt
+++ b/modules/generator/src/main/kotlin/org/lwjgl/generator/NativeClass.kt
@@ -409,7 +409,7 @@ class NativeClass(
         if (hasFunctions || binding is SimpleBinding) {
             // TODO: This is horrible. Refactor so that we build imports after code generation.
             if (functions.any {
-                it.parameters.any {
+                (it.returns.nativeType.isReference && !it.has(Nonnull)) || it.parameters.any {
                     it.nativeType.isReference && it.has(nullable)
                 }
             }) {

--- a/modules/generator/src/main/kotlin/org/lwjgl/generator/NativeClass.kt
+++ b/modules/generator/src/main/kotlin/org/lwjgl/generator/NativeClass.kt
@@ -408,6 +408,14 @@ class NativeClass(
         val hasFunctions = !_functions.isEmpty()
         if (hasFunctions || binding is SimpleBinding) {
             // TODO: This is horrible. Refactor so that we build imports after code generation.
+            if (functions.any {
+                it.parameters.any {
+                    it.nativeType.isReference && it.has(nullable)
+                }
+            }) {
+                println("import javax.annotation.*;\n")
+            }
+
             val hasBuffers = functions.any { it.returns.nativeType.isPointerData || it.hasParam { it.nativeType.isPointerData } }
 
             if (hasBuffers) {

--- a/modules/generator/src/main/kotlin/org/lwjgl/generator/NativeClass.kt
+++ b/modules/generator/src/main/kotlin/org/lwjgl/generator/NativeClass.kt
@@ -411,7 +411,7 @@ class NativeClass(
             if (functions.any {
                 (it.returns.nativeType.isReference && !it.has(Nonnull)) || it.parameters.any {
                     it.nativeType.isReference && it.has(nullable)
-                }
+                } || it.has<MapPointer>()
             }) {
                 println("import javax.annotation.*;\n")
             }

--- a/modules/generator/src/main/kotlin/org/lwjgl/generator/Structs.kt
+++ b/modules/generator/src/main/kotlin/org/lwjgl/generator/Structs.kt
@@ -485,6 +485,8 @@ $indentation}"""
         print(HEADER)
         println("package $packageName;\n")
 
+        println("import javax.annotation.*;\n")
+
         println("import java.nio.*;\n")
 
         if (mallocable || members.any { m -> m.nativeType.let {
@@ -603,7 +605,7 @@ $indentation}"""
 
         print("""
 
-    $className(long address, ByteBuffer container) {
+    $className(long address, @Nullable ByteBuffer container) {
         super(address, container);
     }
 
@@ -680,6 +682,7 @@ $indentation}"""
 
         print("""
     /** Returns a new {@link $className} instance for the specified memory address or {@code null} if the address is {@code NULL}. */
+    @Nullable
     public static $className create(long address) {
         return address == NULL ? null : new $className(address, null);
     }
@@ -691,6 +694,7 @@ $indentation}"""
      *
      * @param $BUFFER_CAPACITY_PARAM the buffer capacity
      */
+    @Nullable
     public static Buffer malloc(int $BUFFER_CAPACITY_PARAM) {
         return create(__malloc($BUFFER_CAPACITY_PARAM, SIZEOF), $BUFFER_CAPACITY_PARAM);
     }
@@ -700,6 +704,7 @@ $indentation}"""
      *
      * @param $BUFFER_CAPACITY_PARAM the buffer capacity
      */
+    @Nullable
     public static Buffer calloc(int $BUFFER_CAPACITY_PARAM) {
         return create(nmemCalloc($BUFFER_CAPACITY_PARAM, SIZEOF), $BUFFER_CAPACITY_PARAM);
     }
@@ -722,6 +727,7 @@ $indentation}"""
      * @param address  the memory address
      * @param $BUFFER_CAPACITY_PARAM the buffer capacity
      */
+    @Nullable
     public static Buffer create(long address, int $BUFFER_CAPACITY_PARAM) {
         return address == NULL ? null : new Buffer(address, null, -1, 0, $BUFFER_CAPACITY_PARAM, $BUFFER_CAPACITY_PARAM);
     }
@@ -881,7 +887,7 @@ ${validations.joinToString("\n")}
 
         print("""
 
-        Buffer(long address, ByteBuffer container, int mark, int pos, int lim, int cap) {
+        Buffer(long address, @Nullable ByteBuffer container, int mark, int pos, int lim, int cap) {
             super(address, container, mark, pos, lim, cap);
         }
 
@@ -891,7 +897,7 @@ ${validations.joinToString("\n")}
         }
 
         @Override
-        protected Buffer newBufferInstance(long address, ByteBuffer container, int mark, int pos, int lim, int cap) {
+        protected Buffer newBufferInstance(long address, @Nullable ByteBuffer container, int mark, int pos, int lim, int cap) {
             return new Buffer(address, container, mark, pos, lim, cap);
         }
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/assimp/templates/Assimp.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/assimp/templates/Assimp.kt
@@ -1349,7 +1349,7 @@ val Assimp = "Assimp".nativeClass(packageName = ASSIMP_PACKAGE, prefix = "ai", p
             "Will be used to open the model file itself and any other files the loader needs to open. Pass #NULL to use the default implementation."
         ),
 
-        returnDoc = "Pointer to the imported data or NULL if the import failed."
+        returnDoc = "Pointer to the imported data or #NULL if the import failed."
     )
 
     aiScene_p(
@@ -2869,7 +2869,7 @@ x1""")}
         "ASSIMP_CFLAGS_SINGLETHREADED"..0x10
     ).noPrefix()
 
-    const..charASCII_p(
+    Nonnull..const..charASCII_p(
         "GetLegalString",
         "Returns a string with legal copyright and licensing information about Assimp. The string may include multiple lines.",
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/glfw/templates/GLFW.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/glfw/templates/GLFW.kt
@@ -827,7 +827,7 @@ val GLFW = "GLFW".nativeClass(packageName = GLFW_PACKAGE, prefix = "GLFW", bindi
         since = "version 1.0"
     )
 
-    const..charASCII_p(
+    Nonnull..const..charASCII_p(
         "GetVersionString",
         """
         Returns the compile-time generated version string of the GLFW library binary. It describes the version, platform, compiler and any platform-specific

--- a/modules/templates/src/main/kotlin/org/lwjgl/nuklear/templates/nuklear.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/nuklear/templates/nuklear.kt
@@ -814,6 +814,7 @@ nk_style_pop_vec2(ctx);""")}
 
             ctx
         )
+
         void(
             "free",
             """

--- a/modules/templates/src/main/kotlin/org/lwjgl/openal/ALCTypes.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/openal/ALCTypes.kt
@@ -8,7 +8,7 @@ import org.lwjgl.generator.*
 
 // void
 
-val ALCvoid = NativeType("ALCvoid", TypeMapping.VOID)
+val ALCvoid = "ALCvoid".void
 val ALCvoid_p = PointerType("ALCvoid", PointerMapping.DATA)
 
 // numeric

--- a/modules/templates/src/main/kotlin/org/lwjgl/openal/ALTypes.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/openal/ALTypes.kt
@@ -28,7 +28,7 @@ fun config() {
 
 // void
 
-val ALvoid = NativeType("ALvoid", TypeMapping.VOID)
+val ALvoid = "ALvoid".void
 val ALvoid_p = PointerType("ALvoid", PointerMapping.DATA)
 
 // numeric

--- a/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/WGL_NV_DX_interop.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/opengl/templates/WGL_NV_DX_interop.kt
@@ -49,7 +49,7 @@ val WGL_NV_DX_interop = "WGLNVDXInterop".nativeClassWGL("WGL_NV_DX_interop", NV)
         "",
 
         HANDLE.IN("device", "")
-    );
+    )
 
     HANDLE(
         "DXRegisterObjectNV",
@@ -63,7 +63,7 @@ val WGL_NV_DX_interop = "WGLNVDXInterop".nativeClassWGL("WGL_NV_DX_interop", NV)
         ),
         GLenum.IN("type", "the GL object type that will map to the DirectX resource being shared"),
         GLenum.IN("access", "indicates the intended usage of the resource in GL", accessModes)
-    );
+    )
 
 
     BOOL(

--- a/modules/templates/src/main/kotlin/org/lwjgl/openvr/OpenVR.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/openvr/OpenVR.kt
@@ -42,6 +42,7 @@ val OPENVR_FNTABLE_BINDING: APIBinding = Generator.register(object : APIBinding(
         javaImport(
             "java.nio.*",
             "java.util.function.*",
+            "javax.annotation.Nullable",
             "org.lwjgl.*",
             "static org.lwjgl.openvr.VR.*",
             "static org.lwjgl.system.MemoryStack.*",
@@ -72,7 +73,7 @@ val OPENVR_FNTABLE_BINDING: APIBinding = Generator.register(object : APIBinding(
             VRTrackedCamera
         )
 
-        println(interfaces.joinToString("\n$t", prefix = t) { "public static ${it.capabilitiesClass} ${it.capabilitiesField};" })
+        println(interfaces.joinToString("\n$t", prefix = t) { "@Nullable public static ${it.capabilitiesClass} ${it.capabilitiesField};" })
 
         // Common constructor
         print("""
@@ -99,6 +100,7 @@ val OPENVR_FNTABLE_BINDING: APIBinding = Generator.register(object : APIBinding(
         print("""
     }
 
+    @Nullable
     private static <T> T getGenericInterface(String interfaceNameVersion, LongFunction<T> supplier) {
         try (MemoryStack stack = stackPush()) {
             IntBuffer peError = stack.mallocInt(1);

--- a/modules/templates/src/main/kotlin/org/lwjgl/ovr/templates/OVR.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/ovr/templates/OVR.kt
@@ -521,7 +521,7 @@ ENABLE_WARNINGS()""")
         ovrErrorInfo_p.OUT("errorInfo", "The last ##OVRErrorInfo for the current thread")
     )
 
-    const..charUTF8_p(
+    Nonnull..const..charUTF8_p(
         "GetVersionString",
         """
         Returns the version string representing the LibOVRRT version.

--- a/modules/templates/src/main/kotlin/org/lwjgl/system/dyncall/DynCallTypes.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/system/dyncall/DynCallTypes.kt
@@ -34,7 +34,7 @@ fun config() {
 val DCCallVM_p = "DCCallVM".p
 val DCstruct_p = "DCstruct".p
 
-val DCvoid = NativeType("DCvoid", TypeMapping.VOID)
+val DCvoid = "DCvoid".void
 
 val DCbool = typedef(intb, "DCbool")
 val DCchar = typedef(char, "DCchar")

--- a/modules/templates/src/main/kotlin/org/lwjgl/system/jawt/JAWTTypes.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/system/jawt/JAWTTypes.kt
@@ -74,8 +74,8 @@ val JAWT_p = struct(JAWT_PACKAGE, "JAWT") {
     nullable..opaque_p.member("SynthesizeWindowActivation", "")
 }.p
 
-val Component = NativeType("jobject", TypeMapping("jobject", java.awt.Component::class.java, java.awt.Component::class.java))
-val Frame = NativeType("jobject", TypeMapping("jobject", java.awt.Frame::class.java, java.awt.Frame::class.java))
+val Component = java.awt.Component::class.jobject
+val Frame = java.awt.Frame::class.jobject
 
 fun config() {
     packageInfo(

--- a/modules/templates/src/main/kotlin/org/lwjgl/system/jni/JNITypes.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/system/jni/JNITypes.kt
@@ -25,27 +25,27 @@ val jlong = IntegerType("jlong", PrimitiveMapping.LONG)
 val jfloat = IntegerType("jfloat", PrimitiveMapping.FLOAT)
 val jdouble = IntegerType("jdouble", PrimitiveMapping.DOUBLE)
 
-val jbooleanArray = NativeType("jbooleanArray", TypeMapping("jbooleanArray", ByteArray::class, ByteArray::class))
-val jbyteArray = NativeType("jbyteArray", TypeMapping("jbyteArray", ByteArray::class, ByteArray::class))
-val jcharArray = NativeType("jcharArray", TypeMapping("jcharArray", CharArray::class, CharArray::class))
-val jshortArray = NativeType("jshortArray", TypeMapping("jshortArray", ShortArray::class, ShortArray::class))
-val jintArray = NativeType("jintArray", TypeMapping("jintArray", IntArray::class, IntArray::class))
-val jlongArray = NativeType("jlongArray", TypeMapping("jlongArray", LongArray::class, LongArray::class))
-val jfloatArray = NativeType("jfloatArray", TypeMapping("jfloatArray", FloatArray::class, FloatArray::class))
-val jdoubleArray = NativeType("jdoubleArray", TypeMapping("jdoubleArray", DoubleArray::class, DoubleArray::class))
+val jbooleanArray = JObjectType("jbooleanArray", ByteArray::class)
+val jbyteArray = JObjectType("jbyteArray", ByteArray::class)
+val jcharArray = JObjectType("jcharArray", CharArray::class)
+val jshortArray = JObjectType("jshortArray", ShortArray::class)
+val jintArray = JObjectType("jintArray", IntArray::class)
+val jlongArray = JObjectType("jlongArray", LongArray::class)
+val jfloatArray = JObjectType("jfloatArray", FloatArray::class)
+val jdoubleArray = JObjectType("jdoubleArray", DoubleArray::class)
 
 val jsize = typedef(jint, "jsize")
 
-val jclass = NativeType("jclass", TypeMapping("jclass", Class::class, Class::class))
+val jclass = JObjectType("jclass", Class::class)
 val jmethodID = "jmethodID".opaque_p
 val jfieldID = "jfieldID".opaque_p
 
-val jobject = NativeType("jobject", TypeMapping("jobject", Any::class.java, Any::class.java))
+val jobject = Any::class.jobject
 val jobject_p = "jobject".opaque_p
 
 val jobjectRefType = "jobjectRefType".enumType
 
-val jstring = NativeType("jstring", TypeMapping("jstring", String::class, String::class))
+val jstring = JObjectType("jstring", String::class)
 
 val java_lang_reflect_Method = java.lang.reflect.Method::class.jobject
 val java_lang_reflect_Field = java.lang.reflect.Field::class.jobject

--- a/modules/templates/src/main/kotlin/org/lwjgl/system/macosx/templates/ObjC.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/system/macosx/templates/ObjC.kt
@@ -1105,7 +1105,7 @@ void myMethodIMP(id self, SEL _cmd)
         """
     )
 
-    (objc_method_description_p)(
+    objc_method_description_p(
         "protocol_copyMethodDescriptionList",
         """
         Returns an array of method descriptions of methods meeting a given specification for a given protocol.

--- a/modules/templates/src/main/kotlin/org/lwjgl/system/windows/WindowsTypes.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/system/windows/WindowsTypes.kt
@@ -19,7 +19,7 @@ val SaveLastError = Code(nativeAfterCall = "${t}saveLastError();")
 
 // UNICODE is defined WindowsLWJGL.h, so all T* types below are UTF16.
 
-val VOID = NativeType("VOID", TypeMapping.VOID)
+val VOID = "VOID".void
 
 val HANDLE = "HANDLE".opaque_p
 val HANDLE_p = HANDLE.p

--- a/modules/templates/src/main/kotlin/org/lwjgl/util/lmdb/templates/lmdb.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/util/lmdb/templates/lmdb.kt
@@ -254,7 +254,7 @@ ENABLE_WARNINGS()""")
         returnDoc = "the library version as a string"
     )
 
-    charASCII_p(
+    Nonnull..charASCII_p(
         "strerror",
         """
         Returns a string describing a given error code.

--- a/modules/templates/src/main/kotlin/org/lwjgl/util/lz4/templates/LZ4.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/util/lz4/templates/LZ4.kt
@@ -43,7 +43,7 @@ ENABLE_WARNINGS()""")
     StringConstant("Version string.", "VERSION_STRING".."""LZ4_VERSION_MAJOR + "." + LZ4_VERSION_MINOR + "." + LZ4_VERSION_RELEASE""")
 
     int("versionNumber", "Returns the version number.")
-    const..charASCII_p("versionString", "Returns the version string.")
+    Nonnull..const..charASCII_p("versionString", "Returns the version string.")
 
     IntConstant(
         "Maximum input size.",

--- a/modules/templates/src/main/kotlin/org/lwjgl/util/yoga/templates/yoga.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/util/yoga/templates/yoga.kt
@@ -755,7 +755,7 @@ div {
 
     fun YG_TYPE_TO_STRING(type: IntegerType) {
         val name = type.name.substring(2)
-        const..charASCII_p(
+        Nonnull..const..charASCII_p(
             "${name}ToString",
             "",
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/util/zstd/templates/Zstd.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/util/zstd/templates/Zstd.kt
@@ -87,7 +87,7 @@ ENABLE_WARNINGS()""")
     StringConstant("Version string.", "VERSION_STRING".."""ZSTD_VERSION_MAJOR + "." + ZSTD_VERSION_MINOR + "." + ZSTD_VERSION_RELEASE""")
 
     unsigned("versionNumber", "Returns the version number.")
-    const..charASCII_p("versionString", "Returns the version string.")
+    Nonnull..const..charASCII_p("versionString", "Returns the version string.")
 
     LongConstant(
         "Content size.",
@@ -207,7 +207,7 @@ ENABLE_WARNINGS()""")
         size_t.IN("code", "")
     )
 
-    const..charASCII_p(
+    Nonnull..const..charASCII_p(
         "getErrorName",
         "Provides readable string from an error code.",
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/util/zstd/templates/ZstdErrors.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/util/zstd/templates/ZstdErrors.kt
@@ -52,7 +52,7 @@ ENABLE_WARNINGS()""")*/
         size_t.IN("functionResult", "")
     )
 
-    const..charASCII_p(
+    Nonnull..const..charASCII_p(
         "getErrorString",
         "",
 

--- a/update-dependencies.xml
+++ b/update-dependencies.xml
@@ -10,6 +10,7 @@
     <import file="${config}/build-definitions.xml" id="defs"/>
 
     <!-- *********************************** -->
+    <property name="findbugs" value="3.0.2"/>
     <property name="testng" value="6.11"/>
     <property name="jcommander" value="1.72"/>
     <property name="joml" value="1.9.7"/>
@@ -67,6 +68,7 @@
 
     <!-- Downloads the Java dependencies. -->
     <target name="-lib-download" unless="lib-uptodate">
+        <update-mvn name="findbugs" group="com/google/code/findbugs" artifact="jsr305" version="${findbugs}" dest="${lib}"/>
         <update-mvn name="JCommander" group="com/beust" artifact="jcommander" version="${jcommander}" dest="${lib}" sources="false"/>
         <update-mvn name="TestNG" group="org/testng" artifact="testng" version="${testng}" dest="${lib}"/>
         <update-mvn name="JOML" group="org/joml" artifact="joml" version="${joml}" dest="${lib}"/>


### PR DESCRIPTION
As previously discussed in Slack, this PR adds JSR-305 like annotations to support null-analysis and to enhance Kotlin interopertability. (See [here](https://kotlinlang.org/docs/reference/java-interop.html#jsr-305-support) for more info.)

@Spasi As suggested I did not add `@Nullable` to most stack allocation methods (the exception being String conversion methods, since they can also be `null` when the passed `CharSequence` is `null`).
I'm open for further suggestions and will implement them ASAP if requested.