### PR TITLE
build: Update URL for maven repo

### DIFF
--- a/config/build-definitions.xml
+++ b/config/build-definitions.xml
@@ -296,7 +296,7 @@ This script is included in /build.xml and /config/update-dependencies.xml.
         <attribute name="dest"/>
 
         <sequential>
-            <get-quiet name="@{name}" url="http://central.maven.org/maven2/@{group}/@{artifact}/@{version}/@{artifact}-@{version}.jar" dest="@{dest}/@{artifact}.jar" skipexisting="false"/>
+            <get-quiet name="@{name}" url="https://repo.maven.org/maven2/@{group}/@{artifact}/@{version}/@{artifact}-@{version}.jar" dest="@{dest}/@{artifact}.jar" skipexisting="false"/>
         </sequential>
     </macrodef>
 


### PR DESCRIPTION
Build was failing on the android branch due to an outdated URL for the maven repo