### PR TITLE
build: add support for Linux MIPS64 cross compilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ following platforms/architectures:
 - Linux x64
 - Linux arm64 (ARMv8/AArch64)
 - Linux arm32 (ARMv7/armhf)
+- Linux mips64 (mips64r2 Little-Endian)
 - macOS x64
 - Windows x64
 - Windows x86

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -62,6 +62,7 @@ enum class Platforms(val classifier: String) {
     LINUX("linux"),
     LINUX_ARM64("linux-arm64"),
     LINUX_ARM32("linux-arm32"),
+    LINUX_MIPS64("linux-mips64"),
     MACOS("macos"),
     WINDOWS("windows"),
     WINDOWS_X86("windows-x86");

--- a/build.xml
+++ b/build.xml
@@ -951,6 +951,7 @@
         <element name="linux-content" optional="true"/>
         <element name="linux-arm64-content" optional="true"/>
         <element name="linux-arm32-content" optional="true"/>
+        <element name="linux-mips64-content" optional="true"/>
         <element name="macos-content" optional="true"/>
         <element name="windows-content" optional="true"/>
         <element name="windows-x86-content" optional="true"/>
@@ -978,6 +979,10 @@
 
                 <get-release platform="linux" arch="arm32" file="lib@{native-library}.so" if:set="auto-natives"/>
                 <get-release platform="linux" arch="arm32" file="lib@{native-library}.so.git" if:set="git-revision"/>
+
+
+                <get-release platform="linux" arch="mips64" file="lib@{native-library}.so" if:set="auto-natives"/>
+                <get-release platform="linux" arch="mips64" file="lib@{native-library}.so.git" if:set="git-revision"/>
 
                 <get-release platform="macos" arch="x64" file="lib@{native-library}.dylib" if:set="auto-natives"/>
                 <get-release platform="macos" arch="x64" file="lib@{native-library}.dylib.git" if:set="git-revision"/>
@@ -1036,6 +1041,9 @@
                 <natives-jar name="@{name}" title="@{title}" platform="linux-arm32" path="linux/arm32" type="so">
                     <linux-arm32-content/>
                 </natives-jar>
+                <natives-jar name="@{name}" title="@{title}" platform="linux-mips64" path="linux/mips64" type="so">
+                    <linux-mips64-content/>
+                </natives-jar>
                 <natives-jar name="@{name}" title="@{title}" platform="macos" path="macos/x64" type="dylib">
                     <macos-content/>
                 </natives-jar>
@@ -1057,6 +1065,7 @@
         <element name="linux" optional="true"/>
         <element name="linux-arm64" optional="true"/>
         <element name="linux-arm32" optional="true"/>
+        <element name="linux-mips64" optional="true"/>
         <element name="macos" optional="true"/>
         <element name="windows" optional="true"/>
         <element name="windows-x86" optional="true"/>
@@ -1078,6 +1087,7 @@
                 <linux-content><linux/></linux-content>
                 <linux-arm64-content><linux-arm64/></linux-arm64-content>
                 <linux-arm32-content><linux-arm32/></linux-arm32-content>
+                <linux-mips64-content><linux-mips64/></linux-mips64-content>
                 <macos-content><macos/></macos-content>
                 <windows-content><windows/></windows-content>
                 <windows-x86-content><windows-x86/></windows-x86-content>
@@ -1271,6 +1281,11 @@
                 <get-release platform="linux" arch="arm32" file="libglfw_wayland.so"/>
                 <get-release platform="linux" arch="arm32" file="libglfw_wayland.so.git"/>
 
+                <get-release platform="linux" arch="mips64" file="libglfw.so"/>
+                <get-release platform="linux" arch="mips64" file="libglfw.so.git"/>
+                <get-release platform="linux" arch="mips64" file="libglfw_wayland.so"/>
+                <get-release platform="linux" arch="mips64" file="libglfw_wayland.so.git"/>
+
                 <get-release platform="macos" arch="x64" file="libglfw.dylib"/>
                 <get-release platform="macos" arch="x64" file="libglfw.dylib.git"/>
 
@@ -1344,6 +1359,9 @@
 
                 <get-release platform="linux" arch="arm32" file="libopenal.so"/>
                 <get-release platform="linux" arch="arm32" file="libopenal.so.git"/>
+
+                <get-release platform="linux" arch="mips64" file="libopenal.so"/>
+                <get-release platform="linux" arch="mips64" file="libopenal.so.git"/>
 
                 <get-release platform="macos" arch="x64" file="libopenal.dylib"/>
                 <get-release platform="macos" arch="x64" file="libopenal.dylib.git"/>
@@ -1420,6 +1438,10 @@
                 <get-release platform="linux" arch="arm32" file="libshaderc.so"/>
                 <get-release platform="linux" arch="arm32" file="libshaderc.so.git"/>
                 <get-release platform="linux" arch="arm32" file="libshaderc_spvc.so"/>
+
+                <get-release platform="linux" arch="mips64" file="libshaderc.so"/>
+                <get-release platform="linux" arch="mips64" file="libshaderc.so.git"/>
+                <get-release platform="linux" arch="mips64" file="libshaderc_spvc.so"/>
 
                 <get-release platform="macos" arch="x64" file="libshaderc.dylib"/>
                 <get-release platform="macos" arch="x64" file="libshaderc.dylib.git"/>

--- a/config/build-bindings.xml
+++ b/config/build-bindings.xml
@@ -14,8 +14,8 @@ This script is included in /config/build-definitions.xml.
 
     <!-- // ========== BINDING FLAGS ======== // -->
 
-    <local name="notARM"/>
-    <condition property="notARM">
+    <local name="isX86Fam"/>
+    <condition property="isX86Fam">
         <or>
             <isset property="build.arch.x64"/>
             <isset property="build.arch.x86"/>
@@ -24,7 +24,8 @@ This script is included in /config/build-definitions.xml.
 
     <property name="binding.assimp" value="true"/>
     <property name="binding.bgfx" value="true"/>
-    <property name="binding.bullet" value="true"/>
+    <!-- FIXME: Build bullet for MIPS64 after switch to libbulletc complete -->
+    <condition property="binding.bullet" value="false" else="true"><isset property="build.arch.mips64"/></condition>
     <property name="binding.cuda" value="true"/>
     <property name="binding.driftfx" value="true"/>
     <property name="binding.egl" value="true"/>
@@ -37,31 +38,31 @@ This script is included in /config/build-definitions.xml.
     <property name="binding.lz4" value="true"/>
     <condition property="binding.meow" value="true" else="false">
         <or>
-            <isset property="notARM"/>
+            <isset property="isX86Fam"/>
             <isset property="build.arch.arm64"/>
         </or>
     </condition>
     <property name="binding.meshoptimizer" value="true"/>
     <property name="binding.nanovg" value="true"/>
-    <condition property="binding.nfd" value="true" else="false"><isset property="notARM"/></condition>
+    <condition property="binding.nfd" value="true" else="false"><isset property="isX86Fam"/></condition>
     <property name="binding.nuklear" value="true"/>
     <property name="binding.odbc" value="true"/>
     <property name="binding.openal" value="true"/>
     <property name="binding.opencl" value="true"/>
     <property name="binding.opengl" value="true"/>
     <property name="binding.opengles" value="true"/>
-    <condition property="binding.openvr" value="true" else="false"><isset property="notARM"/></condition>
+    <condition property="binding.openvr" value="true" else="false"><isset property="isX86Fam"/></condition>
     <property name="binding.opus" value="true"/>
     <property name="binding.par" value="true"/>
     <property name="binding.remotery" value="true"/>
     <property name="binding.rpmalloc" value="true"/>
     <property name="binding.shaderc" value="true"/>
     <property name="binding.spvc" value="true"/>
-    <condition property="binding.sse" value="true" else="false"><isset property="notARM"/></condition>
+    <condition property="binding.sse" value="true" else="false"><isset property="isX86Fam"/></condition>
     <property name="binding.stb" value="true"/>
     <property name="binding.tinyexr" value="true"/>
     <property name="binding.tinyfd" value="true"/>
-    <condition property="binding.tootle" value="true" else="false"><isset property="notARM"/></condition>
+    <condition property="binding.tootle" value="true" else="false"><isset property="isX86Fam"/></condition>
     <property name="binding.vma" value="true"/>
     <property name="binding.vulkan" value="true"/>
     <property name="binding.xxhash" value="true"/>

--- a/config/build-definitions.xml
+++ b/config/build-definitions.xml
@@ -16,15 +16,15 @@ This script is included in /build.xml and /config/update-dependencies.xml.
 
         By default, os.arch of the JVM that runs ANT is used, but this can be overridden for cross-compiling to another architecture.
 
-        Valid values: x64, x86, arm64, arm32
+        Valid values: x64, x86, arm64, arm32, mips64
     -->
     <property name="build.arch" value="${env.LWJGL_BUILD_ARCH}" if:set="env.LWJGL_BUILD_ARCH"/>
     <condition property="build.arch" value="x64" else="x86" unless:set="build.arch"> <!-- Normalize os.arch -->
         <contains string="${os.arch}" substring="64"/>
     </condition>
 
-    <fail message="Invalid or unsupported build architecture: ${build.arch}. Supported: x64, x86, arm64, arm32">
-        <condition><not><matches string="${build.arch}" pattern="^(x64|x86|arm64|arm32)$"/></not></condition>
+    <fail message="Invalid or unsupported build architecture: ${build.arch}. Supported: x64, x86, arm64, arm32, mips64">
+        <condition><not><matches string="${build.arch}" pattern="^(x64|x86|arm64|arm32|mips64)$"/></not></condition>
     </fail>
 
     <property name="build.arch.${build.arch}" value="true"/>

--- a/config/linux/build.xml
+++ b/config/linux/build.xml
@@ -7,6 +7,7 @@
 
     <property name="gcc.prefix" value="aarch64-linux-gnu-" if:set="build.arch.arm64"/>
     <property name="gcc.prefix" value="arm-linux-gnueabihf-" if:set="build.arch.arm32"/>
+    <property name="gcc.prefix" value="mips64el-linux-gnuabi64-" if:set="build.arch.mips64"/>
 
     <condition property="gcc.prefix" value="${gcc.prefix}" else="">
         <isset property="gcc.prefix"/>

--- a/modules/lwjgl/core/src/main/java/org/lwjgl/system/Platform.java
+++ b/modules/lwjgl/core/src/main/java/org/lwjgl/system/Platform.java
@@ -54,7 +54,8 @@ public enum Platform {
         X64(true),
         X86(false),
         ARM64(true),
-        ARM32(false);
+        ARM32(false),
+        MIPS64(true);
 
         static final Architecture current;
 
@@ -64,10 +65,14 @@ public enum Platform {
             String  osArch  = System.getProperty("os.arch");
             boolean is64Bit = osArch.contains("64") || osArch.startsWith("armv8");
 
-            current = osArch.startsWith("arm") || osArch.startsWith("aarch64")
-                ? (is64Bit ? Architecture.ARM64 : Architecture.ARM32)
-                : (is64Bit ? Architecture.X64 : Architecture.X86);
-        }
+                if (osArch.startsWith("arm") || osArch.startsWith("aarch64")) {
+                    current = (is64Bit ? Architecture.ARM64 : Architecture.ARM32);
+                } else if (osArch.startsWith("mips") || osArch.startsWith("loongson")) {
+                    current = Architecture.MIPS64;
+                } else {
+                    current = (is64Bit ? Architecture.X64 : Architecture.X86);
+                }
+            }
 
         Architecture(boolean is64Bit) {
             this.is64Bit = is64Bit;


### PR DESCRIPTION
Mostly identical to the ARM one except bullet is disabled due
to CI no longer provide formal bullet build but switch to
libbulletc has not completed.

bgfx build failure due to: https://github.com/LWJGL-CI/bgfx/pull/2
didn't get really merged, please have a check.

Thanks.
