### PR TITLE
fix: prevent debug message tearing in multithreaded environments

### DIFF
--- a/doc/notes/3.3.2.md
+++ b/doc/notes/3.3.2.md
@@ -75,6 +75,7 @@ This build includes the following changes:
 - Core: Fixed Java/native library incompatibility detection. (#737)
 - Core: Fixed `dlerror` decoding to use UTF-8. (#738)
 - Core: Fixed `Version::getVersion()` when LWJGL is in the module path. (#770)
+- Core: Many debug messages can no longer tear under concurrency. (#825)
 - Build: Fixed offline mode with multiple local architectures. (#740)
 - NanoSVG: Fixed auto-sizing of `NSVGPath::pts` buffer.
 - Opus: Fixed `pcm` parameter type of `opus_decode_float` function. (#785)

--- a/modules/lwjgl/core/src/main/java/org/lwjgl/system/APIUtil.java
+++ b/modules/lwjgl/core/src/main/java/org/lwjgl/system/APIUtil.java
@@ -80,10 +80,20 @@ public final class APIUtil {
      *
      * @param msg the message to print
      */
-    public static void apiLog(@Nullable CharSequence msg) {
+    public static void apiLog(CharSequence msg) {
         if (DEBUG) {
-            DEBUG_STREAM.print("[LWJGL] ");
-            DEBUG_STREAM.println(msg);
+            DEBUG_STREAM.print("[LWJGL] " + msg + "\n");
+        }
+    }
+
+    /**
+     * Same as {@link #apiLog}, but replaces the LWJGL prefix with a tab character.
+     *
+     * @param msg the message to print, in continuation of a previous message
+     */
+    public static void apiLogMore(CharSequence msg) {
+        if (DEBUG) {
+            DEBUG_STREAM.print("\t" + msg + "\n");
         }
     }
 

--- a/modules/lwjgl/core/src/main/java/org/lwjgl/system/Library.java
+++ b/modules/lwjgl/core/src/main/java/org/lwjgl/system/Library.java
@@ -40,11 +40,12 @@ public final class Library {
 
     static {
         if (DEBUG) {
-            apiLog("Version: " + Version.getVersion());
-            apiLog("\t OS: " + System.getProperty("os.name") + " v" + System.getProperty("os.version"));
-            apiLog("\tJRE: " + Platform.get().getName() + " " + System.getProperty("os.arch") + " " + System.getProperty("java.version"));
-            apiLog(
-                "\tJVM: " + System.getProperty("java.vm.name") + " v" + System.getProperty("java.vm.version") + " by " + System.getProperty("java.vm.vendor")
+            DEBUG_STREAM.print(
+                "[LWJGL] Version: " + Version.getVersion() +
+                "\n\t OS: " + System.getProperty("os.name") + " v" + System.getProperty("os.version") +
+                "\n\tJRE: " + Platform.get().getName() + " " + System.getProperty("os.arch") + " " + System.getProperty("java.version") +
+                "\n\tJVM: " + System.getProperty("java.vm.name") + " v" + System.getProperty("java.vm.version") + " by " + System.getProperty("java.vm.vendor") +
+                "\n"
             );
         }
 
@@ -84,13 +85,18 @@ public final class Library {
         String module,
         String name
     ) throws UnsatisfiedLinkError {
-        apiLog("Loading JNI library: " + name);
-        apiLog("\tModule: " + module);
+        if (DEBUG) {
+            DEBUG_STREAM.print(
+                "[LWJGL] Loading JNI library: " + name +
+                "\n\tModule: " + module +
+                "\n"
+            );
+        }
 
         // METHOD 1: absolute path
         if (Paths.get(name).isAbsolute()) {
             load.accept(name);
-            apiLog("\tSuccess");
+            apiLogMore("Success");
             return;
         }
 
@@ -111,7 +117,7 @@ public final class Library {
                     String regular = getRegularFilePath(libURL);
                     if (regular != null) {
                         load.accept(regular);
-                        apiLog("\tLoaded from classpath: " + regular);
+                        apiLogMore("Loaded from classpath: " + regular);
                         return;
                     }
                 }
@@ -119,7 +125,7 @@ public final class Library {
                 // Always use the SLL if the library is found in the classpath,
                 // so that newer versions can be detected.
                 if (debugLoader) {
-                    apiLog("\tUsing SharedLibraryLoader...");
+                    apiLogMore("Using SharedLibraryLoader...");
                 }
                 // Extract from classpath and try org.lwjgl.librarypath
                 try (FileChannel ignored = SharedLibraryLoader.load(name, libName, libURL, load)) {
@@ -151,16 +157,16 @@ public final class Library {
             // In that case, ClassLoader::findLibrary was used to return the library path (e.g. OSGi does this with native libraries in bundles).
             Path libFile = javaLibraryPath == null ? null : findFile(javaLibraryPath, module, libName, bundledWithLWJGL);
             if (libFile != null) {
-                apiLog(String.format("\tLoaded from %s: %s", JAVA_LIBRARY_PATH, libFile));
+                apiLogMore(String.format("Loaded from %s: %s", JAVA_LIBRARY_PATH, libFile));
                 if (bundledWithLWJGL) {
                     checkHash(context, libFile, module, libName);
                 }
             } else {
-                apiLog("\tLoaded from a ClassLoader provided path.");
+                apiLogMore("Loaded from a ClassLoader provided path.");
             }
             return;
         } catch (Throwable t) {
-            apiLog(String.format("\t%s not found in %s", libName, JAVA_LIBRARY_PATH));
+            apiLogMore(libName + " not found in " + JAVA_LIBRARY_PATH);
         }
 
         detectPlatformMismatch(context, module);
@@ -176,12 +182,12 @@ public final class Library {
     private static boolean loadSystem(Consumer<String> load, Class<?> context, String module, String libName, boolean bundledWithLWJGL, String property, String paths) {
         Path libFile = findFile(paths, module, libName, bundledWithLWJGL);
         if (libFile == null) {
-            apiLog(String.format("\t%s not found in %s=%s", libName, property, paths));
+            apiLogMore(libName + " not found in " + property + "=" + paths);
             return false;
         }
 
         load.accept(libFile.toAbsolutePath().toString());
-        apiLog(String.format("\tLoaded from %s: %s", property, libFile));
+        apiLogMore("Loaded from " + property + ": " + libFile);
         if (bundledWithLWJGL) {
             checkHash(context, libFile, module, libName);
         }
@@ -232,13 +238,18 @@ public final class Library {
 
     @SuppressWarnings("try")
     private static SharedLibrary loadNative(Class<?> context, String module, String name, boolean bundledWithLWJGL, boolean printError) {
-        apiLog("Loading library: " + name);
-        apiLog("\tModule: " + module);
+        if (DEBUG) {
+            DEBUG_STREAM.print(
+                "[LWJGL] Loading library: " + name +
+                "\n\tModule: " + module +
+                "\n"
+            );
+        }
 
         // METHOD 1: absolute path
         if (Paths.get(name).isAbsolute()) {
             SharedLibrary lib = apiCreateLibrary(name);
-            apiLog("\tSuccess");
+            apiLogMore("Success");
             return lib;
         }
 
@@ -259,7 +270,7 @@ public final class Library {
                     String regular = getRegularFilePath(libURL);
                     if (regular != null) {
                         lib = apiCreateLibrary(regular);
-                        apiLog("\tLoaded from classpath: " + regular);
+                        apiLogMore("Loaded from classpath: " + regular);
                         return lib;
                     }
                 }
@@ -267,7 +278,7 @@ public final class Library {
                 // Always use the SLL if the library is found in the classpath,
                 // so that newer versions can be detected.
                 if (debugLoader) {
-                    apiLog("\tUsing SharedLibraryLoader...");
+                    apiLogMore("Using SharedLibraryLoader...");
                 }
                 // Extract from classpath and try org.lwjgl.librarypath
                 try (FileChannel ignored = SharedLibraryLoader.load(name, libName, libURL, null)) {
@@ -302,7 +313,7 @@ public final class Library {
                     String libPath = (String)findLibrary.invoke(context.getClassLoader(), name);
                     if (libPath != null) {
                         lib = apiCreateLibrary(libPath);
-                        apiLog(String.format("\tLoaded from ClassLoader provided path: %s", libPath));
+                        apiLogMore("Loaded from ClassLoader provided path: " + libPath);
                         return lib;
                     }
                 } catch (Exception ignored) {
@@ -341,12 +352,12 @@ public final class Library {
         try {
             lib = apiCreateLibrary(libName);
             String path = lib.getPath();
-            apiLog(path == null
-                ? "\tLoaded from system paths"
-                : "\tLoaded from system paths: " + path);
+            apiLogMore(path == null
+                ? "Loaded from system paths"
+                : "Loaded from system paths: " + path);
         } catch (UnsatisfiedLinkError e) {
             lib = null;
-            apiLog(String.format("\t%s not found in system paths", libName));
+            apiLogMore(libName + " not found in system paths");
         }
         return lib;
     }
@@ -364,12 +375,12 @@ public final class Library {
     private static SharedLibrary loadNative(Class<?> context, String module, String libName, boolean bundledWithLWJGL, String property, String paths) {
         Path libFile = findFile(paths, module, libName, bundledWithLWJGL);
         if (libFile == null) {
-            apiLog(String.format("\t%s not found in %s=%s", libName, property, paths));
+            apiLogMore(libName + " not found in " + property + "=" + paths);
             return null;
         }
 
         SharedLibrary lib = apiCreateLibrary(libFile.toAbsolutePath().toString());
-        apiLog(String.format("\tLoaded from %s: %s", property, libFile));
+        apiLogMore("Loaded from " + property + ": " + libFile);
         if (bundledWithLWJGL) {
             checkHash(context, libFile, module, libName);
         }
@@ -518,24 +529,12 @@ public final class Library {
         }
 
         if (!platforms.isEmpty()) {
-            DEBUG_STREAM.println("[LWJGL] Platform/architecture mismatch detected for module: " + module);
-            DEBUG_STREAM.println("\tJVM platform:");
-            DEBUG_STREAM.format(
-                "\t\t%s %s %s\n",
-                Platform.get().getName(),
-                System.getProperty("os.arch"),
-                System.getProperty("java.version")
-            );
-            DEBUG_STREAM.format(
-                "\t\t%s v%s by %s\n",
-                System.getProperty("java.vm.name"),
-                System.getProperty("java.vm.version"),
-                System.getProperty("java.vm.vendor")
-            );
-            DEBUG_STREAM.format(
-                "\tPlatform%s available on classpath:\n\t\t%s\n",
-                (platforms.size() == 1 ? "" : "s"),
-                String.join("\n\t\t", platforms)
+            DEBUG_STREAM.print(
+                "[LWJGL] Platform/architecture mismatch detected for module: " + module +
+                "\n\tJVM platform:" +
+                "\t\t" + Platform.get().getName() + " " + System.getProperty("os.arch") + " " + System.getProperty("java.version") + "\n" +
+                "\t\t" + System.getProperty("java.vm.name") + " v" + System.getProperty("java.vm.version") + " by " + System.getProperty("java.vm.vendor") + "\n" +
+                "\tPlatform" + (platforms.size() == 1 ? "" : "s") + " available on classpath:\n\t\t" + String.join("\n\t\t", platforms) + "\n"
             );
         }
     }
@@ -552,13 +551,17 @@ public final class Library {
     }
 
     static void printError(String message) {
-        DEBUG_STREAM.println(message);
+        StringBuilder sb = new StringBuilder(message);
+        sb.append("\n");
+
         if (!DEBUG) {
-            DEBUG_STREAM.println("[LWJGL] Enable debug mode with -Dorg.lwjgl.util.Debug=true for better diagnostics.");
+            sb.append("[LWJGL] Enable debug mode with -Dorg.lwjgl.util.Debug=true for better diagnostics.\n");
             if (!Configuration.DEBUG_LOADER.get(false)) {
-                DEBUG_STREAM.println("[LWJGL] Enable the SharedLibraryLoader debug mode with -Dorg.lwjgl.util.DebugLoader=true for better diagnostics.");
+                sb.append("[LWJGL] Enable the SharedLibraryLoader debug mode with -Dorg.lwjgl.util.DebugLoader=true for better diagnostics.\n");
             }
         }
+
+        DEBUG_STREAM.print(sb);
     }
 
     /**

--- a/modules/lwjgl/core/src/main/java/org/lwjgl/system/LibraryResource.java
+++ b/modules/lwjgl/core/src/main/java/org/lwjgl/system/LibraryResource.java
@@ -11,6 +11,7 @@ import java.nio.file.*;
 import java.util.function.*;
 
 import static org.lwjgl.system.APIUtil.*;
+import static org.lwjgl.system.Checks.*;
 
 /**
  * Handles loading of native resources in LWJGL. [INTERNAL USE ONLY]
@@ -68,8 +69,13 @@ public final class LibraryResource {
 
     @SuppressWarnings("try")
     private static Path load(Class<?> context, String module, String name, boolean bundledWithLWJGL, boolean printError) {
-        apiLog("Loading library resource: " + name);
-        apiLog("\tModule: " + module);
+        if (DEBUG) {
+            DEBUG_STREAM.print(
+                "[LWJGL] Loading library resource: " + name +
+                "\n\tModule: " + module +
+                "\n"
+            );
+        }
 
         // METHOD 1: absolute path
         Path path = Paths.get(name);
@@ -80,7 +86,7 @@ public final class LibraryResource {
                 }
                 throw new IllegalStateException("Failed to locate library resource: " + name);
             }
-            apiLog("\tSuccess");
+            apiLogMore("Success");
             return path;
         }
 
@@ -96,14 +102,14 @@ public final class LibraryResource {
             try {
                 String regular = Library.getRegularFilePath(resourceURL);
                 if (regular != null) {
-                    apiLog("\tLoaded from classpath: " + regular);
+                    apiLogMore("Loaded from classpath: " + regular);
                     return Paths.get(regular);
                 }
 
                 // Always use the SLL if the resource is found in the classpath,
                 // so that newer versions can be detected.
                 if (debugLoader) {
-                    apiLog("\tUsing SharedLibraryLoader...");
+                    apiLogMore("Using SharedLibraryLoader...");
                 }
                 // Extract from classpath and try org.lwjgl.librarypath
                 try (FileChannel ignored = SharedLibraryLoader.load(name, name, resourceURL, null)) {
@@ -147,11 +153,11 @@ public final class LibraryResource {
     private static Path load(String module, String name, boolean bundledWithLWJGL, String property, String paths) {
         Path resource = Library.findFile(paths, module, name, bundledWithLWJGL);
         if (resource == null) {
-            apiLog(String.format("\t%s not found in %s=%s", name, property, paths));
+            apiLogMore(name + " not found in " + property + "=" + paths);
             return null;
         }
 
-        apiLog(String.format("\tLoaded from %s: %s", property, resource));
+        apiLogMore("Loaded from " + property + ": " + resource);
         return resource;
     }
 

--- a/modules/lwjgl/core/src/main/java/org/lwjgl/system/MemoryManage.java
+++ b/modules/lwjgl/core/src/main/java/org/lwjgl/system/MemoryManage.java
@@ -157,26 +157,36 @@ final class MemoryManage {
 
                 boolean missingStacktrace = false;
                 for (Allocation allocation : ALLOCATIONS.keySet()) {
-                    DEBUG_STREAM.format(
-                        "[LWJGL] %d bytes leaked, thread %d (%s), address: 0x%s\n",
-                        allocation.size,
-                        allocation.threadId,
-                        THREADS.get(allocation.threadId),
-                        Long.toHexString(allocation.address).toUpperCase()
-                    );
+                    StringBuilder sb = new StringBuilder(512);
+
+                    sb
+                        .append("[LWJGL] ")
+                        .append(allocation.size)
+                        .append(" bytes leaked, thread ")
+                        .append(allocation.threadId)
+                        .append(" (")
+                        .append(THREADS.get(allocation.threadId))
+                        .append("), address: 0x")
+                        .append(Long.toHexString(allocation.address).toUpperCase())
+                        .append("\n");
 
                     StackTraceElement[] stackTrace = allocation.getElements();
                     if (stackTrace != null) {
                         for (Object el : stackTrace) {
-                            DEBUG_STREAM.format("\tat %s\n", el.toString());
+                            sb
+                                .append("\tat ")
+                                .append(el.toString())
+                                .append("\n");
                         }
                     } else {
                         missingStacktrace = true;
                     }
+
+                    DEBUG_STREAM.print(sb);
                 }
 
                 if (missingStacktrace) {
-                    DEBUG_STREAM.println("[LWJGL] Reminder: disable Configuration.DEBUG_MEMORY_ALLOCATOR_FAST to get stacktraces of leaking allocations.");
+                    DEBUG_STREAM.print("[LWJGL] Reminder: disable Configuration.DEBUG_MEMORY_ALLOCATOR_FAST to get stacktraces of leaking allocations.\n");
                 }
             }));
         }
@@ -271,21 +281,32 @@ final class MemoryManage {
             throw new IllegalStateException("The memory address specified is already being tracked: 0x" + addressHex);
         }
         private static void trackAbortPrint(Allocation allocation, String name, String address) {
-            DEBUG_STREAM.format(
-                "[LWJGL] %s allocation with size %d, thread %d (%s), address: 0x%s\n",
-                name,
-                allocation.size,
-                allocation.threadId,
-                THREADS.get(allocation.threadId),
-                address
-            );
+            StringBuilder sb = new StringBuilder(512);
+
+            sb
+                .append("[LWJGL] ")
+                .append(name)
+                .append(" allocation with size ")
+                .append(allocation.size)
+                .append(", thread ")
+                .append(allocation.threadId)
+                .append(" (")
+                .append(THREADS.get(allocation.threadId))
+                .append("), address: 0x")
+                .append(address)
+                .append("\n");
 
             StackTraceElement[] stackTrace = allocation.getElements();
             if (stackTrace != null) {
                 for (Object el : stackTrace) {
-                    DEBUG_STREAM.format("\tat %s\n", el.toString());
+                    sb
+                        .append("\tat ")
+                        .append(el.toString())
+                        .append("\n");
                 }
             }
+
+            DEBUG_STREAM.print(sb);
         }
 
         static long untrack(long address) {

--- a/modules/lwjgl/core/src/main/java/org/lwjgl/system/MemoryUtil.java
+++ b/modules/lwjgl/core/src/main/java/org/lwjgl/system/MemoryUtil.java
@@ -152,7 +152,7 @@ public final class MemoryUtil {
 
             apiLog("MemoryUtil allocator: " + ALLOCATOR.getClass().getSimpleName());
             if (debug && !Configuration.DEBUG_MEMORY_ALLOCATOR_FAST.get(false)) {
-                apiLog("\tReminder: enable Configuration.DEBUG_MEMORY_ALLOCATOR_FAST for low overhead allocation tracking.");
+                apiLogMore("Reminder: enable Configuration.DEBUG_MEMORY_ALLOCATOR_FAST for low overhead allocation tracking.");
             }
         }
     }

--- a/modules/lwjgl/core/src/main/java/org/lwjgl/system/SharedLibraryLoader.java
+++ b/modules/lwjgl/core/src/main/java/org/lwjgl/system/SharedLibraryLoader.java
@@ -128,7 +128,7 @@ final class SharedLibraryLoader {
             if (canWrite(root, file, resource, load)) {
                 return file;
             }
-            apiLog(String.format("\tThe path %s is not accessible. Trying other paths.", override));
+            apiLogMore("The path " + override + " is not accessible. Trying other paths.");
         }
 
         String version = Version.getVersion().replace(' ', '-');
@@ -207,7 +207,7 @@ final class SharedLibraryLoader {
             ) {
                 if (crc(source) == crc(target)) {
                     if (Configuration.DEBUG_LOADER.get(false)) {
-                        apiLog(String.format("\tFound at: %s", file));
+                        apiLogMore("Found at: " + file);
                     }
                     return lock(file);
                 }
@@ -215,10 +215,10 @@ final class SharedLibraryLoader {
         }
 
         // If file doesn't exist or the CRC doesn't match, extract it to the temp dir.
-        apiLog(String.format("\tExtracting: %s", resource.getPath()));
+        apiLogMore("Extracting: " + resource.getPath());
         //noinspection FieldAccessNotGuarded (already inside the lock)
         if (extractPath == null) {
-            apiLog(String.format("\t        to: %s", file));
+            apiLogMore("        to: " + file);
         }
 
         Files.createDirectories(file.getParent());
@@ -242,7 +242,7 @@ final class SharedLibraryLoader {
 
             if (fc.tryLock(0L, Long.MAX_VALUE, true) == null) {
                 if (Configuration.DEBUG_LOADER.get(false)) {
-                    apiLog("\tFile is locked by another process, waiting...");
+                    apiLogMore("File is locked by another process, waiting...");
                 }
 
                 fc.lock(0L, Long.MAX_VALUE, true); // this will block until the file is locked

--- a/modules/lwjgl/core/src/main/java/org/lwjgl/system/macosx/MacOSXLibrary.java
+++ b/modules/lwjgl/core/src/main/java/org/lwjgl/system/macosx/MacOSXLibrary.java
@@ -18,7 +18,7 @@ public abstract class MacOSXLibrary extends SharedLibrary.Default {
     public static MacOSXLibrary getWithIdentifier(String bundleID) {
         apiLog("Loading library: " + bundleID);
         MacOSXLibraryBundle lib = MacOSXLibraryBundle.getWithIdentifier(bundleID);
-        apiLog("\tSuccess");
+        apiLogMore("Success");
         return lib;
     }
 

--- a/modules/lwjgl/glfw/src/generated/java/org/lwjgl/glfw/GLFWErrorCallback.java
+++ b/modules/lwjgl/glfw/src/generated/java/org/lwjgl/glfw/GLFWErrorCallback.java
@@ -101,14 +101,24 @@ public abstract class GLFWErrorCallback extends Callback implements GLFWErrorCal
             public void invoke(int error, long description) {
                 String msg = getDescription(description);
 
-                stream.printf("[LWJGL] %s error\n", ERROR_CODES.get(error));
-                stream.println("\tDescription : " + msg);
-                stream.println("\tStacktrace  :");
+                StringBuilder sb = new StringBuilder(512);
+                sb
+                    .append("[LWJGL] ")
+                    .append(ERROR_CODES.get(error))
+                    .append(" error\n")
+                    .append("\tDescription : ")
+                    .append(msg)
+                    .append("\n")
+                    .append("\tStacktrace  :\n");
+
                 StackTraceElement[] stack = Thread.currentThread().getStackTrace();
-                for ( int i = 4; i < stack.length; i++ ) {
-                    stream.print("\t\t");
-                    stream.println(stack[i].toString());
+                for (int i = 4; i < stack.length; i++) {
+                    sb.append("\t\t");
+                    sb.append(stack[i]);
+                    sb.append("\n");
                 }
+
+                stream.print(sb);
             }
         };
     }

--- a/modules/lwjgl/glfw/src/templates/kotlin/glfw/GLFWTypes.kt
+++ b/modules/lwjgl/glfw/src/templates/kotlin/glfw/GLFWTypes.kt
@@ -233,14 +233,24 @@ val GLFWerrorfun = Module.GLFW.callback {
             public void invoke(int error, long description) {
                 String msg = getDescription(description);
 
-                stream.printf("[LWJGL] %s error\n", ERROR_CODES.get(error));
-                stream.println("\tDescription : " + msg);
-                stream.println("\tStacktrace  :");
+                StringBuilder sb = new StringBuilder(512);
+                sb
+                    .append("[LWJGL] ")
+                    .append(ERROR_CODES.get(error))
+                    .append(" error\n")
+                    .append("\tDescription : ")
+                    .append(msg)
+                    .append("\n")
+                    .append("\tStacktrace  :\n");
+
                 StackTraceElement[] stack = Thread.currentThread().getStackTrace();
-                for ( int i = 4; i < stack.length; i++ ) {
-                    stream.print("\t\t");
-                    stream.println(stack[i].toString());
+                for (int i = 4; i < stack.length; i++) {
+                    sb.append("\t\t");
+                    sb.append(stack[i]);
+                    sb.append("\n");
                 }
+
+                stream.print(sb);
             }
         };
     }

--- a/modules/lwjgl/opengl/src/main/java/org/lwjgl/opengl/GLUtil.java
+++ b/modules/lwjgl/opengl/src/main/java/org/lwjgl/opengl/GLUtil.java
@@ -43,12 +43,16 @@ public final class GLUtil {
         if (caps.OpenGL43) {
             apiLog("[GL] Using OpenGL 4.3 for error logging.");
             GLDebugMessageCallback proc = GLDebugMessageCallback.create((source, type, id, severity, length, message, userParam) -> {
-                stream.println("[LWJGL] OpenGL debug message");
-                printDetail(stream, "ID", String.format("0x%X", id));
-                printDetail(stream, "Source", getDebugSource(source));
-                printDetail(stream, "Type", getDebugType(type));
-                printDetail(stream, "Severity", getDebugSeverity(severity));
-                printDetail(stream, "Message", GLDebugMessageCallback.getMessage(length, message));
+                StringBuilder sb = new StringBuilder(300);
+
+                sb.append("[LWJGL] OpenGL debug message\n");
+                printDetail(sb, "ID", "0x" + Integer.toHexString(id).toUpperCase());
+                printDetail(sb, "Source", getDebugSource(source));
+                printDetail(sb, "Type", getDebugType(type));
+                printDetail(sb, "Severity", getDebugSeverity(severity));
+                printDetail(sb, "Message", GLDebugMessageCallback.getMessage(length, message));
+
+                stream.print(sb);
             });
             glDebugMessageCallback(proc, NULL);
             if ((glGetInteger(GL_CONTEXT_FLAGS) & GL_CONTEXT_FLAG_DEBUG_BIT) == 0) {
@@ -61,12 +65,16 @@ public final class GLUtil {
         if (caps.GL_KHR_debug) {
             apiLog("[GL] Using KHR_debug for error logging.");
             GLDebugMessageCallback proc = GLDebugMessageCallback.create((source, type, id, severity, length, message, userParam) -> {
-                stream.println("[LWJGL] OpenGL debug message");
-                printDetail(stream, "ID", String.format("0x%X", id));
-                printDetail(stream, "Source", getDebugSource(source));
-                printDetail(stream, "Type", getDebugType(type));
-                printDetail(stream, "Severity", getDebugSeverity(severity));
-                printDetail(stream, "Message", GLDebugMessageCallback.getMessage(length, message));
+                StringBuilder sb = new StringBuilder(300);
+
+                sb.append("[LWJGL] OpenGL debug message\n");
+                printDetail(sb, "ID", "0x" + Integer.toHexString(id).toUpperCase());
+                printDetail(sb, "Source", getDebugSource(source));
+                printDetail(sb, "Type", getDebugType(type));
+                printDetail(sb, "Severity", getDebugSeverity(severity));
+                printDetail(sb, "Message", GLDebugMessageCallback.getMessage(length, message));
+
+                stream.print(sb);
             });
             KHRDebug.glDebugMessageCallback(proc, NULL);
             if (caps.OpenGL30 && (glGetInteger(GL_CONTEXT_FLAGS) & GL_CONTEXT_FLAG_DEBUG_BIT) == 0) {
@@ -79,12 +87,16 @@ public final class GLUtil {
         if (caps.GL_ARB_debug_output) {
             apiLog("[GL] Using ARB_debug_output for error logging.");
             GLDebugMessageARBCallback proc = GLDebugMessageARBCallback.create((source, type, id, severity, length, message, userParam) -> {
-                stream.println("[LWJGL] ARB_debug_output message");
-                printDetail(stream, "ID", String.format("0x%X", id));
-                printDetail(stream, "Source", getSourceARB(source));
-                printDetail(stream, "Type", getTypeARB(type));
-                printDetail(stream, "Severity", getSeverityARB(severity));
-                printDetail(stream, "Message", GLDebugMessageARBCallback.getMessage(length, message));
+                StringBuilder sb = new StringBuilder(300);
+
+                sb.append("[LWJGL] ARB_debug_output message\n");
+                printDetail(sb, "ID", "0x" + Integer.toHexString(id).toUpperCase());
+                printDetail(sb, "Source", getSourceARB(source));
+                printDetail(sb, "Type", getTypeARB(type));
+                printDetail(sb, "Severity", getSeverityARB(severity));
+                printDetail(sb, "Message", GLDebugMessageARBCallback.getMessage(length, message));
+
+                stream.print(sb);
             });
             glDebugMessageCallbackARB(proc, NULL);
             return proc;
@@ -93,11 +105,15 @@ public final class GLUtil {
         if (caps.GL_AMD_debug_output) {
             apiLog("[GL] Using AMD_debug_output for error logging.");
             GLDebugMessageAMDCallback proc = GLDebugMessageAMDCallback.create((id, category, severity, length, message, userParam) -> {
-                stream.println("[LWJGL] AMD_debug_output message");
-                printDetail(stream, "ID", String.format("0x%X", id));
-                printDetail(stream, "Category", getCategoryAMD(category));
-                printDetail(stream, "Severity", getSeverityAMD(severity));
-                printDetail(stream, "Message", GLDebugMessageAMDCallback.getMessage(length, message));
+                StringBuilder sb = new StringBuilder(300);
+
+                sb.append("[LWJGL] AMD_debug_output message\n");
+                printDetail(sb, "ID", "0x" + Integer.toHexString(id).toUpperCase());
+                printDetail(sb, "Category", getCategoryAMD(category));
+                printDetail(sb, "Severity", getSeverityAMD(severity));
+                printDetail(sb, "Message", GLDebugMessageAMDCallback.getMessage(length, message));
+
+                stream.print(sb);
             });
             glDebugMessageCallbackAMD(proc, NULL);
             return proc;
@@ -107,8 +123,13 @@ public final class GLUtil {
         return null;
     }
 
-    private static void printDetail(PrintStream stream, String type, String message) {
-        stream.printf("\t%s: %s\n", type, message);
+    private static void printDetail(StringBuilder sb, String type, String message) {
+        sb
+            .append("\t")
+            .append(type)
+            .append(": ")
+            .append(message)
+            .append("\n");
     }
 
     private static String getDebugSource(int source) {


### PR DESCRIPTION
There is a tiny chance that the split PrintStream writes could tear in multithreaded environments when writing a lot of messages concurrently. This change uses monitors to prevent such issues going forward.

Since these paths are not performance sensitive, the use of monitors shouldn't be an issue here. Alternatively, we could prebuild and log a single `String` but I think that would cause undesirable output for multiline strings.