### PR TITLE
build: add missing dependencies for demo task

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -684,6 +684,7 @@
         <java classname="${class}" fork="true" failonerror="${failonerror}" spawn="${spawn}" taskname="Demo">
             <classpath>
                 <pathelement path="${module.classpath}"/>
+                <pathelement path="${bin.test}"/>
                 <pathelement path="${bin.samples}"/>
                 <pathelement path="${test.resources}"/>
                 <pathelement path="${lib}/java/testng.jar"/>


### PR DESCRIPTION
Some demos (e.g. OpenCL) depend on utility classes that are in test sourcessets. This is properly configured in IntelliJ but the test outputs have not been added to the classpath in the "demo" task.