### PR TITLE
fix(core): handle trailing newlines in api version parsing.

### DIFF
--- a/modules/lwjgl/core/src/main/java/org/lwjgl/system/APIUtil.java
+++ b/modules/lwjgl/core/src/main/java/org/lwjgl/system/APIUtil.java
@@ -295,9 +295,9 @@ public final class APIUtil {
             pattern = "(?:" + prefix + "\\s+)?" + pattern;
         }
 
-        Matcher matcher = Pattern.compile(pattern).matcher(version);
+        Matcher matcher = Pattern.compile(pattern).matcher(version.trim());
         if (!matcher.matches()) {
-            throw new IllegalArgumentException(String.format("Malformed API version string [%s]", version));
+            throw new IllegalArgumentException(String.format("Malformed API version string [%s]", version.trim()));
         }
 
         return new APIVersion(


### PR DESCRIPTION
I've received a crash log from a user unable launch due to a failure in parsing the api version due to a trailing newline character.

The user is running on macOS, on older hardware.

```
java.lang.IllegalArgumentException: Malformed API version string [2.1 NVIDIA-10.0.35 310.90.10.05b12
]
    at org.lwjgl.system.APIUtil.apiParseVersion(Unknown Source)
    at org.lwjgl.system.APIUtil.apiParseVersion(Unknown Source)
    at org.lwjgl.opengl.GL.createCapabilities(Unknown Source)
    at org.lwjgl.opengl.GL.createCapabilities(Unknown Source)
```