### PR TITLE
NULL value for more readability

### DIFF
--- a/modules/templates/src/main/kotlin/org/lwjgl/glfw/templates/GLFW.kt
+++ b/modules/templates/src/main/kotlin/org/lwjgl/glfw/templates/GLFW.kt
@@ -35,6 +35,12 @@ val GLFW = "GLFW".nativeClass(packageName = GLFW_PACKAGE, prefix = "GLFW", bindi
     )
 
     IntConstant(
+        "NULL value.",
+
+        "NULL".."0"
+    )
+
+    IntConstant(
         "Boolean values.",
         "TRUE".."1",
         "FALSE".."0"


### PR DESCRIPTION
Example:
`long window = glfwCreateWindow(640, 480, "Inception", 0, 0);`

At the moment I'm doing something like that:
`public static final Integer GLFW_NULL = 0;`
`...`
`long window = glfwCreateWindow(640, 480, "Inception", GLFW_NULL, GLFW_NULL);`