### PR TITLE
Relative property location is invalid when building in top-level dirs on linux

### DIFF
--- a/config/linux/build.xml
+++ b/config/linux/build.xml
@@ -75,9 +75,9 @@
             <local name="src.main"/>
             <local name="src.main.rel"/>
             <local name="src.generated"/>
-            <property name="src.main" location="${module.lwjgl}/@{module}/src/main/c" relative="true"/>
-            <property name="src.main.rel" location="${module.lwjgl.rel}/@{module}/src/main/c" relative="true"/>
-            <property name="src.generated" location="${module.lwjgl}/@{module}/src/generated/c" relative="true"/>
+            <property name="src.main" value="${module.lwjgl}/@{module}/src/main/c"/>
+            <property name="src.main.rel" value="${module.lwjgl.rel}/@{module}/src/main/c"/>
+            <property name="src.generated" value="${module.lwjgl}/@{module}/src/generated/c"/>
 
             <local name="name"/>
             <condition property="name" value="lwjgl" else="lwjgl_@{module}">


### PR DESCRIPTION
Trying to build lwjgl on linux failed for me because `src.main.rel` was improperly set to `../../modules/opengl/[...]` when it was supposed to be `../../../../modules/opengl/[...]` where the four `..` come from https://github.com/LWJGL/lwjgl3/blob/015c9a95b5ac98fa53e7e5ba359541b12e6798de/config/linux/build.xml#L20

This happens because `src.main.rel` is set with a relative property location in
https://github.com/LWJGL/lwjgl3/blob/015c9a95b5ac98fa53e7e5ba359541b12e6798de/config/linux/build.xml#L79

and finally used after going two directories deeper (`@{dest}`) at https://github.com/LWJGL/lwjgl3/blob/015c9a95b5ac98fa53e7e5ba359541b12e6798de/config/linux/build.xml#L52

Now, if you happen to build in `/build/lwjgl-xxx/`, the relative path will be truncated (because in `/build/lwjgl-xxx/` `../../../..` is the same as `../..` so some kind of canonicalization occurs.)

Proposed solution in this PR. Tested and working by only changing `src.main.rel`. This PR is more a POC than something to be merged as-is.