### PR TITLE
Fix memLengthUTF8 result being incorrect for unpaired low surrogates

### DIFF
--- a/modules/lwjgl/core/src/main/java/org/lwjgl/system/MemoryUtil.java
+++ b/modules/lwjgl/core/src/main/java/org/lwjgl/system/MemoryUtil.java
@@ -2394,10 +2394,10 @@ public final class MemoryUtil {
                     // c >= 128: 1 (1 input char -> 2 output bytes)
                     bytes += (0x7F - c) >>> 31;
                 } else {
-                    // non-surrogate: 1 input char  -> 3 output bytes
-                    //     surrogate: 2 input chars -> 4 output bytes
+                    // non-high-surrogate: 1 input char  -> 3 output bytes
+                    //     surrogate-pair: 2 input chars -> 4 output bytes
                     bytes += 2;
-                    if (MIN_SURROGATE <= c && c <= MAX_SURROGATE) {
+                    if (isHighSurrogate(c)) {
                         i++;
                     }
                 }


### PR DESCRIPTION
# Description
`MemoryUtil.memLengthUTF8` can return too small values for unpaired low surrogates. This can result in BufferOverflowExceptions. The reason for this is that `memLengthUTF8` incorrectly considers any surrogate char (high or low) followed by any other char to be a surrogate pair:
https://github.com/LWJGL/lwjgl3/blob/1da8c9d41965d06a772b3a1ab875ccc5375a88b9/modules/lwjgl/core/src/main/java/org/lwjgl/system/MemoryUtil.java#L2400

While the <code>encodeUTF8<i>X</i></code> methods more correctly only consider a high surrogate followed by any other char to be a surrogate pair:
https://github.com/LWJGL/lwjgl3/blob/1da8c9d41965d06a772b3a1ab875ccc5375a88b9/modules/lwjgl/core/src/main/java/org/lwjgl/system/MemoryUtil.java#L2217

Therefore `memLengthUTF8` can return for a low surrogate followed by any non-high-surrogate to require 4 bytes to encode while they are actually encoded as two separate chars and can take up to 6 bytes.

# Example
```
// Low surrogate + any other (non high surrogate char) >= 0x800
String str = "\uDC00\u2191";

boolean nullTerminated = true;
int memLengthUTF8 = MemoryUtil.memLengthUTF8(str, nullTerminated);
// To be safe allocate maximum amount of memory encoding could require
ByteBuffer buf = MemoryUtil.memCalloc(str.length() * 4 + 1);

try {
    int actualLen = MemoryUtil.memUTF8(str, nullTerminated, buf);
    
    if (memLengthUTF8 != actualLen) {
        System.out.println(String.format("Length mismatch:\n\tReported: %d\n\tActual: %d", memLengthUTF8, actualLen));
    }
}
finally {
    MemoryUtil.memFree(buf);
}
```