### PR TITLE
feat(OpenXR) construct projection matrix via JOML built-ins

### DIFF
--- a/modules/samples/src/test/java/org/lwjgl/demo/openxr/HelloOpenXRGL.java
+++ b/modules/samples/src/test/java/org/lwjgl/demo/openxr/HelloOpenXRGL.java
@@ -779,9 +779,7 @@ public class HelloOpenXRGL {
         XrPosef       pose        = layerView.pose();
         XrVector3f    pos         = pose.position$();
         XrQuaternionf orientation = pose.orientation();
-        try (MemoryStack stack = stackPush()) {
-            projectionMatrix.set(XRHelper.createProjectionMatrixBuffer(stack, layerView.fov(), 0.1f, 100f, false));
-        }
+        XRHelper.applyProjectionToMatrix(projectionMatrix.identity(), layerView.fov(), 0.1f, 100f, false);
         viewMatrix.translationRotateScaleInvert(
             pos.x(), pos.y(), pos.z(),
             orientation.x(), orientation.y(), orientation.z(), orientation.w(),

--- a/modules/samples/src/test/java/org/lwjgl/demo/openxr/HelloOpenXRVK.java
+++ b/modules/samples/src/test/java/org/lwjgl/demo/openxr/HelloOpenXRVK.java
@@ -1975,7 +1975,7 @@ public class HelloOpenXRVK {
                                 XrCompositionLayerProjectionView projectionView = projectionViews.get(swapchainIndex);
 
                                 Matrix4f projectionMatrix = new Matrix4f();
-                                projectionMatrix.set(XRHelper.createProjectionMatrixBuffer(stack, projectionView.fov(), 0.01f, 100f, true));
+                                XRHelper.applyProjectionToMatrix(projectionMatrix, projectionView.fov(), 0.01f, 100f, true);
 
                                 Matrix4f viewMatrix = new Matrix4f();
 


### PR DESCRIPTION
Since we are given the angles between the left, right, bottom
and top frustum planes, respectively, and the line
perpendicular to the near/far frustum plane, we can use
glFrustum (i.e. Matrix4f.frustum) directly, providing it with
the distances to the frustum planes (via Math.tan(angle)).