### PR TITLE
Add missing `Nullable` marker for `aDefaultPath` in `tinyfd` module

### DIFF
--- a/doc/notes/3.3.4.md
+++ b/doc/notes/3.3.4.md
@@ -10,4 +10,6 @@ This build includes the following changes:
 
 #### Fixes
 
+- tinyfd: The `aDefaultPath` parameter of `tinyfd_selectFolderDialog` is now nullable. (#922)
+
 #### Breaking Changes

--- a/modules/lwjgl/tinyfd/src/generated/java/org/lwjgl/util/tinyfd/TinyFileDialogs.java
+++ b/modules/lwjgl/tinyfd/src/generated/java/org/lwjgl/util/tinyfd/TinyFileDialogs.java
@@ -496,12 +496,12 @@ public class TinyFileDialogs {
      */
     @Nullable
     @NativeType("char const *")
-    public static String tinyfd_selectFolderDialog(@Nullable @NativeType("char const *") ByteBuffer aTitle, @NativeType("char const *") ByteBuffer aDefaultPath) {
+    public static String tinyfd_selectFolderDialog(@Nullable @NativeType("char const *") ByteBuffer aTitle, @Nullable @NativeType("char const *") ByteBuffer aDefaultPath) {
         if (CHECKS) {
             checkNT1Safe(aTitle);
-            checkNT1(aDefaultPath);
+            checkNT1Safe(aDefaultPath);
         }
-        long __result = ntinyfd_selectFolderDialog(memAddressSafe(aTitle), memAddress(aDefaultPath));
+        long __result = ntinyfd_selectFolderDialog(memAddressSafe(aTitle), memAddressSafe(aDefaultPath));
         return memUTF8Safe(__result);
     }
 
@@ -513,13 +513,13 @@ public class TinyFileDialogs {
      */
     @Nullable
     @NativeType("char const *")
-    public static String tinyfd_selectFolderDialog(@Nullable @NativeType("char const *") CharSequence aTitle, @NativeType("char const *") CharSequence aDefaultPath) {
+    public static String tinyfd_selectFolderDialog(@Nullable @NativeType("char const *") CharSequence aTitle, @Nullable @NativeType("char const *") CharSequence aDefaultPath) {
         MemoryStack stack = stackGet(); int stackPointer = stack.getPointer();
         try {
             stack.nUTF8Safe(aTitle, true);
             long aTitleEncoded = aTitle == null ? NULL : stack.getPointerAddress();
-            stack.nUTF8(aDefaultPath, true);
-            long aDefaultPathEncoded = stack.getPointerAddress();
+            stack.nUTF8Safe(aDefaultPath, true);
+            long aDefaultPathEncoded = aDefaultPath == null ? NULL : stack.getPointerAddress();
             long __result = ntinyfd_selectFolderDialog(aTitleEncoded, aDefaultPathEncoded);
             return memUTF8Safe(__result);
         } finally {

--- a/modules/lwjgl/tinyfd/src/templates/kotlin/tinyfd/templates/tinyfiledialogs.kt
+++ b/modules/lwjgl/tinyfd/src/templates/kotlin/tinyfd/templates/tinyfiledialogs.kt
@@ -187,7 +187,7 @@ dialog whiptail basicinput no_solution""")}
         "Displays a folder selection dialog.",
 
         messageBox["aTitle"],
-        charUTF8.const.p("aDefaultPath", "the default path or #NULL")
+        nullable..charUTF8.const.p("aDefaultPath", "the default path or #NULL")
     )
 
     charUTF8.const.p(


### PR DESCRIPTION
I'm currently using the `tinyfd` module and have discovered a minor bug in the generated bindings.

One of the parameters was missing one `Nullable` annotation. I hope this PR will fix that.

![image](https://github.com/LWJGL/lwjgl3/assets/31899809/ff74608f-9266-43f0-b58d-6a1bdbebbc3e)

Thanks for the library!