### PR TITLE
fix(GL/GLES): throw an exception for calls without OpenGL context

### DIFF
--- a/doc/notes/3.1.7.md
+++ b/doc/notes/3.1.7.md
@@ -68,7 +68,8 @@ This build includes the following changes:
     * Yoga
     * Parameters of struct multi-setter methods
 - OpenCL: Fixed `CL_DEVICE_PREFERRED_VECTOR_WIDTH_INT` constant name.
-- OpenGL/GLES: The thread-local-free function pointer lookups do not depend on JVMTI anymore.  
+- OpenGL/GLES: The thread-local-free function pointer lookups do not depend on JVMTI anymore.
+- OpenGL/GLES: An exception is now thrown when called from a thread lacking an OpenGL context, instead of crashing the JVM.
 
 #### Breaking Changes
 

--- a/modules/lwjgl/core/src/main/c/org_lwjgl_system_ThreadLocalUtil.c
+++ b/modules/lwjgl/core/src/main/c/org_lwjgl_system_ThreadLocalUtil.c
@@ -5,10 +5,17 @@
 #include "common_tools.h"
 
 static jint JNICALL functionMissingAbort(void) {
-    fprintf(stderr, "[LWJGL] No context is current or an unavailable function was called. The JVM will abort execution. Inspect the crash log to find the responsible Java code.\n");
+    fprintf(stderr, "[LWJGL] A function that is not available in the current context was called. The JVM will abort execution. Inspect the crash log to find the responsible Java code.\n");
     fflush(stderr);
 
     return *((volatile jint *)NULL); // force a segfault
+}
+
+static void JNICALL noContextAbort(void) {
+    jboolean async;
+    JNIEnv* env = getEnv(&async);
+
+    (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/IllegalStateException"), "No LWJGL context found in the current thread.");
 }
 
 EXTERN_C_ENTER
@@ -31,6 +38,12 @@ JNIEXPORT void JNICALL Java_org_lwjgl_system_ThreadLocalUtil_setThreadJNIEnv(JNI
 JNIEXPORT jlong JNICALL Java_org_lwjgl_system_ThreadLocalUtil_getFunctionMissingAbort(JNIEnv *env, jclass clazz) {
     UNUSED_PARAMS(env, clazz)
     return (jlong)(intptr_t)functionMissingAbort;
+}
+
+// getNoContextAbort()J
+JNIEXPORT jlong JNICALL Java_org_lwjgl_system_ThreadLocalUtil_getNoContextAbort(JNIEnv *env, jclass clazz) {
+    UNUSED_PARAMS(env, clazz)
+    return (jlong)(intptr_t)noContextAbort;
 }
 
 EXTERN_C_EXIT

--- a/modules/lwjgl/opengl/src/main/java/org/lwjgl/opengl/GL.java
+++ b/modules/lwjgl/opengl/src/main/java/org/lwjgl/opengl/GL.java
@@ -205,7 +205,7 @@ public final class GL {
         }
 
         GL.functionProvider = functionProvider;
-        ThreadLocalUtil.setFunctionMissingAddresses(GLCapabilities.class, 3);
+        ThreadLocalUtil.setDefaultCaps(GLCapabilities.class, 3);
     }
 
     /** Unloads the OpenGL native library. */
@@ -214,7 +214,7 @@ public final class GL {
             return;
         }
 
-        ThreadLocalUtil.setFunctionMissingAddresses(null, 3);
+        ThreadLocalUtil.setDefaultCaps(null, 3);
 
         capabilitiesWGL = null;
         capabilitiesGLX = null;

--- a/modules/lwjgl/opengles/src/main/java/org/lwjgl/opengles/GLES.java
+++ b/modules/lwjgl/opengles/src/main/java/org/lwjgl/opengles/GLES.java
@@ -141,7 +141,7 @@ public final class GLES {
         }
 
         GLES.functionProvider = functionProvider;
-        ThreadLocalUtil.setFunctionMissingAddresses(GLESCapabilities.class, 3);
+        ThreadLocalUtil.setDefaultCaps(GLESCapabilities.class, 3);
     }
     /** Unloads the OpenGL ES native library. */
     public static void destroy() {
@@ -149,7 +149,7 @@ public final class GLES {
             return;
         }
 
-        ThreadLocalUtil.setFunctionMissingAddresses(null, 3);
+        ThreadLocalUtil.setDefaultCaps(null, 3);
 
         if (functionProvider instanceof NativeResource) {
             ((NativeResource)functionProvider).free();


### PR DESCRIPTION
Before, a cross-thread  would cause the JVM to crash (in 3.1.6, without any clear indication as to why).  Now, an exception will be raised instead, which could be handled by the game (e.g. `Thread.setDefaultUncaughtExceptionHandler`) and by default is logged (`Exception in thread "Thread-1" java.lang.IllegalStateException: No LWJGL context found in the current thread.`).

A simple test case, which triggers when `C` is pressed in the space game demo:

```diff
diff --git a/src/org/lwjgl/demo/game/SpaceGame.java b/src/org/lwjgl/demo/game/SpaceGame.java
index ab93c40..982f8cf 100644
--- a/src/org/lwjgl/demo/game/SpaceGame.java
+++ b/src/org/lwjgl/demo/game/SpaceGame.java
@@ -276,6 +276,15 @@ public class SpaceGame {
                 if (key == GLFW_KEY_ESCAPE && action == GLFW_RELEASE) {
                     glfwSetWindowShouldClose(window, true);
                 }
+                if (key == GLFW_KEY_C && action == GLFW_PRESS) {
+                    new Thread() {
+                        @Override
+                        public void run() {
+                            System.out.println("Trying to call glGenTextures cross-thread...");
+                            System.out.println("Result: " + glGenTextures());
+                        }
+                    }.start();
+                }
                 if (action == GLFW_PRESS || action == GLFW_REPEAT) {
                     keyDown[key] = true;
                 } else {
```

The code for this change was already partially added in 622d5a2b41ee9f1e423626ea294a08bbba5c48e6, but it called `functionMissingAbort` in that case which crashes the JVM (although it does also log a warning).  I've cleaned up the change there so that it raises an `IllegalStateException` instead, which should be much more usable; this can happen from a user error and I think it's better to handle it in a user-friendly way.  (`functionMissingAbort`, as far as I can tell, can't happen that way so I think it's fine to leave it as crashing the JVM).