### PR TITLE
Improve VKCapabilitiesDevice and VKCapabilitiesInstance documentation

### DIFF
--- a/modules/lwjgl/vulkan/src/generated/java/org/lwjgl/vulkan/VKCapabilitiesDevice.java
+++ b/modules/lwjgl/vulkan/src/generated/java/org/lwjgl/vulkan/VKCapabilitiesDevice.java
@@ -10,11 +10,15 @@ import org.lwjgl.system.*;
 
 import static org.lwjgl.system.Checks.*;
 
-/** Defines the enabled capabilities of a Vulkan {@code VkDevice}. */
+/**
+ * Reports the enabled capabilities and function pointers of a Vulkan {@code VkDevice}.
+ * 
+ * <p>The addresses are cached for future use. This class also allows developers to query the capabilities made available to the Vulkan device handle.</p>
+ */
 @SuppressWarnings("SimplifiableIfStatement")
 public class VKCapabilitiesDevice {
 
-    // VK10
+    /** Function pointers for VK10 */
     public final long
         vkGetDeviceProcAddr,
         vkDestroyDevice,
@@ -138,7 +142,7 @@ public class VKCapabilitiesDevice {
         vkCmdEndRenderPass,
         vkCmdExecuteCommands;
 
-    // VK11
+    /** Function pointers for VK11 */
     public final long
         vkBindBufferMemory2,
         vkBindImageMemory2,
@@ -157,7 +161,7 @@ public class VKCapabilitiesDevice {
         vkUpdateDescriptorSetWithTemplate,
         vkGetDescriptorSetLayoutSupport;
 
-    // VK12
+    /** Function pointers for VK12 */
     public final long
         vkCmdDrawIndirectCount,
         vkCmdDrawIndexedIndirectCount,
@@ -173,7 +177,7 @@ public class VKCapabilitiesDevice {
         vkGetBufferOpaqueCaptureAddress,
         vkGetDeviceMemoryOpaqueCaptureAddress;
 
-    // VK13
+    /** Function pointers for VK13 */
     public final long
         vkCreatePrivateDataSlot,
         vkDestroyPrivateDataSlot,
@@ -212,41 +216,41 @@ public class VKCapabilitiesDevice {
         vkGetDeviceImageMemoryRequirements,
         vkGetDeviceImageSparseMemoryRequirements;
 
-    // AMD_buffer_marker
+    /** Function pointers for AMD_buffer_marker */
     public final long
         vkCmdWriteBufferMarkerAMD;
 
-    // AMD_display_native_hdr
+    /** Function pointers for AMD_display_native_hdr */
     public final long
         vkSetLocalDimmingAMD;
 
-    // AMD_draw_indirect_count
+    /** Function pointers for AMD_draw_indirect_count */
     public final long
         vkCmdDrawIndirectCountAMD,
         vkCmdDrawIndexedIndirectCountAMD;
 
-    // AMD_shader_info
+    /** Function pointers for AMD_shader_info */
     public final long
         vkGetShaderInfoAMD;
 
-    // EXT_buffer_device_address
+    /** Function pointers for EXT_buffer_device_address */
     public final long
         vkGetBufferDeviceAddressEXT;
 
-    // EXT_calibrated_timestamps
+    /** Function pointers for EXT_calibrated_timestamps */
     public final long
         vkGetCalibratedTimestampsEXT;
 
-    // EXT_color_write_enable
+    /** Function pointers for EXT_color_write_enable */
     public final long
         vkCmdSetColorWriteEnableEXT;
 
-    // EXT_conditional_rendering
+    /** Function pointers for EXT_conditional_rendering */
     public final long
         vkCmdBeginConditionalRenderingEXT,
         vkCmdEndConditionalRenderingEXT;
 
-    // EXT_debug_marker
+    /** Function pointers for EXT_debug_marker */
     public final long
         vkDebugMarkerSetObjectTagEXT,
         vkDebugMarkerSetObjectNameEXT,
@@ -254,22 +258,22 @@ public class VKCapabilitiesDevice {
         vkCmdDebugMarkerEndEXT,
         vkCmdDebugMarkerInsertEXT;
 
-    // EXT_device_fault
+    /** Function pointers for EXT_device_fault */
     public final long
         vkGetDeviceFaultInfoEXT;
 
-    // EXT_discard_rectangles
+    /** Function pointers for EXT_discard_rectangles */
     public final long
         vkCmdSetDiscardRectangleEXT;
 
-    // EXT_display_control
+    /** Function pointers for EXT_display_control */
     public final long
         vkDisplayPowerControlEXT,
         vkRegisterDeviceEventEXT,
         vkRegisterDisplayEventEXT,
         vkGetSwapchainCounterEXT;
 
-    // EXT_extended_dynamic_state
+    /** Function pointers for EXT_extended_dynamic_state */
     public final long
         vkCmdSetCullModeEXT,
         vkCmdSetFrontFaceEXT,
@@ -284,7 +288,7 @@ public class VKCapabilitiesDevice {
         vkCmdSetStencilTestEnableEXT,
         vkCmdSetStencilOpEXT;
 
-    // EXT_extended_dynamic_state2
+    /** Function pointers for EXT_extended_dynamic_state2 */
     public final long
         vkCmdSetPatchControlPointsEXT,
         vkCmdSetRasterizerDiscardEnableEXT,
@@ -292,7 +296,7 @@ public class VKCapabilitiesDevice {
         vkCmdSetLogicOpEXT,
         vkCmdSetPrimitiveRestartEnableEXT;
 
-    // EXT_extended_dynamic_state3
+    /** Function pointers for EXT_extended_dynamic_state3 */
     public final long
         vkCmdSetTessellationDomainOriginEXT,
         vkCmdSetDepthClampEnableEXT,
@@ -326,52 +330,52 @@ public class VKCapabilitiesDevice {
         vkCmdSetRepresentativeFragmentTestEnableNV,
         vkCmdSetCoverageReductionModeNV;
 
-    // EXT_external_memory_host
+    /** Function pointers for EXT_external_memory_host */
     public final long
         vkGetMemoryHostPointerPropertiesEXT;
 
-    // EXT_full_screen_exclusive
+    /** Function pointers for EXT_full_screen_exclusive */
     public final long
         vkAcquireFullScreenExclusiveModeEXT,
         vkReleaseFullScreenExclusiveModeEXT,
         vkGetDeviceGroupSurfacePresentModes2EXT;
 
-    // EXT_hdr_metadata
+    /** Function pointers for EXT_hdr_metadata */
     public final long
         vkSetHdrMetadataEXT;
 
-    // EXT_host_query_reset
+    /** Function pointers for EXT_host_query_reset */
     public final long
         vkResetQueryPoolEXT;
 
-    // EXT_image_compression_control
+    /** Function pointers for EXT_image_compression_control */
     public final long
         vkGetImageSubresourceLayout2EXT;
 
-    // EXT_image_drm_format_modifier
+    /** Function pointers for EXT_image_drm_format_modifier */
     public final long
         vkGetImageDrmFormatModifierPropertiesEXT;
 
-    // EXT_line_rasterization
+    /** Function pointers for EXT_line_rasterization */
     public final long
         vkCmdSetLineStippleEXT;
 
-    // EXT_mesh_shader
+    /** Function pointers for EXT_mesh_shader */
     public final long
         vkCmdDrawMeshTasksEXT,
         vkCmdDrawMeshTasksIndirectEXT,
         vkCmdDrawMeshTasksIndirectCountEXT;
 
-    // EXT_metal_objects
+    /** Function pointers for EXT_metal_objects */
     public final long
         vkExportMetalObjectsEXT;
 
-    // EXT_multi_draw
+    /** Function pointers for EXT_multi_draw */
     public final long
         vkCmdDrawMultiEXT,
         vkCmdDrawMultiIndexedEXT;
 
-    // EXT_opacity_micromap
+    /** Function pointers for EXT_opacity_micromap */
     public final long
         vkCreateMicromapEXT,
         vkDestroyMicromapEXT,
@@ -388,31 +392,31 @@ public class VKCapabilitiesDevice {
         vkGetDeviceMicromapCompatibilityEXT,
         vkGetMicromapBuildSizesEXT;
 
-    // EXT_pageable_device_local_memory
+    /** Function pointers for EXT_pageable_device_local_memory */
     public final long
         vkSetDeviceMemoryPriorityEXT;
 
-    // EXT_pipeline_properties
+    /** Function pointers for EXT_pipeline_properties */
     public final long
         vkGetPipelinePropertiesEXT;
 
-    // EXT_private_data
+    /** Function pointers for EXT_private_data */
     public final long
         vkCreatePrivateDataSlotEXT,
         vkDestroyPrivateDataSlotEXT,
         vkSetPrivateDataEXT,
         vkGetPrivateDataEXT;
 
-    // EXT_sample_locations
+    /** Function pointers for EXT_sample_locations */
     public final long
         vkCmdSetSampleLocationsEXT;
 
-    // EXT_shader_module_identifier
+    /** Function pointers for EXT_shader_module_identifier */
     public final long
         vkGetShaderModuleIdentifierEXT,
         vkGetShaderModuleCreateInfoIdentifierEXT;
 
-    // EXT_transform_feedback
+    /** Function pointers for EXT_transform_feedback */
     public final long
         vkCmdBindTransformFeedbackBuffersEXT,
         vkCmdBeginTransformFeedbackEXT,
@@ -421,32 +425,32 @@ public class VKCapabilitiesDevice {
         vkCmdEndQueryIndexedEXT,
         vkCmdDrawIndirectByteCountEXT;
 
-    // EXT_validation_cache
+    /** Function pointers for EXT_validation_cache */
     public final long
         vkCreateValidationCacheEXT,
         vkDestroyValidationCacheEXT,
         vkMergeValidationCachesEXT,
         vkGetValidationCacheDataEXT;
 
-    // EXT_vertex_input_dynamic_state
+    /** Function pointers for EXT_vertex_input_dynamic_state */
     public final long
         vkCmdSetVertexInputEXT;
 
-    // GOOGLE_display_timing
+    /** Function pointers for GOOGLE_display_timing */
     public final long
         vkGetRefreshCycleDurationGOOGLE,
         vkGetPastPresentationTimingGOOGLE;
 
-    // HUAWEI_invocation_mask
+    /** Function pointers for HUAWEI_invocation_mask */
     public final long
         vkCmdBindInvocationMaskHUAWEI;
 
-    // HUAWEI_subpass_shading
+    /** Function pointers for HUAWEI_subpass_shading */
     public final long
         vkGetDeviceSubpassShadingMaxWorkgroupSizeHUAWEI,
         vkCmdSubpassShadingHUAWEI;
 
-    // INTEL_performance_query
+    /** Function pointers for INTEL_performance_query */
     public final long
         vkInitializePerformanceApiINTEL,
         vkUninitializePerformanceApiINTEL,
@@ -458,7 +462,7 @@ public class VKCapabilitiesDevice {
         vkQueueSetPerformanceConfigurationINTEL,
         vkGetPerformanceParameterINTEL;
 
-    // KHR_acceleration_structure
+    /** Function pointers for KHR_acceleration_structure */
     public final long
         vkCreateAccelerationStructureKHR,
         vkDestroyAccelerationStructureKHR,
@@ -477,18 +481,18 @@ public class VKCapabilitiesDevice {
         vkGetDeviceAccelerationStructureCompatibilityKHR,
         vkGetAccelerationStructureBuildSizesKHR;
 
-    // KHR_bind_memory2
+    /** Function pointers for KHR_bind_memory2 */
     public final long
         vkBindBufferMemory2KHR,
         vkBindImageMemory2KHR;
 
-    // KHR_buffer_device_address
+    /** Function pointers for KHR_buffer_device_address */
     public final long
         vkGetBufferDeviceAddressKHR,
         vkGetBufferOpaqueCaptureAddressKHR,
         vkGetDeviceMemoryOpaqueCaptureAddressKHR;
 
-    // KHR_copy_commands2
+    /** Function pointers for KHR_copy_commands2 */
     public final long
         vkCmdCopyBuffer2KHR,
         vkCmdCopyImage2KHR,
@@ -497,14 +501,14 @@ public class VKCapabilitiesDevice {
         vkCmdBlitImage2KHR,
         vkCmdResolveImage2KHR;
 
-    // KHR_create_renderpass2
+    /** Function pointers for KHR_create_renderpass2 */
     public final long
         vkCreateRenderPass2KHR,
         vkCmdBeginRenderPass2KHR,
         vkCmdNextSubpass2KHR,
         vkCmdEndRenderPass2KHR;
 
-    // KHR_deferred_host_operations
+    /** Function pointers for KHR_deferred_host_operations */
     public final long
         vkCreateDeferredOperationKHR,
         vkDestroyDeferredOperationKHR,
@@ -512,14 +516,14 @@ public class VKCapabilitiesDevice {
         vkGetDeferredOperationResultKHR,
         vkDeferredOperationJoinKHR;
 
-    // KHR_descriptor_update_template
+    /** Function pointers for KHR_descriptor_update_template */
     public final long
         vkCreateDescriptorUpdateTemplateKHR,
         vkDestroyDescriptorUpdateTemplateKHR,
         vkUpdateDescriptorSetWithTemplateKHR,
         vkCmdPushDescriptorSetWithTemplateKHR;
 
-    // KHR_device_group
+    /** Function pointers for KHR_device_group */
     public final long
         vkGetDeviceGroupPeerMemoryFeaturesKHR,
         vkCmdSetDeviceMaskKHR,
@@ -528,98 +532,98 @@ public class VKCapabilitiesDevice {
         vkGetDeviceGroupSurfacePresentModesKHR,
         vkAcquireNextImage2KHR;
 
-    // KHR_display_swapchain
+    /** Function pointers for KHR_display_swapchain */
     public final long
         vkCreateSharedSwapchainsKHR;
 
-    // KHR_draw_indirect_count
+    /** Function pointers for KHR_draw_indirect_count */
     public final long
         vkCmdDrawIndirectCountKHR,
         vkCmdDrawIndexedIndirectCountKHR;
 
-    // KHR_dynamic_rendering
+    /** Function pointers for KHR_dynamic_rendering */
     public final long
         vkCmdBeginRenderingKHR,
         vkCmdEndRenderingKHR;
 
-    // KHR_external_fence_fd
+    /** Function pointers for KHR_external_fence_fd */
     public final long
         vkImportFenceFdKHR,
         vkGetFenceFdKHR;
 
-    // KHR_external_fence_win32
+    /** Function pointers for KHR_external_fence_win32 */
     public final long
         vkImportFenceWin32HandleKHR,
         vkGetFenceWin32HandleKHR;
 
-    // KHR_external_memory_fd
+    /** Function pointers for KHR_external_memory_fd */
     public final long
         vkGetMemoryFdKHR,
         vkGetMemoryFdPropertiesKHR;
 
-    // KHR_external_memory_win32
+    /** Function pointers for KHR_external_memory_win32 */
     public final long
         vkGetMemoryWin32HandleKHR,
         vkGetMemoryWin32HandlePropertiesKHR;
 
-    // KHR_external_semaphore_fd
+    /** Function pointers for KHR_external_semaphore_fd */
     public final long
         vkImportSemaphoreFdKHR,
         vkGetSemaphoreFdKHR;
 
-    // KHR_external_semaphore_win32
+    /** Function pointers for KHR_external_semaphore_win32 */
     public final long
         vkImportSemaphoreWin32HandleKHR,
         vkGetSemaphoreWin32HandleKHR;
 
-    // KHR_fragment_shading_rate
+    /** Function pointers for KHR_fragment_shading_rate */
     public final long
         vkCmdSetFragmentShadingRateKHR;
 
-    // KHR_get_memory_requirements2
+    /** Function pointers for KHR_get_memory_requirements2 */
     public final long
         vkGetImageMemoryRequirements2KHR,
         vkGetBufferMemoryRequirements2KHR,
         vkGetImageSparseMemoryRequirements2KHR;
 
-    // KHR_maintenance1
+    /** Function pointers for KHR_maintenance1 */
     public final long
         vkTrimCommandPoolKHR;
 
-    // KHR_maintenance3
+    /** Function pointers for KHR_maintenance3 */
     public final long
         vkGetDescriptorSetLayoutSupportKHR;
 
-    // KHR_maintenance4
+    /** Function pointers for KHR_maintenance4 */
     public final long
         vkGetDeviceBufferMemoryRequirementsKHR,
         vkGetDeviceImageMemoryRequirementsKHR,
         vkGetDeviceImageSparseMemoryRequirementsKHR;
 
-    // KHR_performance_query
+    /** Function pointers for KHR_performance_query */
     public final long
         vkAcquireProfilingLockKHR,
         vkReleaseProfilingLockKHR;
 
-    // KHR_pipeline_executable_properties
+    /** Function pointers for KHR_pipeline_executable_properties */
     public final long
         vkGetPipelineExecutablePropertiesKHR,
         vkGetPipelineExecutableStatisticsKHR,
         vkGetPipelineExecutableInternalRepresentationsKHR;
 
-    // KHR_present_wait
+    /** Function pointers for KHR_present_wait */
     public final long
         vkWaitForPresentKHR;
 
-    // KHR_push_descriptor
+    /** Function pointers for KHR_push_descriptor */
     public final long
         vkCmdPushDescriptorSetKHR;
 
-    // KHR_ray_tracing_maintenance1
+    /** Function pointers for KHR_ray_tracing_maintenance1 */
     public final long
         vkCmdTraceRaysIndirect2KHR;
 
-    // KHR_ray_tracing_pipeline
+    /** Function pointers for KHR_ray_tracing_pipeline */
     public final long
         vkCmdTraceRaysKHR,
         vkCreateRayTracingPipelinesKHR,
@@ -629,16 +633,16 @@ public class VKCapabilitiesDevice {
         vkGetRayTracingShaderGroupStackSizeKHR,
         vkCmdSetRayTracingPipelineStackSizeKHR;
 
-    // KHR_sampler_ycbcr_conversion
+    /** Function pointers for KHR_sampler_ycbcr_conversion */
     public final long
         vkCreateSamplerYcbcrConversionKHR,
         vkDestroySamplerYcbcrConversionKHR;
 
-    // KHR_shared_presentable_image
+    /** Function pointers for KHR_shared_presentable_image */
     public final long
         vkGetSwapchainStatusKHR;
 
-    // KHR_swapchain
+    /** Function pointers for KHR_swapchain */
     public final long
         vkCreateSwapchainKHR,
         vkDestroySwapchainKHR,
@@ -646,7 +650,7 @@ public class VKCapabilitiesDevice {
         vkAcquireNextImageKHR,
         vkQueuePresentKHR;
 
-    // KHR_synchronization2
+    /** Function pointers for KHR_synchronization2 */
     public final long
         vkCmdSetEvent2KHR,
         vkCmdResetEvent2KHR,
@@ -657,21 +661,21 @@ public class VKCapabilitiesDevice {
         vkCmdWriteBufferMarker2AMD,
         vkGetQueueCheckpointData2NV;
 
-    // KHR_timeline_semaphore
+    /** Function pointers for KHR_timeline_semaphore */
     public final long
         vkGetSemaphoreCounterValueKHR,
         vkWaitSemaphoresKHR,
         vkSignalSemaphoreKHR;
 
-    // KHR_video_decode_queue
+    /** Function pointers for KHR_video_decode_queue */
     public final long
         vkCmdDecodeVideoKHR;
 
-    // KHR_video_encode_queue
+    /** Function pointers for KHR_video_encode_queue */
     public final long
         vkCmdEncodeVideoKHR;
 
-    // KHR_video_queue
+    /** Function pointers for KHR_video_queue */
     public final long
         vkCreateVideoSessionKHR,
         vkDestroyVideoSessionKHR,
@@ -684,16 +688,16 @@ public class VKCapabilitiesDevice {
         vkCmdEndVideoCodingKHR,
         vkCmdControlVideoCodingKHR;
 
-    // NV_clip_space_w_scaling
+    /** Function pointers for NV_clip_space_w_scaling */
     public final long
         vkCmdSetViewportWScalingNV;
 
-    // NV_device_diagnostic_checkpoints
+    /** Function pointers for NV_device_diagnostic_checkpoints */
     public final long
         vkCmdSetCheckpointNV,
         vkGetQueueCheckpointDataNV;
 
-    // NV_device_generated_commands
+    /** Function pointers for NV_device_generated_commands */
     public final long
         vkGetGeneratedCommandsMemoryRequirementsNV,
         vkCmdPreprocessGeneratedCommandsNV,
@@ -702,32 +706,32 @@ public class VKCapabilitiesDevice {
         vkCreateIndirectCommandsLayoutNV,
         vkDestroyIndirectCommandsLayoutNV;
 
-    // NV_external_memory_rdma
+    /** Function pointers for NV_external_memory_rdma */
     public final long
         vkGetMemoryRemoteAddressNV;
 
-    // NV_external_memory_win32
+    /** Function pointers for NV_external_memory_win32 */
     public final long
         vkGetMemoryWin32HandleNV;
 
-    // NV_fragment_shading_rate_enums
+    /** Function pointers for NV_fragment_shading_rate_enums */
     public final long
         vkCmdSetFragmentShadingRateEnumNV;
 
-    // NV_mesh_shader
+    /** Function pointers for NV_mesh_shader */
     public final long
         vkCmdDrawMeshTasksNV,
         vkCmdDrawMeshTasksIndirectNV,
         vkCmdDrawMeshTasksIndirectCountNV;
 
-    // NV_optical_flow
+    /** Function pointers for NV_optical_flow */
     public final long
         vkCreateOpticalFlowSessionNV,
         vkDestroyOpticalFlowSessionNV,
         vkBindOpticalFlowSessionImageNV,
         vkCmdOpticalFlowExecuteNV;
 
-    // NV_ray_tracing
+    /** Function pointers for NV_ray_tracing */
     public final long
         vkCreateAccelerationStructureNV,
         vkDestroyAccelerationStructureNV,
@@ -742,17 +746,17 @@ public class VKCapabilitiesDevice {
         vkCmdWriteAccelerationStructuresPropertiesNV,
         vkCompileDeferredNV;
 
-    // NV_scissor_exclusive
+    /** Function pointers for NV_scissor_exclusive */
     public final long
         vkCmdSetExclusiveScissorNV;
 
-    // NV_shading_rate_image
+    /** Function pointers for NV_shading_rate_image */
     public final long
         vkCmdBindShadingRateImageNV,
         vkCmdSetViewportShadingRatePaletteNV,
         vkCmdSetCoarseSampleOrderNV;
 
-    // NVX_binary_import
+    /** Function pointers for NVX_binary_import */
     public final long
         vkCreateCuModuleNVX,
         vkCreateCuFunctionNVX,
@@ -760,17 +764,17 @@ public class VKCapabilitiesDevice {
         vkDestroyCuFunctionNVX,
         vkCmdCuLaunchKernelNVX;
 
-    // NVX_image_view_handle
+    /** Function pointers for NVX_image_view_handle */
     public final long
         vkGetImageViewHandleNVX,
         vkGetImageViewAddressNVX;
 
-    // QCOM_tile_properties
+    /** Function pointers for QCOM_tile_properties */
     public final long
         vkGetFramebufferTilePropertiesQCOM,
         vkGetDynamicRenderingTilePropertiesQCOM;
 
-    // VALVE_descriptor_set_host_mapping
+    /** Function pointers for VALVE_descriptor_set_host_mapping */
     public final long
         vkGetDescriptorSetLayoutHostMappingInfoVALVE,
         vkGetDescriptorSetHostMappingVALVE;

--- a/modules/lwjgl/vulkan/src/generated/java/org/lwjgl/vulkan/VKCapabilitiesInstance.java
+++ b/modules/lwjgl/vulkan/src/generated/java/org/lwjgl/vulkan/VKCapabilitiesInstance.java
@@ -10,11 +10,15 @@ import java.util.Set;
 
 import static org.lwjgl.system.Checks.*;
 
-/** Defines the enabled capabilities of a Vulkan {@code VkInstance}. */
+/**
+ * Reports the enabled capabilities and function pointers of a Vulkan {@code VkInstance}.
+ * 
+ * <p>The addresses are cached for future use. This class also allows developers to query the capabilities made available to the Vulkan instance handle.</p>
+ */
 @SuppressWarnings("SimplifiableIfStatement")
 public class VKCapabilitiesInstance {
 
-    // VK10
+    /** Function pointers for VK10 */
     public final long
         vkDestroyInstance,
         vkEnumeratePhysicalDevices,
@@ -29,7 +33,7 @@ public class VKCapabilitiesInstance {
         vkEnumerateDeviceLayerProperties,
         vkGetPhysicalDeviceSparseImageFormatProperties;
 
-    // VK11
+    /** Function pointers for VK11 */
     public final long
         vkEnumeratePhysicalDeviceGroups,
         vkGetPhysicalDeviceFeatures2,
@@ -43,31 +47,31 @@ public class VKCapabilitiesInstance {
         vkGetPhysicalDeviceExternalFenceProperties,
         vkGetPhysicalDeviceExternalSemaphoreProperties;
 
-    // VK13
+    /** Function pointers for VK13 */
     public final long
         vkGetPhysicalDeviceToolProperties;
 
-    // EXT_acquire_drm_display
+    /** Function pointers for EXT_acquire_drm_display */
     public final long
         vkAcquireDrmDisplayEXT,
         vkGetDrmDisplayEXT;
 
-    // EXT_acquire_xlib_display
+    /** Function pointers for EXT_acquire_xlib_display */
     public final long
         vkAcquireXlibDisplayEXT,
         vkGetRandROutputDisplayEXT;
 
-    // EXT_calibrated_timestamps
+    /** Function pointers for EXT_calibrated_timestamps */
     public final long
         vkGetPhysicalDeviceCalibrateableTimeDomainsEXT;
 
-    // EXT_debug_report
+    /** Function pointers for EXT_debug_report */
     public final long
         vkCreateDebugReportCallbackEXT,
         vkDestroyDebugReportCallbackEXT,
         vkDebugReportMessageEXT;
 
-    // EXT_debug_utils
+    /** Function pointers for EXT_debug_utils */
     public final long
         vkSetDebugUtilsObjectNameEXT,
         vkSetDebugUtilsObjectTagEXT,
@@ -81,43 +85,43 @@ public class VKCapabilitiesInstance {
         vkDestroyDebugUtilsMessengerEXT,
         vkSubmitDebugUtilsMessageEXT;
 
-    // EXT_direct_mode_display
+    /** Function pointers for EXT_direct_mode_display */
     public final long
         vkReleaseDisplayEXT;
 
-    // EXT_display_surface_counter
+    /** Function pointers for EXT_display_surface_counter */
     public final long
         vkGetPhysicalDeviceSurfaceCapabilities2EXT;
 
-    // EXT_full_screen_exclusive
+    /** Function pointers for EXT_full_screen_exclusive */
     public final long
         vkGetPhysicalDeviceSurfacePresentModes2EXT;
 
-    // EXT_headless_surface
+    /** Function pointers for EXT_headless_surface */
     public final long
         vkCreateHeadlessSurfaceEXT;
 
-    // EXT_metal_surface
+    /** Function pointers for EXT_metal_surface */
     public final long
         vkCreateMetalSurfaceEXT;
 
-    // EXT_sample_locations
+    /** Function pointers for EXT_sample_locations */
     public final long
         vkGetPhysicalDeviceMultisamplePropertiesEXT;
 
-    // EXT_tooling_info
+    /** Function pointers for EXT_tooling_info */
     public final long
         vkGetPhysicalDeviceToolPropertiesEXT;
 
-    // KHR_device_group
+    /** Function pointers for KHR_device_group */
     public final long
         vkGetPhysicalDevicePresentRectanglesKHR;
 
-    // KHR_device_group_creation
+    /** Function pointers for KHR_device_group_creation */
     public final long
         vkEnumeratePhysicalDeviceGroupsKHR;
 
-    // KHR_display
+    /** Function pointers for KHR_display */
     public final long
         vkGetPhysicalDeviceDisplayPropertiesKHR,
         vkGetPhysicalDeviceDisplayPlanePropertiesKHR,
@@ -127,30 +131,30 @@ public class VKCapabilitiesInstance {
         vkGetDisplayPlaneCapabilitiesKHR,
         vkCreateDisplayPlaneSurfaceKHR;
 
-    // KHR_external_fence_capabilities
+    /** Function pointers for KHR_external_fence_capabilities */
     public final long
         vkGetPhysicalDeviceExternalFencePropertiesKHR;
 
-    // KHR_external_memory_capabilities
+    /** Function pointers for KHR_external_memory_capabilities */
     public final long
         vkGetPhysicalDeviceExternalBufferPropertiesKHR;
 
-    // KHR_external_semaphore_capabilities
+    /** Function pointers for KHR_external_semaphore_capabilities */
     public final long
         vkGetPhysicalDeviceExternalSemaphorePropertiesKHR;
 
-    // KHR_fragment_shading_rate
+    /** Function pointers for KHR_fragment_shading_rate */
     public final long
         vkGetPhysicalDeviceFragmentShadingRatesKHR;
 
-    // KHR_get_display_properties2
+    /** Function pointers for KHR_get_display_properties2 */
     public final long
         vkGetPhysicalDeviceDisplayProperties2KHR,
         vkGetPhysicalDeviceDisplayPlaneProperties2KHR,
         vkGetDisplayModeProperties2KHR,
         vkGetDisplayPlaneCapabilities2KHR;
 
-    // KHR_get_physical_device_properties2
+    /** Function pointers for KHR_get_physical_device_properties2 */
     public final long
         vkGetPhysicalDeviceFeatures2KHR,
         vkGetPhysicalDeviceProperties2KHR,
@@ -160,17 +164,17 @@ public class VKCapabilitiesInstance {
         vkGetPhysicalDeviceMemoryProperties2KHR,
         vkGetPhysicalDeviceSparseImageFormatProperties2KHR;
 
-    // KHR_get_surface_capabilities2
+    /** Function pointers for KHR_get_surface_capabilities2 */
     public final long
         vkGetPhysicalDeviceSurfaceCapabilities2KHR,
         vkGetPhysicalDeviceSurfaceFormats2KHR;
 
-    // KHR_performance_query
+    /** Function pointers for KHR_performance_query */
     public final long
         vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR,
         vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR;
 
-    // KHR_surface
+    /** Function pointers for KHR_surface */
     public final long
         vkDestroySurfaceKHR,
         vkGetPhysicalDeviceSurfaceSupportKHR,
@@ -178,48 +182,48 @@ public class VKCapabilitiesInstance {
         vkGetPhysicalDeviceSurfaceFormatsKHR,
         vkGetPhysicalDeviceSurfacePresentModesKHR;
 
-    // KHR_video_queue
+    /** Function pointers for KHR_video_queue */
     public final long
         vkGetPhysicalDeviceVideoCapabilitiesKHR,
         vkGetPhysicalDeviceVideoFormatPropertiesKHR;
 
-    // KHR_wayland_surface
+    /** Function pointers for KHR_wayland_surface */
     public final long
         vkCreateWaylandSurfaceKHR,
         vkGetPhysicalDeviceWaylandPresentationSupportKHR;
 
-    // KHR_win32_surface
+    /** Function pointers for KHR_win32_surface */
     public final long
         vkCreateWin32SurfaceKHR,
         vkGetPhysicalDeviceWin32PresentationSupportKHR;
 
-    // KHR_xlib_surface
+    /** Function pointers for KHR_xlib_surface */
     public final long
         vkCreateXlibSurfaceKHR,
         vkGetPhysicalDeviceXlibPresentationSupportKHR;
 
-    // MVK_macos_surface
+    /** Function pointers for MVK_macos_surface */
     public final long
         vkCreateMacOSSurfaceMVK;
 
-    // NV_acquire_winrt_display
+    /** Function pointers for NV_acquire_winrt_display */
     public final long
         vkAcquireWinrtDisplayNV,
         vkGetWinrtDisplayNV;
 
-    // NV_cooperative_matrix
+    /** Function pointers for NV_cooperative_matrix */
     public final long
         vkGetPhysicalDeviceCooperativeMatrixPropertiesNV;
 
-    // NV_coverage_reduction_mode
+    /** Function pointers for NV_coverage_reduction_mode */
     public final long
         vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV;
 
-    // NV_external_memory_capabilities
+    /** Function pointers for NV_external_memory_capabilities */
     public final long
         vkGetPhysicalDeviceExternalImageFormatPropertiesNV;
 
-    // NV_optical_flow
+    /** Function pointers for NV_optical_flow */
     public final long
         vkGetPhysicalDeviceOpticalFlowImageFormatsNV;
 
@@ -442,7 +446,7 @@ public class VKCapabilitiesInstance {
         vkGetPhysicalDeviceOpticalFlowImageFormatsNV = caps[97];
     }
 
-    private static boolean check_VK10(FunctionProvider provider, long[] caps, java.util.Set<String> ext) {
+    private static boolean check_VK10(FunctionProvider provider, long[] caps, Set<String> ext) {
         if (!ext.contains("Vulkan10")) {
             return false;
         }
@@ -457,7 +461,7 @@ public class VKCapabilitiesInstance {
         ) || reportMissing("VK", "Vulkan10");
     }
 
-    private static boolean check_VK11(FunctionProvider provider, long[] caps, java.util.Set<String> ext) {
+    private static boolean check_VK11(FunctionProvider provider, long[] caps, Set<String> ext) {
         if (!ext.contains("Vulkan11")) {
             return false;
         }
@@ -472,7 +476,7 @@ public class VKCapabilitiesInstance {
         ) || reportMissing("VK", "Vulkan11");
     }
 
-    private static boolean check_VK13(FunctionProvider provider, long[] caps, java.util.Set<String> ext) {
+    private static boolean check_VK13(FunctionProvider provider, long[] caps, Set<String> ext) {
         if (!ext.contains("Vulkan13")) {
             return false;
         }
@@ -484,7 +488,7 @@ public class VKCapabilitiesInstance {
         ) || reportMissing("VK", "Vulkan13");
     }
 
-    private static boolean check_EXT_acquire_drm_display(FunctionProvider provider, long[] caps, java.util.Set<String> ext) {
+    private static boolean check_EXT_acquire_drm_display(FunctionProvider provider, long[] caps, Set<String> ext) {
         if (!ext.contains("VK_EXT_acquire_drm_display")) {
             return false;
         }
@@ -496,7 +500,7 @@ public class VKCapabilitiesInstance {
         ) || reportMissing("VK", "VK_EXT_acquire_drm_display");
     }
 
-    private static boolean check_EXT_acquire_xlib_display(FunctionProvider provider, long[] caps, java.util.Set<String> ext) {
+    private static boolean check_EXT_acquire_xlib_display(FunctionProvider provider, long[] caps, Set<String> ext) {
         if (!ext.contains("VK_EXT_acquire_xlib_display")) {
             return false;
         }
@@ -508,7 +512,7 @@ public class VKCapabilitiesInstance {
         ) || reportMissing("VK", "VK_EXT_acquire_xlib_display");
     }
 
-    private static boolean check_EXT_calibrated_timestamps(FunctionProvider provider, long[] caps, java.util.Set<String> ext) {
+    private static boolean check_EXT_calibrated_timestamps(FunctionProvider provider, long[] caps, Set<String> ext) {
         if (!ext.contains("VK_EXT_calibrated_timestamps")) {
             return false;
         }
@@ -520,7 +524,7 @@ public class VKCapabilitiesInstance {
         ) || reportMissing("VK", "VK_EXT_calibrated_timestamps");
     }
 
-    private static boolean check_EXT_debug_report(FunctionProvider provider, long[] caps, java.util.Set<String> ext) {
+    private static boolean check_EXT_debug_report(FunctionProvider provider, long[] caps, Set<String> ext) {
         if (!ext.contains("VK_EXT_debug_report")) {
             return false;
         }
@@ -532,7 +536,7 @@ public class VKCapabilitiesInstance {
         ) || reportMissing("VK", "VK_EXT_debug_report");
     }
 
-    private static boolean check_EXT_debug_utils(FunctionProvider provider, long[] caps, java.util.Set<String> ext) {
+    private static boolean check_EXT_debug_utils(FunctionProvider provider, long[] caps, Set<String> ext) {
         if (!ext.contains("VK_EXT_debug_utils")) {
             return false;
         }
@@ -546,7 +550,7 @@ public class VKCapabilitiesInstance {
         ) || reportMissing("VK", "VK_EXT_debug_utils");
     }
 
-    private static boolean check_EXT_direct_mode_display(FunctionProvider provider, long[] caps, java.util.Set<String> ext) {
+    private static boolean check_EXT_direct_mode_display(FunctionProvider provider, long[] caps, Set<String> ext) {
         if (!ext.contains("VK_EXT_direct_mode_display")) {
             return false;
         }
@@ -558,7 +562,7 @@ public class VKCapabilitiesInstance {
         ) || reportMissing("VK", "VK_EXT_direct_mode_display");
     }
 
-    private static boolean check_EXT_display_surface_counter(FunctionProvider provider, long[] caps, java.util.Set<String> ext) {
+    private static boolean check_EXT_display_surface_counter(FunctionProvider provider, long[] caps, Set<String> ext) {
         if (!ext.contains("VK_EXT_display_surface_counter")) {
             return false;
         }
@@ -570,7 +574,7 @@ public class VKCapabilitiesInstance {
         ) || reportMissing("VK", "VK_EXT_display_surface_counter");
     }
 
-    private static boolean check_EXT_full_screen_exclusive(FunctionProvider provider, long[] caps, java.util.Set<String> ext) {
+    private static boolean check_EXT_full_screen_exclusive(FunctionProvider provider, long[] caps, Set<String> ext) {
         if (!ext.contains("VK_EXT_full_screen_exclusive")) {
             return false;
         }
@@ -582,7 +586,7 @@ public class VKCapabilitiesInstance {
         ) || reportMissing("VK", "VK_EXT_full_screen_exclusive");
     }
 
-    private static boolean check_EXT_headless_surface(FunctionProvider provider, long[] caps, java.util.Set<String> ext) {
+    private static boolean check_EXT_headless_surface(FunctionProvider provider, long[] caps, Set<String> ext) {
         if (!ext.contains("VK_EXT_headless_surface")) {
             return false;
         }
@@ -594,7 +598,7 @@ public class VKCapabilitiesInstance {
         ) || reportMissing("VK", "VK_EXT_headless_surface");
     }
 
-    private static boolean check_EXT_metal_surface(FunctionProvider provider, long[] caps, java.util.Set<String> ext) {
+    private static boolean check_EXT_metal_surface(FunctionProvider provider, long[] caps, Set<String> ext) {
         if (!ext.contains("VK_EXT_metal_surface")) {
             return false;
         }
@@ -606,7 +610,7 @@ public class VKCapabilitiesInstance {
         ) || reportMissing("VK", "VK_EXT_metal_surface");
     }
 
-    private static boolean check_EXT_sample_locations(FunctionProvider provider, long[] caps, java.util.Set<String> ext) {
+    private static boolean check_EXT_sample_locations(FunctionProvider provider, long[] caps, Set<String> ext) {
         if (!ext.contains("VK_EXT_sample_locations")) {
             return false;
         }
@@ -618,7 +622,7 @@ public class VKCapabilitiesInstance {
         ) || reportMissing("VK", "VK_EXT_sample_locations");
     }
 
-    private static boolean check_EXT_tooling_info(FunctionProvider provider, long[] caps, java.util.Set<String> ext) {
+    private static boolean check_EXT_tooling_info(FunctionProvider provider, long[] caps, Set<String> ext) {
         if (!ext.contains("VK_EXT_tooling_info")) {
             return false;
         }
@@ -630,7 +634,7 @@ public class VKCapabilitiesInstance {
         ) || reportMissing("VK", "VK_EXT_tooling_info");
     }
 
-    private static boolean check_KHR_device_group(FunctionProvider provider, long[] caps, java.util.Set<String> ext) {
+    private static boolean check_KHR_device_group(FunctionProvider provider, long[] caps, Set<String> ext) {
         if (!ext.contains("VK_KHR_device_group")) {
             return false;
         }
@@ -644,7 +648,7 @@ public class VKCapabilitiesInstance {
         ) || reportMissing("VK", "VK_KHR_device_group");
     }
 
-    private static boolean check_KHR_device_group_creation(FunctionProvider provider, long[] caps, java.util.Set<String> ext) {
+    private static boolean check_KHR_device_group_creation(FunctionProvider provider, long[] caps, Set<String> ext) {
         if (!ext.contains("VK_KHR_device_group_creation")) {
             return false;
         }
@@ -656,7 +660,7 @@ public class VKCapabilitiesInstance {
         ) || reportMissing("VK", "VK_KHR_device_group_creation");
     }
 
-    private static boolean check_KHR_display(FunctionProvider provider, long[] caps, java.util.Set<String> ext) {
+    private static boolean check_KHR_display(FunctionProvider provider, long[] caps, Set<String> ext) {
         if (!ext.contains("VK_KHR_display")) {
             return false;
         }
@@ -669,7 +673,7 @@ public class VKCapabilitiesInstance {
         ) || reportMissing("VK", "VK_KHR_display");
     }
 
-    private static boolean check_KHR_external_fence_capabilities(FunctionProvider provider, long[] caps, java.util.Set<String> ext) {
+    private static boolean check_KHR_external_fence_capabilities(FunctionProvider provider, long[] caps, Set<String> ext) {
         if (!ext.contains("VK_KHR_external_fence_capabilities")) {
             return false;
         }
@@ -681,7 +685,7 @@ public class VKCapabilitiesInstance {
         ) || reportMissing("VK", "VK_KHR_external_fence_capabilities");
     }
 
-    private static boolean check_KHR_external_memory_capabilities(FunctionProvider provider, long[] caps, java.util.Set<String> ext) {
+    private static boolean check_KHR_external_memory_capabilities(FunctionProvider provider, long[] caps, Set<String> ext) {
         if (!ext.contains("VK_KHR_external_memory_capabilities")) {
             return false;
         }
@@ -693,7 +697,7 @@ public class VKCapabilitiesInstance {
         ) || reportMissing("VK", "VK_KHR_external_memory_capabilities");
     }
 
-    private static boolean check_KHR_external_semaphore_capabilities(FunctionProvider provider, long[] caps, java.util.Set<String> ext) {
+    private static boolean check_KHR_external_semaphore_capabilities(FunctionProvider provider, long[] caps, Set<String> ext) {
         if (!ext.contains("VK_KHR_external_semaphore_capabilities")) {
             return false;
         }
@@ -705,7 +709,7 @@ public class VKCapabilitiesInstance {
         ) || reportMissing("VK", "VK_KHR_external_semaphore_capabilities");
     }
 
-    private static boolean check_KHR_fragment_shading_rate(FunctionProvider provider, long[] caps, java.util.Set<String> ext) {
+    private static boolean check_KHR_fragment_shading_rate(FunctionProvider provider, long[] caps, Set<String> ext) {
         if (!ext.contains("VK_KHR_fragment_shading_rate")) {
             return false;
         }
@@ -717,7 +721,7 @@ public class VKCapabilitiesInstance {
         ) || reportMissing("VK", "VK_KHR_fragment_shading_rate");
     }
 
-    private static boolean check_KHR_get_display_properties2(FunctionProvider provider, long[] caps, java.util.Set<String> ext) {
+    private static boolean check_KHR_get_display_properties2(FunctionProvider provider, long[] caps, Set<String> ext) {
         if (!ext.contains("VK_KHR_get_display_properties2")) {
             return false;
         }
@@ -730,7 +734,7 @@ public class VKCapabilitiesInstance {
         ) || reportMissing("VK", "VK_KHR_get_display_properties2");
     }
 
-    private static boolean check_KHR_get_physical_device_properties2(FunctionProvider provider, long[] caps, java.util.Set<String> ext) {
+    private static boolean check_KHR_get_physical_device_properties2(FunctionProvider provider, long[] caps, Set<String> ext) {
         if (!ext.contains("VK_KHR_get_physical_device_properties2")) {
             return false;
         }
@@ -744,7 +748,7 @@ public class VKCapabilitiesInstance {
         ) || reportMissing("VK", "VK_KHR_get_physical_device_properties2");
     }
 
-    private static boolean check_KHR_get_surface_capabilities2(FunctionProvider provider, long[] caps, java.util.Set<String> ext) {
+    private static boolean check_KHR_get_surface_capabilities2(FunctionProvider provider, long[] caps, Set<String> ext) {
         if (!ext.contains("VK_KHR_get_surface_capabilities2")) {
             return false;
         }
@@ -756,7 +760,7 @@ public class VKCapabilitiesInstance {
         ) || reportMissing("VK", "VK_KHR_get_surface_capabilities2");
     }
 
-    private static boolean check_KHR_performance_query(FunctionProvider provider, long[] caps, java.util.Set<String> ext) {
+    private static boolean check_KHR_performance_query(FunctionProvider provider, long[] caps, Set<String> ext) {
         if (!ext.contains("VK_KHR_performance_query")) {
             return false;
         }
@@ -768,7 +772,7 @@ public class VKCapabilitiesInstance {
         ) || reportMissing("VK", "VK_KHR_performance_query");
     }
 
-    private static boolean check_KHR_surface(FunctionProvider provider, long[] caps, java.util.Set<String> ext) {
+    private static boolean check_KHR_surface(FunctionProvider provider, long[] caps, Set<String> ext) {
         if (!ext.contains("VK_KHR_surface")) {
             return false;
         }
@@ -781,7 +785,7 @@ public class VKCapabilitiesInstance {
         ) || reportMissing("VK", "VK_KHR_surface");
     }
 
-    private static boolean check_KHR_swapchain(FunctionProvider provider, long[] caps, java.util.Set<String> ext) {
+    private static boolean check_KHR_swapchain(FunctionProvider provider, long[] caps, Set<String> ext) {
         if (!ext.contains("VK_KHR_swapchain")) {
             return false;
         }
@@ -795,7 +799,7 @@ public class VKCapabilitiesInstance {
         ) || reportMissing("VK", "VK_KHR_swapchain");
     }
 
-    private static boolean check_KHR_video_queue(FunctionProvider provider, long[] caps, java.util.Set<String> ext) {
+    private static boolean check_KHR_video_queue(FunctionProvider provider, long[] caps, Set<String> ext) {
         if (!ext.contains("VK_KHR_video_queue")) {
             return false;
         }
@@ -807,7 +811,7 @@ public class VKCapabilitiesInstance {
         ) || reportMissing("VK", "VK_KHR_video_queue");
     }
 
-    private static boolean check_KHR_wayland_surface(FunctionProvider provider, long[] caps, java.util.Set<String> ext) {
+    private static boolean check_KHR_wayland_surface(FunctionProvider provider, long[] caps, Set<String> ext) {
         if (!ext.contains("VK_KHR_wayland_surface")) {
             return false;
         }
@@ -819,7 +823,7 @@ public class VKCapabilitiesInstance {
         ) || reportMissing("VK", "VK_KHR_wayland_surface");
     }
 
-    private static boolean check_KHR_win32_surface(FunctionProvider provider, long[] caps, java.util.Set<String> ext) {
+    private static boolean check_KHR_win32_surface(FunctionProvider provider, long[] caps, Set<String> ext) {
         if (!ext.contains("VK_KHR_win32_surface")) {
             return false;
         }
@@ -831,7 +835,7 @@ public class VKCapabilitiesInstance {
         ) || reportMissing("VK", "VK_KHR_win32_surface");
     }
 
-    private static boolean check_KHR_xlib_surface(FunctionProvider provider, long[] caps, java.util.Set<String> ext) {
+    private static boolean check_KHR_xlib_surface(FunctionProvider provider, long[] caps, Set<String> ext) {
         if (!ext.contains("VK_KHR_xlib_surface")) {
             return false;
         }
@@ -843,7 +847,7 @@ public class VKCapabilitiesInstance {
         ) || reportMissing("VK", "VK_KHR_xlib_surface");
     }
 
-    private static boolean check_MVK_macos_surface(FunctionProvider provider, long[] caps, java.util.Set<String> ext) {
+    private static boolean check_MVK_macos_surface(FunctionProvider provider, long[] caps, Set<String> ext) {
         if (!ext.contains("VK_MVK_macos_surface")) {
             return false;
         }
@@ -855,7 +859,7 @@ public class VKCapabilitiesInstance {
         ) || reportMissing("VK", "VK_MVK_macos_surface");
     }
 
-    private static boolean check_NV_acquire_winrt_display(FunctionProvider provider, long[] caps, java.util.Set<String> ext) {
+    private static boolean check_NV_acquire_winrt_display(FunctionProvider provider, long[] caps, Set<String> ext) {
         if (!ext.contains("VK_NV_acquire_winrt_display")) {
             return false;
         }
@@ -867,7 +871,7 @@ public class VKCapabilitiesInstance {
         ) || reportMissing("VK", "VK_NV_acquire_winrt_display");
     }
 
-    private static boolean check_NV_cooperative_matrix(FunctionProvider provider, long[] caps, java.util.Set<String> ext) {
+    private static boolean check_NV_cooperative_matrix(FunctionProvider provider, long[] caps, Set<String> ext) {
         if (!ext.contains("VK_NV_cooperative_matrix")) {
             return false;
         }
@@ -879,7 +883,7 @@ public class VKCapabilitiesInstance {
         ) || reportMissing("VK", "VK_NV_cooperative_matrix");
     }
 
-    private static boolean check_NV_coverage_reduction_mode(FunctionProvider provider, long[] caps, java.util.Set<String> ext) {
+    private static boolean check_NV_coverage_reduction_mode(FunctionProvider provider, long[] caps, Set<String> ext) {
         if (!ext.contains("VK_NV_coverage_reduction_mode")) {
             return false;
         }
@@ -891,7 +895,7 @@ public class VKCapabilitiesInstance {
         ) || reportMissing("VK", "VK_NV_coverage_reduction_mode");
     }
 
-    private static boolean check_NV_external_memory_capabilities(FunctionProvider provider, long[] caps, java.util.Set<String> ext) {
+    private static boolean check_NV_external_memory_capabilities(FunctionProvider provider, long[] caps, Set<String> ext) {
         if (!ext.contains("VK_NV_external_memory_capabilities")) {
             return false;
         }
@@ -903,7 +907,7 @@ public class VKCapabilitiesInstance {
         ) || reportMissing("VK", "VK_NV_external_memory_capabilities");
     }
 
-    private static boolean check_NV_optical_flow(FunctionProvider provider, long[] caps, java.util.Set<String> ext) {
+    private static boolean check_NV_optical_flow(FunctionProvider provider, long[] caps, Set<String> ext) {
         if (!ext.contains("VK_NV_optical_flow")) {
             return false;
         }

--- a/modules/lwjgl/vulkan/src/templates/kotlin/vulkan/VKBinding.kt
+++ b/modules/lwjgl/vulkan/src/templates/kotlin/vulkan/VKBinding.kt
@@ -102,7 +102,7 @@ val VK_BINDING_INSTANCE = Generator.register(object : APIBinding(
         val capName = nativeClass.capName
 
         print("""
-    private static boolean check_${nativeClass.templateName}(FunctionProvider provider, long[] caps, java.util.Set<String> ext) {
+    private static boolean check_${nativeClass.templateName}(FunctionProvider provider, long[] caps, Set<String> ext) {
         if (!ext.contains("$capName")) {
             return false;
         }""")
@@ -132,7 +132,12 @@ val VK_BINDING_INSTANCE = Generator.register(object : APIBinding(
     init {
         javaImport("static org.lwjgl.system.Checks.*")
 
-        documentation = "Defines the enabled capabilities of a Vulkan {@code VkInstance}."
+        documentation =
+            """
+            Reports the enabled capabilities and function pointers of a Vulkan {@code VkInstance}.
+
+            The addresses are cached for future use. This class also allows developers to query the capabilities made available to the Vulkan instance handle.
+            """
     }
 
     override fun PrintWriter.generateJava() {
@@ -159,7 +164,7 @@ val VK_BINDING_INSTANCE = Generator.register(object : APIBinding(
                     .joinToString(",\n$t$t") { cmd -> cmd.name }
 
                 if (functions.isNotEmpty()) {
-                    println("\n$t// ${it.templateName}")
+                    println("\n$t/** Function pointers for ${it.templateName} */")
                     println("${t}public final long")
                     println("$t$t$functions;")
                 }
@@ -276,7 +281,12 @@ val VK_BINDING_DEVICE = Generator.register(object : GeneratorTarget(Module.VULKA
             "static org.lwjgl.system.Checks.*"
         )
 
-        documentation = "Defines the enabled capabilities of a Vulkan {@code VkDevice}."
+        documentation =
+            """
+            Reports the enabled capabilities and function pointers of a Vulkan {@code VkDevice}.
+
+            The addresses are cached for future use. This class also allows developers to query the capabilities made available to the Vulkan device handle.
+            """
     }
 
     override fun PrintWriter.generateJava() {
@@ -303,7 +313,7 @@ val VK_BINDING_DEVICE = Generator.register(object : GeneratorTarget(Module.VULKA
                     .joinToString(",\n$t$t") { cmd -> cmd.name }
 
                 if (functions.isNotEmpty()) {
-                    println("\n$t// ${it.templateName}")
+                    println("\n$t/** Function pointers for ${it.templateName} */")
                     println("${t}public final long")
                     println("$t$t$functions;")
                 }


### PR DESCRIPTION
#809 was opened because `VKCapabilitiesDevice` and `VKCapabilitiesInstance` was insufficient at indicating its purpose. This makes clear what those classes are and what the public fields are and mean.