### PR TITLE
Add GitHub Actions workflow to validate the Gradle wrapper

### DIFF
--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -1,0 +1,10 @@
+name: "Validate Gradle Wrapper"
+on: [push, pull_request]
+
+jobs:
+  validation:
+    name: "Validation"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: gradle/wrapper-validation-action@v1


### PR DESCRIPTION
This PR adds a GitHub Actions workflow to validate the (binary) `gradle-wrapper.jar`. This is achieved by using the official [Gradle Wrapper Validation Action](https://github.com/gradle/wrapper-validation-action) from the Gradle team.

The motivation behind this change is to provide better protection against potentially malicious contributions. As an added bonus, reviewing contributions such as #693 gets significantly easier. **However,** the action only verifies the `gradle-wrapper.jar` and not the `gradlew` scripts that are frequently updated together with the wrapper.


Also, note that this should eventually be merged into a general CI workflow if one is added to this repository.

An example run can be found [here](https://github.com/TheMrMilchmann/lwjgl3/runs/4583857099).