### PR TITLE
for Callback.Container classes, when it free(), I think it is better  to free its delegate first.

### DIFF
--- a/modules/generator/src/main/kotlin/org/lwjgl/generator/CallbackFunction.kt
+++ b/modules/generator/src/main/kotlin/org/lwjgl/generator/CallbackFunction.kt
@@ -183,6 +183,14 @@ import static org.lwjgl.system.MemoryUtil.*;
             }}) {
             ${if (returns.mapping != TypeMapping.VOID) "return " else ""}delegate.invoke(${javaSignature.map { it.name }.joinToString(", ")});
         }
+        
+        @Override
+        public void free() {
+            if (this.delegate instanceof ${className}) {
+                this.delegate.free();
+            }
+            super.free();
+        }
 
     }
 

--- a/modules/generator/src/main/kotlin/org/lwjgl/generator/CallbackFunction.kt
+++ b/modules/generator/src/main/kotlin/org/lwjgl/generator/CallbackFunction.kt
@@ -186,8 +186,8 @@ import static org.lwjgl.system.MemoryUtil.*;
         
         @Override
         public void free() {
-            if (this.delegate instanceof ${className}) {
-                this.delegate.free();
+            if (this.delegate instanceof Callback) {
+                ((Callback)this.delegate).free();
             }
             super.free();
         }


### PR DESCRIPTION
for Callback.Container classes, when it free(), I think it is better to free its delegate first.