### PR TITLE
Support JNI_VERSION_19 fixing crash with Java 19 EA when preview features are enabled.

### DIFF
--- a/doc/notes/3.3.2.md
+++ b/doc/notes/3.3.2.md
@@ -25,6 +25,7 @@ This build includes the following changes:
 #### Improvements
 
 - Windows: Shared libraries are now built with Visual Studio 2022 (up from 2019)
+- Core: Added support for JDK 19 (#799)
 - Core: Added `MemoryUtil::memByteBuffer(Struct)`. It creates a `ByteBuffer` view of a struct value.
 - Core: More `SharedLibraryLoader` improvements. (#790)
   * The default `Configuration.SHARED_LIBRARY_EXTRACT_DIRECTORY` is now `lwjgl_<trimmed_user_name>`.

--- a/modules/lwjgl/core/src/generated/java/org/lwjgl/system/jni/JNINativeInterface.java
+++ b/modules/lwjgl/core/src/generated/java/org/lwjgl/system/jni/JNINativeInterface.java
@@ -42,7 +42,8 @@ public class JNINativeInterface {
         JNI_VERSION_1_6 = 0x10006,
         JNI_VERSION_1_8 = 0x10008,
         JNI_VERSION_9   = 0x90000,
-        JNI_VERSION_10  = 0xA0000;
+        JNI_VERSION_10  = 0xA0000,
+        JNI_VERSION_19  = 0x130000;
 
     /**
      * {@code jobjectRefType}: Return values from {@link #GetObjectRefType}.

--- a/modules/lwjgl/core/src/main/java/org/lwjgl/system/ThreadLocalUtil.java
+++ b/modules/lwjgl/core/src/main/java/org/lwjgl/system/ThreadLocalUtil.java
@@ -130,8 +130,11 @@ public final class ThreadLocalUtil {
             case JNI_VERSION_10:
                 jniCallCount = 230;
                 break;
+            case JNI_VERSION_19:
+                jniCallCount = 231;
+                break;
             default:
-                jniCallCount = 230;
+                jniCallCount = 231;
                 DEBUG_STREAM
                     .println("[LWJGL] [ThreadLocalUtil] Unsupported JNI version detected, this may result in a crash. Please inform LWJGL developers.");
         }

--- a/modules/lwjgl/core/src/templates/kotlin/core/jni/templates/JNINativeInterface.kt
+++ b/modules/lwjgl/core/src/templates/kotlin/core/jni/templates/JNINativeInterface.kt
@@ -32,7 +32,8 @@ val JNINativeInterface = "JNINativeInterface".nativeClass(Module.CORE_JNI, prefi
         "VERSION_1_6"..0x00010006,
         "VERSION_1_8"..0x00010008,
         "VERSION_9"..0x00090000,
-        "VERSION_10"..0x000A0000
+        "VERSION_10"..0x000A0000,
+        "VERSION_19"..0x00130000
     )
 
     EnumConstant(


### PR DESCRIPTION
[JEP 425](https://openjdk.org/jeps/425) (Project Loom) added the JNI function `IsVirtualThread`. This PR updates `ThreadLocalUtil` to support the addion of this new function and JNI version.

JDK change: https://github.com/openjdk/jdk/commit/53bf1bfdabb79b37afedd09051d057f9eea620f2
JDK issue: https://bugs.openjdk.org/browse/JDK-8286176

This change fixes a crash when running on the latest Java 19 EA build with preview features enabled. This was noticed when testing with Minecraft 1.19.2 on Windows + Java 19 EA with preview features enabled.

Please let me know if any further information or testing is required 👍 