### PR TITLE
add compatibility for OpenGL ES contexts in GL.createCapabilities()

### DIFF
--- a/modules/lwjgl/opengl/src/main/java/org/lwjgl/opengl/GL.java
+++ b/modules/lwjgl/opengl/src/main/java/org/lwjgl/opengl/GL.java
@@ -378,7 +378,13 @@ public final class GL {
                         throw new IllegalStateException("There is no OpenGL context current in the current thread.");
                     }
 
-                    APIVersion apiVersion = apiParseVersion(versionString);
+                    APIVersion apiVersion = null;
+                    try {
+                    	apiVersion = apiParseVersion(versionString);
+                    } catch (IllegalArgumentException iae) {
+                    	// fallback for some drivers that hand out OpenGL ES contexts
+                    	apiVersion = apiParseVersion(versionString, "OpenGL ES");
+                    }
 
                     majorVersion = apiVersion.major;
                     minorVersion = apiVersion.minor;


### PR DESCRIPTION
I am on Windows platform with Intel HD 4000 graphics card, driver version 10.18.10.5100 and LWJGL 3.2.3.
For reproduction purposes I created a MVE

```java
package mve;

import static org.lwjgl.glfw.Callbacks.glfwFreeCallbacks;
import static org.lwjgl.glfw.GLFW.GLFW_KEY_ESCAPE;
import static org.lwjgl.glfw.GLFW.GLFW_RELEASE;
import static org.lwjgl.glfw.GLFW.glfwCreateWindow;
import static org.lwjgl.glfw.GLFW.glfwInit;
import static org.lwjgl.glfw.GLFW.glfwMakeContextCurrent;
import static org.lwjgl.glfw.GLFW.glfwPollEvents;
import static org.lwjgl.glfw.GLFW.glfwSetKeyCallback;
import static org.lwjgl.glfw.GLFW.glfwSetWindowShouldClose;
import static org.lwjgl.glfw.GLFW.glfwShowWindow;
import static org.lwjgl.glfw.GLFW.glfwSwapBuffers;
import static org.lwjgl.glfw.GLFW.glfwTerminate;
import static org.lwjgl.glfw.GLFW.glfwWindowHint;
import static org.lwjgl.glfw.GLFW.glfwWindowShouldClose;
import static org.lwjgl.system.MemoryUtil.NULL;

import org.lwjgl.glfw.GLFW;
import org.lwjgl.glfw.GLFWErrorCallback;
import org.lwjgl.opengl.GL;
import org.lwjgl.opengl.GL11;

public class MVE {

	public static void main(String[] args) {
		GLFWErrorCallback.createPrint().set();
		if (!glfwInit()) {
			throw new IllegalStateException("Unable to initialize glfw");
		}

		glfwWindowHint(GLFW.GLFW_CLIENT_API, GLFW.GLFW_OPENGL_ES_API);
		glfwWindowHint(GLFW.GLFW_CONTEXT_VERSION_MAJOR, 2);
		glfwWindowHint(GLFW.GLFW_CONTEXT_VERSION_MINOR, 0);

		int WIDTH = 300;
		int HEIGHT = 300;

		long window = glfwCreateWindow(WIDTH, HEIGHT, "Minimal viable example", NULL, NULL);
		if (window == NULL) {
			throw new RuntimeException("Failed to create the GLFW window");
		}

		glfwSetKeyCallback(window, (windowHnd, key, scancode, action, mods) -> {
			if (action == GLFW_RELEASE && key == GLFW_KEY_ESCAPE) {
				glfwSetWindowShouldClose(windowHnd, true);
			}
		});

		glfwMakeContextCurrent(window);
		GL.createCapabilities();

		System.out.println("GL_VENDOR: " + GL11.glGetString(GL11.GL_VENDOR));
		System.out.println("GL_VERSION: " + GL11.glGetString(GL11.GL_VERSION));
		System.out.println("GL_RENDERER: " + GL11.glGetString(GL11.GL_RENDERER));

		glfwShowWindow(window);

		GL11.glClearColor(1.0f, 1.0f, 0.8f, 1.0f);
		while (!glfwWindowShouldClose(window)) {
			glfwPollEvents();

			GL11.glClear(GL11.GL_COLOR_BUFFER_BIT);

			glfwSwapBuffers(window);

		}

		glfwFreeCallbacks(window);
		glfwTerminate();
	}

}
```

Running this gives me the following exception calling GL.createCapabilites().

```
Exception in thread "main" java.lang.IllegalArgumentException: Malformed API version string [OpenGL ES 2.0 - Build 10.18.10.5100]
	at org.lwjgl.system.APIUtil.apiParseVersion(APIUtil.java:300)
	at org.lwjgl.system.APIUtil.apiParseVersion(APIUtil.java:279)
	at org.lwjgl.opengl.GL.createCapabilities(GL.java:381)
	at org.lwjgl.opengl.GL.createCapabilities(GL.java:322)
	at mve.MVE.main(MVE.java:51)
```

In this example I explicitly demand an OpenGL ES 2.0 context, which fails. When I try to get an OpenGL ES >= 3.0 context, everything succeeds, because for major versions >= 3 the method APIUtil.apiParseVersion() is not called, which throws the exception

```
GL_VENDOR: Intel
GL_VERSION: OpenGL ES 3.0 - Build 10.18.10.5100
GL_RENDERER: Intel(R) HD Graphics 4000
```

From what I understand, LWJGL is spec conformant, because GL.createCapabilities() does not expect an OpenGL ES version string. GLES.createCapabilities() would be the correct call. But this fails on my platform because there is no libGLESv2.dll available (on embedded platforms this of course works perfectly fine)

```
Exception in thread "main" java.lang.UnsatisfiedLinkError: Failed to locate library: libGLESv2.dll
	at org.lwjgl.system.Library.loadNative(Library.java:324)
	at org.lwjgl.system.Library.loadNative(Library.java:411)
	at org.lwjgl.system.Library.loadNative(Library.java:378)
	at org.lwjgl.opengles.GLES.create(GLES.java:89)
	at org.lwjgl.opengles.GLES.<clinit>(GLES.java:67)
	at mve.MVE.main(MVE.java:52)
```

But the driver itself is perfectly capable to hand out OpenGL ES contexts and it would be too bad if it could not be used.

The PR creates a fallback in GL.createCapabilities() to also allow "OpenGL ES" in the version string.

With this PR the above code succeeds (I've compiled and tested locally)
```
GL_VENDOR: Intel
GL_VERSION: OpenGL ES 2.0 - Build 10.18.10.5100
GL_RENDERER: Intel(R) HD Graphics 4000
```