### PR TITLE
Check for non-ASCII characters inside workaround check for JDK-8195129

### DIFF
--- a/modules/lwjgl/core/src/main/java/org/lwjgl/system/SharedLibraryLoader.java
+++ b/modules/lwjgl/core/src/main/java/org/lwjgl/system/SharedLibraryLoader.java
@@ -315,7 +315,15 @@ final class SharedLibraryLoader {
     }
 
     private static boolean workaroundJDK8195129(Path file) {
-        return Platform.get() == Platform.WINDOWS && file.toString().endsWith(".dll");
+        boolean isWinDll = Platform.get() == Platform.WINDOWS && file.toString().endsWith(".dll");
+        if (isWinDll) {
+            // Check for unicode characters if this path is going to be loaded with System.load
+            for (char c : file.toString().toCharArray()) {
+                if (c > '\u007f') {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
-
 }


### PR DESCRIPTION
Closes #648

This change should maintain existing functionality of the JDK-8195129 check, but narrow it to only affect non-ASCII paths.