### PR TITLE
fix(jemalloc): update jemalloc version in bindings to 5.2.1

### DIFF
--- a/modules/lwjgl/jemalloc/src/generated/java/org/lwjgl/system/jemalloc/JEmalloc.java
+++ b/modules/lwjgl/jemalloc/src/generated/java/org/lwjgl/system/jemalloc/JEmalloc.java
@@ -74,13 +74,13 @@ public class JEmalloc {
     public static final int JEMALLOC_VERSION_MINOR = 2;
 
     /** The bugfix version. */
-    public static final int JEMALLOC_VERSION_BUGFIX = 0;
+    public static final int JEMALLOC_VERSION_BUGFIX = 1;
 
     /** The revision number. */
     public static final int JEMALLOC_VERSION_NREV = 0;
 
     /** The globally unique identifier (git commit hash). */
-    public static final String JEMALLOC_VERSION_GID = "b0b3e49a54ec29e32636f4577d9d5a896d67fd20";
+    public static final String JEMALLOC_VERSION_GID = "ea6b3e973b477b8061e0076bb257dbd7f3faa756";
 
     /** The version string. */
     public static final String JEMALLOC_VERSION = JEMALLOC_VERSION_MAJOR + "." + JEMALLOC_VERSION_MINOR + "." + JEMALLOC_VERSION_BUGFIX + "-" + JEMALLOC_VERSION_NREV + "-g" + JEMALLOC_VERSION_GID;

--- a/modules/lwjgl/jemalloc/src/templates/kotlin/jemalloc/templates/jemalloc.kt
+++ b/modules/lwjgl/jemalloc/src/templates/kotlin/jemalloc/templates/jemalloc.kt
@@ -26,13 +26,13 @@ val jemalloc = "JEmalloc".nativeClass(Module.JEMALLOC, prefixMethod = "je_", bin
 
     IntConstant("The major version.", "JEMALLOC_VERSION_MAJOR".."5")
     IntConstant("The minor version.", "JEMALLOC_VERSION_MINOR".."2")
-    IntConstant("The bugfix version.", "JEMALLOC_VERSION_BUGFIX".."0")
+    IntConstant("The bugfix version.", "JEMALLOC_VERSION_BUGFIX".."1")
     IntConstant("The revision number.", "JEMALLOC_VERSION_NREV".."0")
 
     StringConstant(
         "The globally unique identifier (git commit hash).",
 
-        "JEMALLOC_VERSION_GID".."b0b3e49a54ec29e32636f4577d9d5a896d67fd20"
+        "JEMALLOC_VERSION_GID".."ea6b3e973b477b8061e0076bb257dbd7f3faa756"
     )
 
     StringConstant(


### PR DESCRIPTION
It seems this was checked off in b8aaf7355f78f4ffc12667607203bbefa9fbaca3, but the actual change never made it in. As a result any uses of memoryutil on windows suffer from the nasty leak fixed in jemalloc 5.2.1 with current releases, but bumping it should resolve things. 