### PR TITLE
VK_API_VERSION_* macros

### DIFF
--- a/modules/lwjgl/vulkan/src/generated/java/org/lwjgl/vulkan/VK10.java
+++ b/modules/lwjgl/vulkan/src/generated/java/org/lwjgl/vulkan/VK10.java
@@ -15401,12 +15401,79 @@ public class VK10 {
         }
     }
 
+    // --- [ VK_MAKE_API_VERSION ] ---
+
+    /**
+     * Constructs an API version number.
+     * 
+     * <p>This macro <b>can</b> be used when constructing the {@link VkApplicationInfo}{@code ::pname:apiVersion} parameter passed to {@link #vkCreateInstance CreateInstance}.</p>
+     *
+     * @param variant the variant number
+     * @param major   the major version number
+     * @param minor   the minor version number
+     * @param patch   the patch version number
+     */
+    @NativeType("uint32_t")
+    public static int VK_MAKE_API_VERSION(@NativeType("uint32_t") int variant, @NativeType("uint32_t") int major, @NativeType("uint32_t") int minor, @NativeType("uint32_t") int patch) {
+        return (variant << 29) | (major << 22) | (minor << 12) | patch;
+    }
+
+    // --- [ VK_API_VERSION_VARIANT ] ---
+
+    /**
+     * Extracts the API variant version number from a packed version number.
+     *
+     * @param version the Vulkan API version
+     */
+    @NativeType("uint32_t")
+    public static int VK_API_VERSION_VARIANT(@NativeType("uint32_t") int version) {
+        return version >>> 29;
+    }
+
+    // --- [ VK_API_VERSION_MAJOR ] ---
+
+    /**
+     * Extracts the API major version number from a packed version number.
+     *
+     * @param version the Vulkan API version
+     */
+    @NativeType("uint32_t")
+    public static int VK_API_VERSION_MAJOR(@NativeType("uint32_t") int version) {
+        return (version >>> 22) & 0x7F;
+    }
+
+    // --- [ VK_API_VERSION_MINOR ] ---
+
+    /**
+     * Extracts the API minor version number from a packed version number.
+     *
+     * @param version the Vulkan API version
+     */
+    @NativeType("uint32_t")
+    public static int VK_API_VERSION_MINOR(@NativeType("uint32_t") int version) {
+        return (version >>> 12) & 0x3FF;
+    }
+
+    // --- [ VK_API_VERSION_PATCH ] ---
+
+    /**
+     * Extracts the API patch version number from a packed version number.
+     *
+     * @param version the Vulkan API version
+     */
+    @NativeType("uint32_t")
+    public static int VK_API_VERSION_PATCH(@NativeType("uint32_t") int version) {
+        return (version >>> 22) & 0xFFF;
+    }
+
     // --- [ VK_MAKE_VERSION ] ---
 
     /**
      * Constructs an API version number.
      * 
      * <p>This macro <b>can</b> be used when constructing the {@link VkApplicationInfo}{@code ::pname:apiVersion} parameter passed to {@link #vkCreateInstance CreateInstance}.</p>
+     * 
+     * <p><em>Deprecated</em>, {@link #VK_MAKE_API_VERSION} should be used instead.</p>
      *
      * @param major the major version number
      * @param minor the minor version number
@@ -15421,6 +15488,8 @@ public class VK10 {
 
     /**
      * Extracts the API major version number from a packed version number.
+     * 
+     * <p><em>Deprecated</em>, {@link #VK_API_VERSION_MAJOR} should be used instead.</p>
      *
      * @param version the Vulkan API version
      */
@@ -15433,6 +15502,8 @@ public class VK10 {
 
     /**
      * Extracts the API minor version number from a packed version number.
+     * 
+     * <p><em>Deprecated</em>, {@link #VK_API_VERSION_MINOR} should be used instead.</p>
      *
      * @param version the Vulkan API version
      */
@@ -15445,6 +15516,8 @@ public class VK10 {
 
     /**
      * Extracts the API patch version number from a packed version number.
+     * 
+     * <p><em>Deprecated</em>, {@link #VK_API_VERSION_PATCH} should be used instead.</p>
      *
      * @param version the Vulkan API version
      */

--- a/modules/lwjgl/vulkan/src/templates/kotlin/vulkan/Custom.kt
+++ b/modules/lwjgl/vulkan/src/templates/kotlin/vulkan/Custom.kt
@@ -58,12 +58,66 @@ fun templateCustomization() {
             "NULL_HANDLE"..0L
         )
 
+        macro(expression = "(variant << 29) | (major << 22) | (minor << 12) | patch")..uint32_t(
+            "VK_MAKE_API_VERSION",
+            """
+            Constructs an API version number.
+
+            This macro <b>can</b> be used when constructing the ##VkApplicationInfo{@code ::pname:apiVersion} parameter passed to #CreateInstance().
+            """,
+
+            uint32_t("variant", "the variant number"),
+            uint32_t("major", "the major version number"),
+            uint32_t("minor", "the minor version number"),
+            uint32_t("patch", "the patch version number"),
+
+            noPrefix = true
+        )
+
+        macro(expression = "version >>> 29")..uint32_t(
+            "VK_API_VERSION_VARIANT",
+            "Extracts the API variant version number from a packed version number.",
+
+            uint32_t("version", "the Vulkan API version"),
+
+            noPrefix = true
+        )
+
+        macro(expression = "(version >>> 22) & 0x7F")..uint32_t(
+            "VK_API_VERSION_MAJOR",
+            "Extracts the API major version number from a packed version number.",
+
+            uint32_t("version", "the Vulkan API version"),
+
+            noPrefix = true
+        )
+
+        macro(expression = "(version >>> 12) & 0x3FF")..uint32_t(
+            "VK_API_VERSION_MINOR",
+            "Extracts the API minor version number from a packed version number.",
+
+            uint32_t("version", "the Vulkan API version"),
+
+            noPrefix = true
+        )
+
+        macro(expression = "(version >>> 22) & 0xFFF")..uint32_t(
+            "VK_API_VERSION_PATCH",
+            "Extracts the API patch version number from a packed version number.",
+
+            uint32_t("version", "the Vulkan API version"),
+
+            noPrefix = true
+        )
+
         macro(expression = "(major << 22) | (minor << 12) | patch")..uint32_t(
             "VK_MAKE_VERSION",
             """
             Constructs an API version number.
 
             This macro <b>can</b> be used when constructing the ##VkApplicationInfo{@code ::pname:apiVersion} parameter passed to #CreateInstance().
+
+            <em>Deprecated</em>, #VK_MAKE_API_VERSION() should be used instead.
             """,
 
             uint32_t("major", "the major version number"),
@@ -75,7 +129,11 @@ fun templateCustomization() {
 
         macro(expression = "version >>> 22")..uint32_t(
             "VK_VERSION_MAJOR",
-            "Extracts the API major version number from a packed version number.",
+            """
+            Extracts the API major version number from a packed version number.
+
+            <em>Deprecated</em>, #VK_API_VERSION_MAJOR() should be used instead.
+            """,
 
             uint32_t("version", "the Vulkan API version"),
 
@@ -84,7 +142,11 @@ fun templateCustomization() {
 
         macro(expression = "(version >>> 12) & 0x3FF")..uint32_t(
             "VK_VERSION_MINOR",
-            "Extracts the API minor version number from a packed version number.",
+            """
+            Extracts the API minor version number from a packed version number.
+
+            <em>Deprecated</em>, #VK_API_VERSION_MINOR() should be used instead.
+            """,
 
             uint32_t("version", "the Vulkan API version"),
 
@@ -93,7 +155,11 @@ fun templateCustomization() {
 
         macro(expression = "version & 0xFFF")..uint32_t(
             "VK_VERSION_PATCH",
-            "Extracts the API patch version number from a packed version number.",
+            """
+            Extracts the API patch version number from a packed version number.
+
+            <em>Deprecated</em>, #VK_API_VERSION_PATCH() should be used instead.
+            """,
 
             uint32_t("version", "the Vulkan API version"),
 


### PR DESCRIPTION
Vulkan added new header macros and deprecated the older ones. This PR mirrors that change.

Simple upgrade table:

`VK_MAKE_VERSION(major, minor, patch)` -> `VK_API_MAKE_VERSION(0, major, minor, patch)`

(new, replaces nothing) ->`VK_API_VERSION_VARIANT(version)`
`VK_VERSION_MAJOR(version)` -> `VK_API_VERSION_MAJOR(version)`
`VK_VERSION_MINOR(version)` -> `VK_API_VERSION_MAJOR(version)`
`VK_VERSION_PATCH(version)` -> `VK_API_VERSION_PATCH(version)`