### PR TITLE
docs(glfw): clean up glfwCreateStandardCursor

### DIFF
--- a/modules/lwjgl/glfw/src/templates/kotlin/glfw/templates/GLFW.kt
+++ b/modules/lwjgl/glfw/src/templates/kotlin/glfw/templates/GLFW.kt
@@ -2538,7 +2538,6 @@ val GLFW = "GLFW".nativeClass(Module.GLFW, prefix = "GLFW", binding = GLFW_BINDI
 
         ${note(ul(
             "This function must only be called from the main thread.",
-            "The specified image data is copied before this function returns."
         ))}
         """,
 


### PR DESCRIPTION
Removed irrelevant line from glfwCreateStandardCursor documentation that describes copying image data. This function does not handle external image data.