### PR TITLE
build: make native modules optional at runtime

### DIFF
--- a/modules/module-info-gen/src/main/java/org/lwjgl/tool/ModuleInfoGen.java
+++ b/modules/module-info-gen/src/main/java/org/lwjgl/tool/ModuleInfoGen.java
@@ -72,7 +72,7 @@ public final class ModuleInfoGen {
             .orElseThrow(() -> new IllegalStateException("Failed to find module name"))
             .group(1);
 
-        if (Pattern.compile("[{;]\\s*requires(?:\\s+transitive)?\\s+" + module + ".natives\\s*;").matcher(moduleInfo).find()) {
+        if (Pattern.compile("[{;]\\s*requires(?:\\s+static)?\\s+" + module + ".natives\\s*;").matcher(moduleInfo).find()) {
             compileModuleInfo(module + ".natives", "module " + module + ".natives {}");
         }
 

--- a/modules/module-info-gen/src/main/resources/org.lwjgl.assimp.java
+++ b/modules/module-info-gen/src/main/resources/org.lwjgl.assimp.java
@@ -4,7 +4,7 @@
  */
 module org.lwjgl.assimp {
     requires transitive org.lwjgl;
-    requires transitive org.lwjgl.assimp.natives;
+    requires static org.lwjgl.assimp.natives;
 
     exports org.lwjgl.assimp;
 }

--- a/modules/module-info-gen/src/main/resources/org.lwjgl.bgfx.java
+++ b/modules/module-info-gen/src/main/resources/org.lwjgl.bgfx.java
@@ -4,7 +4,7 @@
  */
 module org.lwjgl.bgfx {
     requires transitive org.lwjgl;
-    requires transitive org.lwjgl.bgfx.natives;
+    requires static org.lwjgl.bgfx.natives;
 
     exports org.lwjgl.bgfx;
 }

--- a/modules/module-info-gen/src/main/resources/org.lwjgl.glfw.java
+++ b/modules/module-info-gen/src/main/resources/org.lwjgl.glfw.java
@@ -4,7 +4,7 @@
  */
 module org.lwjgl.glfw {
     requires transitive org.lwjgl;
-    requires transitive org.lwjgl.glfw.natives;
+    requires static org.lwjgl.glfw.natives;
 
     exports org.lwjgl.glfw;
 }

--- a/modules/module-info-gen/src/main/resources/org.lwjgl.java
+++ b/modules/module-info-gen/src/main/resources/org.lwjgl.java
@@ -5,7 +5,7 @@
 module org.lwjgl {
     requires jdk.unsupported;
 
-    requires transitive org.lwjgl.natives;
+    requires static org.lwjgl.natives;
 
     exports org.lwjgl;
     exports org.lwjgl.system;

--- a/modules/module-info-gen/src/main/resources/org.lwjgl.jemalloc.java
+++ b/modules/module-info-gen/src/main/resources/org.lwjgl.jemalloc.java
@@ -4,7 +4,7 @@
  */
 module org.lwjgl.jemalloc {
     requires transitive org.lwjgl;
-    requires transitive org.lwjgl.jemalloc.natives;
+    requires static org.lwjgl.jemalloc.natives;
 
     exports org.lwjgl.system.jemalloc;
 }

--- a/modules/module-info-gen/src/main/resources/org.lwjgl.lmdb.java
+++ b/modules/module-info-gen/src/main/resources/org.lwjgl.lmdb.java
@@ -4,7 +4,7 @@
  */
 module org.lwjgl.lmdb {
     requires transitive org.lwjgl;
-    requires transitive org.lwjgl.lmdb.natives;
+    requires static org.lwjgl.lmdb.natives;
 
     exports org.lwjgl.util.lmdb;
 }

--- a/modules/module-info-gen/src/main/resources/org.lwjgl.lz4.java
+++ b/modules/module-info-gen/src/main/resources/org.lwjgl.lz4.java
@@ -4,7 +4,7 @@
  */
 module org.lwjgl.lz4 {
     requires transitive org.lwjgl;
-    requires transitive org.lwjgl.lz4.natives;
+    requires static org.lwjgl.lz4.natives;
 
     exports org.lwjgl.util.lz4;
 }

--- a/modules/module-info-gen/src/main/resources/org.lwjgl.nanovg.java
+++ b/modules/module-info-gen/src/main/resources/org.lwjgl.nanovg.java
@@ -4,7 +4,7 @@
  */
 module org.lwjgl.nanovg {
     requires transitive org.lwjgl;
-    requires transitive org.lwjgl.nanovg.natives;
+    requires static org.lwjgl.nanovg.natives;
 
     exports org.lwjgl.nanovg;
 }

--- a/modules/module-info-gen/src/main/resources/org.lwjgl.nfd.java
+++ b/modules/module-info-gen/src/main/resources/org.lwjgl.nfd.java
@@ -4,7 +4,7 @@
  */
 module org.lwjgl.nfd {
     requires transitive org.lwjgl;
-    requires transitive org.lwjgl.nfd.natives;
+    requires static org.lwjgl.nfd.natives;
 
     exports org.lwjgl.util.nfd;
 }

--- a/modules/module-info-gen/src/main/resources/org.lwjgl.nuklear.java
+++ b/modules/module-info-gen/src/main/resources/org.lwjgl.nuklear.java
@@ -4,7 +4,7 @@
  */
 module org.lwjgl.nuklear {
     requires transitive org.lwjgl;
-    requires transitive org.lwjgl.nuklear.natives;
+    requires static org.lwjgl.nuklear.natives;
 
     exports org.lwjgl.nuklear;
 }

--- a/modules/module-info-gen/src/main/resources/org.lwjgl.openal.java
+++ b/modules/module-info-gen/src/main/resources/org.lwjgl.openal.java
@@ -4,7 +4,7 @@
  */
 module org.lwjgl.openal {
     requires transitive org.lwjgl;
-    requires transitive org.lwjgl.openal.natives;
+    requires static org.lwjgl.openal.natives;
 
     exports org.lwjgl.openal;
 }

--- a/modules/module-info-gen/src/main/resources/org.lwjgl.opengl.java
+++ b/modules/module-info-gen/src/main/resources/org.lwjgl.opengl.java
@@ -4,7 +4,7 @@
  */
 module org.lwjgl.opengl {
     requires transitive org.lwjgl;
-    requires transitive org.lwjgl.opengl.natives;
+    requires static org.lwjgl.opengl.natives;
 
     exports org.lwjgl.opengl;
 }

--- a/modules/module-info-gen/src/main/resources/org.lwjgl.opengles.java
+++ b/modules/module-info-gen/src/main/resources/org.lwjgl.opengles.java
@@ -4,7 +4,7 @@
  */
 module org.lwjgl.opengles {
     requires transitive org.lwjgl;
-    requires transitive org.lwjgl.opengles.natives;
+    requires static org.lwjgl.opengles.natives;
 
     exports org.lwjgl.opengles;
 }

--- a/modules/module-info-gen/src/main/resources/org.lwjgl.openvr.java
+++ b/modules/module-info-gen/src/main/resources/org.lwjgl.openvr.java
@@ -4,7 +4,7 @@
  */
 module org.lwjgl.openvr {
     requires transitive org.lwjgl;
-    requires transitive org.lwjgl.openvr.natives;
+    requires static org.lwjgl.openvr.natives;
 
     exports org.lwjgl.openvr;
 }

--- a/modules/module-info-gen/src/main/resources/org.lwjgl.ovr.java
+++ b/modules/module-info-gen/src/main/resources/org.lwjgl.ovr.java
@@ -4,7 +4,7 @@
  */
 module org.lwjgl.ovr {
     requires transitive org.lwjgl;
-    requires transitive org.lwjgl.ovr.natives;
+    requires static org.lwjgl.ovr.natives;
 
     exports org.lwjgl.ovr;
 }

--- a/modules/module-info-gen/src/main/resources/org.lwjgl.par.java
+++ b/modules/module-info-gen/src/main/resources/org.lwjgl.par.java
@@ -4,7 +4,7 @@
  */
 module org.lwjgl.par {
     requires transitive org.lwjgl;
-    requires transitive org.lwjgl.par.natives;
+    requires static org.lwjgl.par.natives;
 
     exports org.lwjgl.util.par;
 }

--- a/modules/module-info-gen/src/main/resources/org.lwjgl.remotery.java
+++ b/modules/module-info-gen/src/main/resources/org.lwjgl.remotery.java
@@ -4,7 +4,7 @@
  */
 module org.lwjgl.remotery {
     requires transitive org.lwjgl;
-    requires transitive org.lwjgl.remotery.natives;
+    requires static org.lwjgl.remotery.natives;
 
     exports org.lwjgl.util.remotery;
 }

--- a/modules/module-info-gen/src/main/resources/org.lwjgl.rpmalloc.java
+++ b/modules/module-info-gen/src/main/resources/org.lwjgl.rpmalloc.java
@@ -4,7 +4,7 @@
  */
 module org.lwjgl.rpmalloc {
     requires transitive org.lwjgl;
-    requires transitive org.lwjgl.rpmalloc.natives;
+    requires static org.lwjgl.rpmalloc.natives;
 
     exports org.lwjgl.system.rpmalloc;
 }

--- a/modules/module-info-gen/src/main/resources/org.lwjgl.sse.java
+++ b/modules/module-info-gen/src/main/resources/org.lwjgl.sse.java
@@ -4,7 +4,7 @@
  */
 module org.lwjgl.sse {
     requires transitive org.lwjgl;
-    requires transitive org.lwjgl.sse.natives;
+    requires static org.lwjgl.sse.natives;
 
     exports org.lwjgl.util.simd;
 }

--- a/modules/module-info-gen/src/main/resources/org.lwjgl.stb.java
+++ b/modules/module-info-gen/src/main/resources/org.lwjgl.stb.java
@@ -4,7 +4,7 @@
  */
 module org.lwjgl.stb {
     requires transitive org.lwjgl;
-    requires transitive org.lwjgl.stb.natives;
+    requires static org.lwjgl.stb.natives;
 
     exports org.lwjgl.stb;
 }

--- a/modules/module-info-gen/src/main/resources/org.lwjgl.tinyexr.java
+++ b/modules/module-info-gen/src/main/resources/org.lwjgl.tinyexr.java
@@ -4,7 +4,7 @@
  */
 module org.lwjgl.tinyexr {
     requires transitive org.lwjgl;
-    requires transitive org.lwjgl.tinyexr.natives;
+    requires static org.lwjgl.tinyexr.natives;
 
     exports org.lwjgl.util.tinyexr;
 }

--- a/modules/module-info-gen/src/main/resources/org.lwjgl.tinyfd.java
+++ b/modules/module-info-gen/src/main/resources/org.lwjgl.tinyfd.java
@@ -4,7 +4,7 @@
  */
 module org.lwjgl.tinyfd {
     requires transitive org.lwjgl;
-    requires transitive org.lwjgl.tinyfd.natives;
+    requires static org.lwjgl.tinyfd.natives;
 
     exports org.lwjgl.util.tinyfd;
 }

--- a/modules/module-info-gen/src/main/resources/org.lwjgl.tootle.java
+++ b/modules/module-info-gen/src/main/resources/org.lwjgl.tootle.java
@@ -4,7 +4,7 @@
  */
 module org.lwjgl.tootle {
     requires transitive org.lwjgl;
-    requires transitive org.lwjgl.tootle.natives;
+    requires static org.lwjgl.tootle.natives;
 
     exports org.lwjgl.util.tootle;
 }

--- a/modules/module-info-gen/src/main/resources/org.lwjgl.xxhash.java
+++ b/modules/module-info-gen/src/main/resources/org.lwjgl.xxhash.java
@@ -4,7 +4,7 @@
  */
 module org.lwjgl.xxhash {
     requires transitive org.lwjgl;
-    requires transitive org.lwjgl.xxhash.natives;
+    requires static org.lwjgl.xxhash.natives;
 
     exports org.lwjgl.util.xxhash;
 }

--- a/modules/module-info-gen/src/main/resources/org.lwjgl.yoga.java
+++ b/modules/module-info-gen/src/main/resources/org.lwjgl.yoga.java
@@ -4,7 +4,7 @@
  */
 module org.lwjgl.yoga {
     requires transitive org.lwjgl;
-    requires transitive org.lwjgl.yoga.natives;
+    requires static org.lwjgl.yoga.natives;
 
     exports org.lwjgl.util.yoga;
 }

--- a/modules/module-info-gen/src/main/resources/org.lwjgl.zstd.java
+++ b/modules/module-info-gen/src/main/resources/org.lwjgl.zstd.java
@@ -4,7 +4,7 @@
  */
 module org.lwjgl.zstd {
     requires transitive org.lwjgl;
-    requires transitive org.lwjgl.zstd.natives;
+    requires static org.lwjgl.zstd.natives;
 
     exports org.lwjgl.util.zstd;
 }


### PR DESCRIPTION
Currently, native modules are required at runtime which is counter-productive when native libraries are meant to be loaded from a separate directory instead of extracting them from a jar.
This PR changes the module declarations of binding to depend "statically" on the native modules (which means that the native modules are required at compile time but optional at runtime). The only regression is that native modules are now no longer visible for modules depending on binding modules. However, this should not be a problem since these modules are empty anyway.