### PR TITLE
Fix SharedLibraryUtil#getLibraryPath returning NUL

### DIFF
--- a/doc/notes/3.3.1.md
+++ b/doc/notes/3.3.1.md
@@ -19,6 +19,7 @@ This build includes the following changes:
 
 #### Fixes
 
+- Core: Fixed extra `NUL` in string returned from `SharedLibrary::getPath()` on Linux & macOS. (#713)
 - vma: Fixed nullability of `VmaVirtualAllocationCreateInfo::pUserData` member.
 - Vulkan: All `noautovalidity` parameters/members are now regarded as nullable. (#702)
 

--- a/modules/lwjgl/core/src/main/java/org/lwjgl/system/SharedLibraryUtil.java
+++ b/modules/lwjgl/core/src/main/java/org/lwjgl/system/SharedLibraryUtil.java
@@ -25,7 +25,7 @@ public final class SharedLibraryUtil {
                     return null;
                 }
                 if (len < maxLen) {
-                    return memUTF8(buffer, len);
+                    return memUTF8(buffer, len - 1); // drop the null-terminator
                 }
                 buffer = memRealloc(buffer, maxLen = maxLen * 3 / 2);
             }


### PR DESCRIPTION
The length includes the null-terminator, but memUTF8 assumes there isn't one.