### PR TITLE
fix VK_API_VERSION_PATCH

### DIFF
--- a/doc/notes/3.3.2.md
+++ b/doc/notes/3.3.2.md
@@ -15,6 +15,7 @@ This build includes the following changes:
 - Core: Fixed Java/native library incompatibility detection. (#737)
 - Core: Fixed `dlerror` decoding to use UTF-8. (#738)
 - Build: Fixed offline mode with multiple local architectures. (#740)
+- Vulkan: Fixed definition of the `VK_API_VERSION_PATCH` macro. (#743)
 
 #### Breaking Changes
 

--- a/modules/lwjgl/vulkan/src/generated/java/org/lwjgl/vulkan/VK10.java
+++ b/modules/lwjgl/vulkan/src/generated/java/org/lwjgl/vulkan/VK10.java
@@ -15491,7 +15491,7 @@ public class VK10 {
      */
     @NativeType("uint32_t")
     public static int VK_API_VERSION_PATCH(@NativeType("uint32_t") int version) {
-        return (version >>> 22) & 0xFFF;
+        return version & 0xFFF;
     }
 
     // --- [ VK_MAKE_VERSION ] ---

--- a/modules/lwjgl/vulkan/src/templates/kotlin/vulkan/Custom.kt
+++ b/modules/lwjgl/vulkan/src/templates/kotlin/vulkan/Custom.kt
@@ -101,7 +101,7 @@ fun templateCustomization() {
             noPrefix = true
         )
 
-        macro(expression = "(version >>> 22) & 0xFFF")..uint32_t(
+        macro(expression = "version & 0xFFF")..uint32_t(
             "VK_API_VERSION_PATCH",
             "Extracts the API patch version number from a packed version number.",
 


### PR DESCRIPTION
the implementation of VK_API_VERSION_PATCH added in c4815d3 mistakenly returns bits 22-31 instead of 0-11