### PR TITLE
chore: use SPDX license identifier in POM

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -360,7 +360,7 @@ publishing {
 
             licenses {
                 license {
-                    name.set("BSD")
+                    name.set("BSD-3-Clause")
                     url.set("https://www.lwjgl.org/license")
                     distribution.set("repo")
                 }

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
     <licenses>
         <license>
-            <name>BSD</name>
+            <name>BSD-3-Clause</name>
             <url>https://www.lwjgl.org/license</url>
             <distribution>repo</distribution>
         </license>


### PR DESCRIPTION
Simply change the license `name` in the POM to a [valid SPDX identifier](https://spdx.org/licenses/BSD-3-Clause.html). This allows tools to automatically detect the license for LWJGL artifacts and is even [recommended in the POM documentation](https://maven.apache.org/pom.html#licenses).

For consistency, I updated the dummy POM too.