### PR TITLE
feat(core) add MemoryUtil.memByteBuffer(Struct)

### DIFF
--- a/modules/lwjgl/core/src/main/java/org/lwjgl/system/MemoryUtil.java
+++ b/modules/lwjgl/core/src/main/java/org/lwjgl/system/MemoryUtil.java
@@ -992,6 +992,19 @@ public final class MemoryUtil {
     }
 
     /**
+     * Creates a {@link ByteBuffer} instance as a view of the specified {@link Struct}.
+     *
+     * <p>The returned {@code ByteBuffer} instance will be set to the native {@link ByteOrder}.</p>
+     *
+     * @param struct the source struct
+     *
+     * @return the {@code ByteBuffer} view
+     */
+    public static ByteBuffer memByteBuffer(Struct struct) {
+        return wrap(BUFFER_BYTE, struct.address(), struct.sizeof()).order(NATIVE_ORDER);
+    }
+
+    /**
      * Creates a new direct ShortBuffer that starts at the specified memory address and has the specified capacity.
      *
      * <p>The {@code address} specified must be aligned to 2 bytes. If not, use {@code memByteBuffer(address, capacity * 2).asShortBuffer()}.</p>


### PR DESCRIPTION
What already works: View a `Struct.Buffer` as a `ByteBuffer`:
```java
uploadBuffer(
  memByteBuffer(
    // VkAccelerationStructureInstanceKHR.Buffer
    VkAccelerationStructureInstanceKHR
      .calloc(1, stack)
      .accelerationStructureReference(blasDeviceAddress)
      .mask(~0)
      .flags(...)
      .transform(...)
  )
);
```

What this PR is adding: View _a single_ `Struct` as a `ByteBuffer`:
```java
uploadBuffer(
  memByteBuffer(
    // VkAccelerationStructureInstanceKHR
    VkAccelerationStructureInstanceKHR
      .calloc(stack)
      .accelerationStructureReference(blasDeviceAddress)
      .mask(~0)
      .flags(...)
      .transform(...)
  )
);
```