### PR TITLE
fix(OpenXR): Invert y-axis of projection matrix in Vulkan example

### DIFF
--- a/modules/samples/src/test/java/org/lwjgl/demo/openxr/HelloOpenXRVK.java
+++ b/modules/samples/src/test/java/org/lwjgl/demo/openxr/HelloOpenXRVK.java
@@ -1974,7 +1974,7 @@ public class HelloOpenXRVK {
                                 // If the position tracker is working, we should use it to create the camera matrix
                                 XrCompositionLayerProjectionView projectionView = projectionViews.get(swapchainIndex);
 
-                                Matrix4f projectionMatrix = new Matrix4f();
+                                Matrix4f projectionMatrix = new Matrix4f().scale(1f, -1f, 1f);
                                 XRHelper.applyProjectionToMatrix(projectionMatrix, projectionView.fov(), 0.01f, 100f, true);
 
                                 Matrix4f viewMatrix = new Matrix4f();


### PR DESCRIPTION
While refactoring `XRHelper.applyProjectionToMatrix`, we forgot to account for the fact that the y-axis is 'upside-down' in the Vulkan coordinate system. So currently, the Vulkan example is basically upside down (this looks really weird when rotating the head vertically since the projection matrix basically 'counters' it).

This is probably the easiest solution to account for the 'upside-down' y-axis. The OpenXR + OpenGL demo looks good.