### PR TITLE
Make Listener3i take ALint instead of ALfloat

### DIFF
--- a/doc/notes/3.2.1.md
+++ b/doc/notes/3.2.1.md
@@ -61,6 +61,7 @@ This build includes the following changes:
 - Core: Fixed text decoding from buffer with `.position() > 0`.
     * Affected all decoders on Java 9+, only UTF-16 on Java 8.
 - Core: Fixed the bounds check in `memCopy`. (#414)
+- OpenAL: Fixed signature of `alListener3i`. (#427)
 - OpenVR: The `pGamePoseArray` parameter of `VRCompositor_WaitGetPoses` is now nullable. (#418)
 - OpenVR: Fixed returned type of `VRRenderModels_GetComponentStateForDevicePath`.
 - OpenVR: Renamed `VRInput_UncompressSkeletalActionData` to `VRInput_DecompressSkeletalBoneData`.

--- a/modules/lwjgl/openal/src/generated/java/org/lwjgl/openal/AL11.java
+++ b/modules/lwjgl/openal/src/generated/java/org/lwjgl/openal/AL11.java
@@ -53,7 +53,7 @@ public class AL11 extends AL10 {
      * @param value3    the third value
      */
     @NativeType("ALvoid")
-    public static void alListener3i(@NativeType("ALenum") int paramName, @NativeType("ALfloat") float value1, @NativeType("ALfloat") float value2, @NativeType("ALfloat") float value3) {
+    public static void alListener3i(@NativeType("ALenum") int paramName, @NativeType("ALint") int value1, @NativeType("ALint") int value2, @NativeType("ALint") int value3) {
         long __functionAddress = AL.getICD().alListener3i;
         if (CHECKS) {
             check(__functionAddress);

--- a/modules/lwjgl/openal/src/templates/kotlin/openal/templates/AL11.kt
+++ b/modules/lwjgl/openal/src/templates/kotlin/openal/templates/AL11.kt
@@ -33,9 +33,9 @@ val AL11 = "AL11".nativeClassAL("AL11") {
         "Sets the 3 dimensional integer values of a listener parameter.",
 
         ALenum("paramName", "the parameter to modify"),
-        ALfloat("value1", "the first value"),
-        ALfloat("value2", "the second value"),
-        ALfloat("value3", "the third value")
+        ALint("value1", "the first value"),
+        ALint("value2", "the second value"),
+        ALint("value3", "the third value")
     )
 
     ALvoid(


### PR DESCRIPTION
Bug in lwjgl's bindings for OpenAL 1.1