### PR TITLE
Specifying GLFW 3.2 for MacOS X compatibility

### DIFF
--- a/modules/samples/src/test/java/org/lwjgl/demo/glfw/Gears.java
+++ b/modules/samples/src/test/java/org/lwjgl/demo/glfw/Gears.java
@@ -70,6 +70,8 @@ public class Gears {
         glfwWindowHint(GLFW_SCALE_TO_MONITOR, GLFW_TRUE);
         glfwWindowHint(GLFW_OPENGL_DEBUG_CONTEXT, GLFW_TRUE);
         if (Platform.get() == Platform.MACOSX) {
+	    glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
+            glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 2);
             glfwWindowHint(GLFW_COCOA_RETINA_FRAMEBUFFER, GLFW_FALSE);
         }
 


### PR DESCRIPTION
Demo sample for gears does not run in MacOS X and gives will known [error](https://stackoverflow.com/questions/20264814/glsl-version-130-on-mac-os-x-causes-error).

It can be fixed by explicitly specifying version as suggested in  [forum](http://forum.lwjgl.org/index.php?topic=5578.0) thread.
```
glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 2);
```