### PR TITLE
feat(core) add MemoryStack.pointersOfElements(CustomBuffer)

### DIFF
--- a/modules/lwjgl/core/src/main/java/org/lwjgl/system/MemoryStack.java
+++ b/modules/lwjgl/core/src/main/java/org/lwjgl/system/MemoryStack.java
@@ -693,6 +693,27 @@ public class MemoryStack extends Pointer.Default implements AutoCloseable {
     // -------------------------------------------------
 
     /**
+     * Allocates a new {@link PointerBuffer} of size {@code buffer.remaining()}
+     * and fills it with the addresses of the values within the provided {@link CustomBuffer}
+     * starting at {@code buffer.position()}.
+     *
+     * @param buffer the {@link CustomBuffer} to obtain its element addresses of
+     * @return a {@link PointerBuffer} containing the buffer's element addresses
+     */
+    public PointerBuffer pointersOfElements(CustomBuffer<?> buffer) {
+        int remaining = buffer.remaining();
+        long addr = buffer.address();
+        long sizeof = buffer.sizeof();
+        PointerBuffer pointerBuffer = mallocPointer(remaining);
+        for (int i = 0; i < remaining; i++) {
+            pointerBuffer.put(i, addr + sizeof * i);
+        }
+        return pointerBuffer;
+    }
+
+    // -------------------------------------------------
+
+    /**
      * Encodes the specified text on the stack using ASCII encoding and returns a {@code ByteBuffer} that points to the encoded text, including a
      * null-terminator.
      *


### PR DESCRIPTION
Primary use-case is the argument `ppBuildRangeInfos` of the `vkCmdBuildAccelerationStructuresKHR` function.
It takes a `const VkAccelerationStructureBuildRangeInfoKHR* const*` which in LWJGL is a `PointerBuffer` which should hold the addresses of `VkAccelerationStructureBuildRangeInfoKHR` struct values.
Those values can be created by `VkAccelerationStructureBuildRangeInfoKHR.malloc/calloc(N, stack)` but there needs to be a way to convert that into a `PointerBuffer` of all struct addresses (simply offset by the StructBuffer's base address).