### PR TITLE
Fix the signature of JNINativeInterface::ToReflectedField

### DIFF
--- a/modules/templates/src/main/kotlin/org/lwjgl/system/jni/templates/JNINativeInterface.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/system/jni/templates/JNINativeInterface.kt
@@ -104,7 +104,7 @@ val JNINativeInterface = "JNINativeInterface".nativeClass(JNI_PACKAGE, prefix = 
         jboolean.IN("isStatic", "must be set to #TRUE if the method ID refers to a static field, and # FALSE otherwise")
     )
 
-    java_lang_reflect_Method(
+    java_lang_reflect_Field(
         "ToReflectedField",
         "Converts a field ID derived from {@code cls} to a ##Field object.",
 

--- a/modules/templates/src/main/kotlin/org/lwjgl/system/macosx/templates/LibC.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/system/macosx/templates/LibC.kt
@@ -13,5 +13,5 @@ val libc = "LibC".nativeClass(MACOSX_PACKAGE, binding = libSystem.binding!!.dele
     pid_t(
         "getpid",
         "Returns the process ID of the calling process."
-    );
+    )
 }


### PR DESCRIPTION
Fixes the signature of JNINativeInterface::ToReflectedField. (The method returned a `java.lang.reflect.Method` instead of a `java.lang.reflect.Field`.)

Also removes an unnecessary semicolon in the LibC mac template.