### PR TITLE
updated the class path for Eclipse

### DIFF
--- a/config/ide/eclipse/.classpath
+++ b/config/ide/eclipse/.classpath
@@ -1,14 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="src" path="modules/core/src/generated/java"/>
-	<classpathentry kind="src" path="modules/core/src/main/java" />
-	<classpathentry excluding="org/lwjgl/demo/ovr/" kind="src" path="modules/core/src/test/java"/>
-	<classpathentry kind="src" path="modules/core/src/test/resources"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER">
-		<attributes>
-			<attribute name="org.eclipse.jdt.launching.CLASSPATH_ATTR_LIBRARY_PATH_ENTRY" value="lwjgl3/libs"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="lib" path="libs/testng.jar"/>
+	<classpathentry kind="src" path="modules/generator/src/main/java"/>
+	<classpathentry kind="src" path="modules/lwjgl/core/src/generated/java"/>
+	<classpathentry kind="src" path="modules/lwjgl/core/src/main/java"/>
+	<classpathentry kind="src" path="modules/lwjgl/core/src/test/java"/>
+	<classpathentry kind="lib" path="bin/libs/java/jcommander.jar"/>
+	<classpathentry kind="lib" path="bin/libs/java/joml.jar"/>
+	<classpathentry kind="lib" path="bin/libs/java/jsr305.jar"/>
+	<classpathentry kind="lib" path="bin/libs/java/testng.jar"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry kind="output" path="bin/eclipse"/>
 </classpath>


### PR DESCRIPTION
Related to issue #367 I've updated the eclipse .classpath file.

The steps to set up lwjgl 3 in eclipse are:

1. Check out git project (do not add as existing project)
2. Run ant
- Open terminal
- CD to lwjgl3 directory
- `ant init`
- `ant compile-templates compile-tests`
3. Copy .classpath and .project from lwjgl3/config/ide/eclipse to the root lwjgl3/ directory
4. In Eclipse (File > Import > Existing Project Into Workspace)
- select the root lwjgl3/ directory
5. Related to issue #349 
- Open Build Path > Libraries tab and add the Tools.jar file as an external jar from your /usr/lib/jvm/\<java implementation\>/libs directory
6. If you have TestNG installed right click the /modules/lwjgl/core/src/test/java folder and Run As > TestNG Test
- If you're running Linux expect 25 of 30 passes. For some reason the 5 windows specific tests don't work ¯\\\_(ツ)\_/¯
