### PR TITLE
feat(OpenXR) add EGL support to HelloOpenXRGL demo

### DIFF
--- a/modules/samples/src/test/java/org/lwjgl/demo/openxr/XRHelper.java
+++ b/modules/samples/src/test/java/org/lwjgl/demo/openxr/XRHelper.java
@@ -6,11 +6,13 @@ package org.lwjgl.demo.openxr;
 
 import org.joml.Math;
 import org.joml.*;
+import org.lwjgl.egl.*;
 import org.lwjgl.openxr.*;
 import org.lwjgl.system.*;
 import org.lwjgl.system.linux.*;
 
 import static org.lwjgl.glfw.GLFW.*;
+import static org.lwjgl.glfw.GLFWNativeEGL.*;
 import static org.lwjgl.glfw.GLFWNativeGLX.*;
 import static org.lwjgl.glfw.GLFWNativeWGL.*;
 import static org.lwjgl.glfw.GLFWNativeWayland.*;
@@ -102,37 +104,63 @@ final class XRHelper {
     }
 
     /**
-     * <p>
-     * Allocates a {@code XrGraphicsBindingOpenGL**} struct for the current platform onto the given stack. It should
-     * be included in the next-chain of the {@link XrSessionCreateInfo} that will be used to create an
-     * OpenXR session with OpenGL rendering. (Every platform requires a different OpenGL graphics binding
-     * struct, so this method spares users the trouble of working with all these cases themselves.)
-     * </p>
+     * Appends the right <i>XrGraphicsBinding</i>** struct to the next chain of <i>sessionCreateInfo</i>. OpenGL
+     * session creation is poorly standardized in OpenXR, so the right graphics binding struct depends on the OS and
+     * the windowing system, among others. There are basically 4 graphics binding structs for this:
+     * <ul>
+     *     <li><i>XrGraphicsBindingOpenGLWin32KHR</i>, which can only be used on Windows computers.</li>
+     *     <li><i>XrGraphicsBindingOpenGLXlibKHR</i>, which can only be used on Linux computers with the X11 windowing system.</li>
+     *     <li>
+     *         <i>XrGraphicsBindingOpenGLWaylandKHR</i>, which can only be used on Linux computers with the
+     *         Wayland windowing system. But, no OpenXR runtime has implemented the specification for this struct and
+     *         the Wayland developers have claimed that the specification doesn't make sense and can't be implemented
+     *         as such. For this reason, this method won't use this struct.
+     *     </li>
+     *     <li>
+     *         <i>XrGraphicsBindingEGLMNDX</i>, which is cross-platform, but can only be used if the experimental
+     *         OpenXR extension <i>XR_MNDX_egl_enable</i> is enabled. But, since the extension is experimental, it
+     *         is not widely supported (at the time of writing this only by the Monado OpenXR runtime). Nevertheless,
+     *         this is the only way to create an OpenXR session on the Wayland windowing system (or on systems
+     *         without well-known windowing system).
+     *     </li>
+     * </ul>
      *
-     * <p>
-     * Note: {@link XR10#xrCreateSession} must be called <b>before</b> the given stack is dropped!
-     * </p>
+     * The parameter <b>useEGL</b> determines which graphics binding struct this method will choose:
+     * <ul>
+     *     <li>
+     *          If <b>useEGL</b> is true, this method will use <i>XrGraphicsBindingEGLMNDX</i>.
+     *          The caller must ensure that the extension <i>XR_MNDX_egl_enable</i> has been enabled.
+     *     </li>
+     *     <li>
+     *         If <b>useEGL</b> is false, this method will try to use a platform-specific struct.
+     *         If no such struct exists, it will throw an <i>IllegalStateException</i>.
+     *     </li>
+     * </ul>
      *
-     * <p>
-     * Note: Linux support is not finished, so only Windows works at the moment. This should be fixed in the
-     * future. Until then, Vulkan is the only cross-platform rendering API for the OpenXR Java bindings.
-     * </p>
-     *
-     * @param stack  The stack onto which to allocate the graphics binding struct
-     * @param window The GLFW window handle used to create the OpenGL context
-     *
-     * @return A {@code XrGraphicsBindingOpenGL**} struct that can be used to create a session
-     *
-     * @throws IllegalStateException If the current platform is not supported
+     * @param sessionCreateInfo The <i>XrSessionCreateInfo</i> whose next chain should be populated
+     * @param stack The <i>MemoryStack</i> onto which this method should allocate the graphics binding struct
+     * @param window The GLFW window
+     * @param useEGL Whether this method should use <i>XrGraphicsBindingEGLMNDX</i>
+     * @return sessionCreateInfo (after appending a graphics binding to it)
+     * @throws IllegalStateException If the current OS and/or windowing system needs EGL, but <b>useEGL</b> is false
      */
-    static XrSessionCreateInfo createGraphicsBindingOpenGL(XrSessionCreateInfo sessionCreateInfo, MemoryStack stack, long window) throws IllegalStateException {
+    static XrSessionCreateInfo createGraphicsBindingOpenGL(
+        XrSessionCreateInfo sessionCreateInfo, MemoryStack stack, long window, boolean useEGL
+    ) throws IllegalStateException {
+        if (useEGL) {
+            System.out.println("Using XrGraphicsBindingEGLMNDX to create the session...");
+            return sessionCreateInfo.next(
+                XrGraphicsBindingEGLMNDX.malloc(stack)
+                    .type$Default()
+                    .next(NULL)
+                    .getProcAddress(EGL.getCapabilities().eglGetProcAddress)
+                    .display(glfwGetEGLDisplay())
+                    .config(glfwGetEGLConfig(window))
+                    .context(glfwGetEGLContext(window))
+            );
+        }
         switch (Platform.get()) {
             case LINUX:
-                /*
-                 * NOTE: X11 is preferred over Wayland because Monado, the most promising Linux OpenXR runtime,
-                 * doesn't handle XrGraphicsBindingOpenGLWaylandKHR at the moment. See
-                 * https://gitlab.freedesktop.org/monado/monado/-/issues/128 for the current status on this.
-                 */
                 int platform = glfwGetPlatform();
                 if (platform == GLFW_PLATFORM_X11) {
                     long display   = glfwGetX11Display();
@@ -144,6 +172,7 @@ final class XRHelper {
                     }
                     long visualid = visualInfo.visualid();
 
+                    System.out.println("Using XrGraphicsBindingOpenGLXlibKHR to create the session");
                     return sessionCreateInfo.next(
                         XrGraphicsBindingOpenGLXlibKHR.malloc(stack)
                             .type$Default()
@@ -153,16 +182,13 @@ final class XRHelper {
                             .glxDrawable(glXGetCurrentDrawable())
                             .glxContext(glfwGetGLXContext(window))
                     );
-                } else if (platform == GLFW_PLATFORM_WAYLAND) {
-                    return sessionCreateInfo.next(
-                        XrGraphicsBindingOpenGLWaylandKHR.malloc(stack)
-                            .type$Default()
-                            .display(glfwGetWaylandDisplay())
-                    );
                 } else {
-                    throw new IllegalStateException("Unsupported Linux windowing system. Only X11 and Wayland are supported");
+                    throw new IllegalStateException(
+                        "X11 is the only Linux windowing system with explicit OpenXR support. All other Linux systems must use EGL."
+                    );
                 }
             case WINDOWS:
+                System.out.println("Using XrGraphicsBindingOpenGLWin32KHR to create the session");
                 return sessionCreateInfo.next(
                     XrGraphicsBindingOpenGLWin32KHR.malloc(stack)
                         .type$Default()
@@ -170,7 +196,9 @@ final class XRHelper {
                         .hGLRC(glfwGetWGLContext(window))
                 );
             default:
-                throw new IllegalStateException("Unsupported operation system: " + Platform.get());
+                throw new IllegalStateException(
+                    "Windows and Linux are the only platforms with explicit OpenXR support. All other platforms must use EGL."
+                );
         }
     }
 }


### PR DESCRIPTION
This merge request lets the `HelloOpenXRGL` demo use the extension `XR_MNDX_egl_enable`, when it is available. This extension is needed to support OpenGL session creation on Wayland and will possibly become more important in the future.