### PR TITLE
Fix memory leak in Callback.free

### DIFF
--- a/doc/notes/3.3.4.md
+++ b/doc/notes/3.3.4.md
@@ -10,6 +10,7 @@ This build includes the following changes:
 
 #### Fixes
 
+- Core: Fixed callback wrapper memory leak with the CHM closure registry. (#927)
 - tinyfd: The `aDefaultPath` parameter of `tinyfd_selectFolderDialog` is now nullable. (#922)
 
 #### Breaking Changes

--- a/modules/lwjgl/core/src/main/java/org/lwjgl/system/Callback.java
+++ b/modules/lwjgl/core/src/main/java/org/lwjgl/system/Callback.java
@@ -206,7 +206,7 @@ public abstract class Callback implements Pointer, NativeResource {
             MemoryManage.DebugAllocator.untrack(functionPointer);
         }
 
-        FFIClosure closure = CLOSURE_REGISTRY.get(functionPointer);
+        FFIClosure closure = CLOSURE_REGISTRY.remove(functionPointer);
 
         DeleteGlobalRef(closure.user_data());
         ffi_closure_free(closure);


### PR DESCRIPTION
CallbackRegistry.remove appears to be unused currently, meaning creating and freeing callbacks on platforms that *don't* use the no-op registry leaks memory.