### PR TITLE
LLVM target initialization bindings for AArch64, ARM, AVR, Mips, PPC & WASM

### DIFF
--- a/modules/lwjgl/llvm/src/generated/java/org/lwjgl/llvm/LLVMTargetAArch64.java
+++ b/modules/lwjgl/llvm/src/generated/java/org/lwjgl/llvm/LLVMTargetAArch64.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright LWJGL. All rights reserved.
+ * License terms: https://www.lwjgl.org/license
+ * MACHINE GENERATED FILE, DO NOT EDIT
+ */
+package org.lwjgl.llvm;
+
+import org.lwjgl.system.*;
+
+import static org.lwjgl.system.APIUtil.*;
+import static org.lwjgl.system.JNI.*;
+
+public class LLVMTargetAArch64 {
+
+    /** Contains the function pointers loaded from {@code LLVMCore.getLibrary()}. */
+    public static final class Functions {
+
+        private Functions() {}
+
+        /** Function address. */
+        public static final long
+            InitializeAArch64TargetInfo   = apiGetFunctionAddress(LLVMCore.getLibrary(), "LLVMInitializeAArch64TargetInfo"),
+            InitializeAArch64Target       = apiGetFunctionAddress(LLVMCore.getLibrary(), "LLVMInitializeAArch64Target"),
+            InitializeAArch64TargetMC     = apiGetFunctionAddress(LLVMCore.getLibrary(), "LLVMInitializeAArch64TargetMC"),
+            InitializeAArch64AsmPrinter   = apiGetFunctionAddress(LLVMCore.getLibrary(), "LLVMInitializeAArch64AsmPrinter"),
+            InitializeAArch64AsmParser    = apiGetFunctionAddress(LLVMCore.getLibrary(), "LLVMInitializeAArch64AsmParser"),
+            InitializeAArch64Disassembler = apiGetFunctionAddress(LLVMCore.getLibrary(), "LLVMInitializeAArch64Disassembler");
+
+    }
+
+    protected LLVMTargetAArch64() {
+        throw new UnsupportedOperationException();
+    }
+
+    // --- [ LLVMInitializeAArch64TargetInfo ] ---
+
+    public static void LLVMInitializeAArch64TargetInfo() {
+        long __functionAddress = Functions.InitializeAArch64TargetInfo;
+        invokeV(__functionAddress);
+    }
+
+    // --- [ LLVMInitializeAArch64Target ] ---
+
+    public static void LLVMInitializeAArch64Target() {
+        long __functionAddress = Functions.InitializeAArch64Target;
+        invokeV(__functionAddress);
+    }
+
+    // --- [ LLVMInitializeAArch64TargetMC ] ---
+
+    public static void LLVMInitializeAArch64TargetMC() {
+        long __functionAddress = Functions.InitializeAArch64TargetMC;
+        invokeV(__functionAddress);
+    }
+
+    // --- [ LLVMInitializeAArch64AsmPrinter ] ---
+
+    public static void LLVMInitializeAArch64AsmPrinter() {
+        long __functionAddress = Functions.InitializeAArch64AsmPrinter;
+        invokeV(__functionAddress);
+    }
+
+    // --- [ LLVMInitializeAArch64AsmParser ] ---
+
+    public static void LLVMInitializeAArch64AsmParser() {
+        long __functionAddress = Functions.InitializeAArch64AsmParser;
+        invokeV(__functionAddress);
+    }
+
+    // --- [ LLVMInitializeAArch64Disassembler ] ---
+
+    public static void LLVMInitializeAArch64Disassembler() {
+        long __functionAddress = Functions.InitializeAArch64Disassembler;
+        invokeV(__functionAddress);
+    }
+
+}

--- a/modules/lwjgl/llvm/src/generated/java/org/lwjgl/llvm/LLVMTargetAMDGPU.java
+++ b/modules/lwjgl/llvm/src/generated/java/org/lwjgl/llvm/LLVMTargetAMDGPU.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright LWJGL. All rights reserved.
+ * License terms: https://www.lwjgl.org/license
+ * MACHINE GENERATED FILE, DO NOT EDIT
+ */
+package org.lwjgl.llvm;
+
+import org.lwjgl.system.*;
+
+import static org.lwjgl.system.APIUtil.*;
+import static org.lwjgl.system.Checks.*;
+import static org.lwjgl.system.JNI.*;
+
+public class LLVMTargetAMDGPU {
+
+    /** Contains the function pointers loaded from {@code LLVMCore.getLibrary()}. */
+    public static final class Functions {
+
+        private Functions() {}
+
+        /** Function address. */
+        public static final long
+            InitializeAMDGPUTargetInfo   = apiGetFunctionAddress(LLVMCore.getLibrary(), "LLVMInitializeAMDGPUTargetInfo"),
+            InitializeAMDGPUTarget       = apiGetFunctionAddress(LLVMCore.getLibrary(), "LLVMInitializeAMDGPUTarget"),
+            InitializeAMDGPUTargetMC     = apiGetFunctionAddress(LLVMCore.getLibrary(), "LLVMInitializeAMDGPUTargetMC"),
+            InitializeAMDGPUTargetMCA    = apiGetFunctionAddressOptional(LLVMCore.getLibrary(), "LLVMInitializeAMDGPUTargetMCA"),
+            InitializeAMDGPUAsmPrinter   = apiGetFunctionAddress(LLVMCore.getLibrary(), "LLVMInitializeAMDGPUAsmPrinter"),
+            InitializeAMDGPUAsmParser    = apiGetFunctionAddress(LLVMCore.getLibrary(), "LLVMInitializeAMDGPUAsmParser"),
+            InitializeAMDGPUDisassembler = apiGetFunctionAddress(LLVMCore.getLibrary(), "LLVMInitializeAMDGPUDisassembler");
+
+    }
+
+    protected LLVMTargetAMDGPU() {
+        throw new UnsupportedOperationException();
+    }
+
+    // --- [ LLVMInitializeAMDGPUTargetInfo ] ---
+
+    public static void LLVMInitializeAMDGPUTargetInfo() {
+        long __functionAddress = Functions.InitializeAMDGPUTargetInfo;
+        invokeV(__functionAddress);
+    }
+
+    // --- [ LLVMInitializeAMDGPUTarget ] ---
+
+    public static void LLVMInitializeAMDGPUTarget() {
+        long __functionAddress = Functions.InitializeAMDGPUTarget;
+        invokeV(__functionAddress);
+    }
+
+    // --- [ LLVMInitializeAMDGPUTargetMC ] ---
+
+    public static void LLVMInitializeAMDGPUTargetMC() {
+        long __functionAddress = Functions.InitializeAMDGPUTargetMC;
+        invokeV(__functionAddress);
+    }
+
+    // --- [ LLVMInitializeAMDGPUTargetMCA ] ---
+
+    public static void LLVMInitializeAMDGPUTargetMCA() {
+        long __functionAddress = Functions.InitializeAMDGPUTargetMCA;
+        if (CHECKS) {
+            check(__functionAddress);
+        }
+        invokeV(__functionAddress);
+    }
+
+    // --- [ LLVMInitializeAMDGPUAsmPrinter ] ---
+
+    public static void LLVMInitializeAMDGPUAsmPrinter() {
+        long __functionAddress = Functions.InitializeAMDGPUAsmPrinter;
+        invokeV(__functionAddress);
+    }
+
+    // --- [ LLVMInitializeAMDGPUAsmParser ] ---
+
+    public static void LLVMInitializeAMDGPUAsmParser() {
+        long __functionAddress = Functions.InitializeAMDGPUAsmParser;
+        invokeV(__functionAddress);
+    }
+
+    // --- [ LLVMInitializeAMDGPUDisassembler ] ---
+
+    public static void LLVMInitializeAMDGPUDisassembler() {
+        long __functionAddress = Functions.InitializeAMDGPUDisassembler;
+        invokeV(__functionAddress);
+    }
+
+}

--- a/modules/lwjgl/llvm/src/generated/java/org/lwjgl/llvm/LLVMTargetARM.java
+++ b/modules/lwjgl/llvm/src/generated/java/org/lwjgl/llvm/LLVMTargetARM.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright LWJGL. All rights reserved.
+ * License terms: https://www.lwjgl.org/license
+ * MACHINE GENERATED FILE, DO NOT EDIT
+ */
+package org.lwjgl.llvm;
+
+import org.lwjgl.system.*;
+
+import static org.lwjgl.system.APIUtil.*;
+import static org.lwjgl.system.JNI.*;
+
+public class LLVMTargetARM {
+
+    /** Contains the function pointers loaded from {@code LLVMCore.getLibrary()}. */
+    public static final class Functions {
+
+        private Functions() {}
+
+        /** Function address. */
+        public static final long
+            InitializeARMTargetInfo   = apiGetFunctionAddress(LLVMCore.getLibrary(), "LLVMInitializeARMTargetInfo"),
+            InitializeARMTarget       = apiGetFunctionAddress(LLVMCore.getLibrary(), "LLVMInitializeARMTarget"),
+            InitializeARMTargetMC     = apiGetFunctionAddress(LLVMCore.getLibrary(), "LLVMInitializeARMTargetMC"),
+            InitializeARMAsmPrinter   = apiGetFunctionAddress(LLVMCore.getLibrary(), "LLVMInitializeARMAsmPrinter"),
+            InitializeARMAsmParser    = apiGetFunctionAddress(LLVMCore.getLibrary(), "LLVMInitializeARMAsmParser"),
+            InitializeARMDisassembler = apiGetFunctionAddress(LLVMCore.getLibrary(), "LLVMInitializeARMDisassembler");
+
+    }
+
+    protected LLVMTargetARM() {
+        throw new UnsupportedOperationException();
+    }
+
+    // --- [ LLVMInitializeARMTargetInfo ] ---
+
+    public static void LLVMInitializeARMTargetInfo() {
+        long __functionAddress = Functions.InitializeARMTargetInfo;
+        invokeV(__functionAddress);
+    }
+
+    // --- [ LLVMInitializeARMTarget ] ---
+
+    public static void LLVMInitializeARMTarget() {
+        long __functionAddress = Functions.InitializeARMTarget;
+        invokeV(__functionAddress);
+    }
+
+    // --- [ LLVMInitializeARMTargetMC ] ---
+
+    public static void LLVMInitializeARMTargetMC() {
+        long __functionAddress = Functions.InitializeARMTargetMC;
+        invokeV(__functionAddress);
+    }
+
+    // --- [ LLVMInitializeARMAsmPrinter ] ---
+
+    public static void LLVMInitializeARMAsmPrinter() {
+        long __functionAddress = Functions.InitializeARMAsmPrinter;
+        invokeV(__functionAddress);
+    }
+
+    // --- [ LLVMInitializeARMAsmParser ] ---
+
+    public static void LLVMInitializeARMAsmParser() {
+        long __functionAddress = Functions.InitializeARMAsmParser;
+        invokeV(__functionAddress);
+    }
+
+    // --- [ LLVMInitializeARMDisassembler ] ---
+
+    public static void LLVMInitializeARMDisassembler() {
+        long __functionAddress = Functions.InitializeARMDisassembler;
+        invokeV(__functionAddress);
+    }
+
+}

--- a/modules/lwjgl/llvm/src/generated/java/org/lwjgl/llvm/LLVMTargetMips.java
+++ b/modules/lwjgl/llvm/src/generated/java/org/lwjgl/llvm/LLVMTargetMips.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright LWJGL. All rights reserved.
+ * License terms: https://www.lwjgl.org/license
+ * MACHINE GENERATED FILE, DO NOT EDIT
+ */
+package org.lwjgl.llvm;
+
+import org.lwjgl.system.*;
+
+import static org.lwjgl.system.APIUtil.*;
+import static org.lwjgl.system.JNI.*;
+
+public class LLVMTargetMips {
+
+    /** Contains the function pointers loaded from {@code LLVMCore.getLibrary()}. */
+    public static final class Functions {
+
+        private Functions() {}
+
+        /** Function address. */
+        public static final long
+            InitializeMipsTargetInfo   = apiGetFunctionAddress(LLVMCore.getLibrary(), "LLVMInitializeMipsTargetInfo"),
+            InitializeMipsTarget       = apiGetFunctionAddress(LLVMCore.getLibrary(), "LLVMInitializeMipsTarget"),
+            InitializeMipsTargetMC     = apiGetFunctionAddress(LLVMCore.getLibrary(), "LLVMInitializeMipsTargetMC"),
+            InitializeMipsAsmPrinter   = apiGetFunctionAddress(LLVMCore.getLibrary(), "LLVMInitializeMipsAsmPrinter"),
+            InitializeMipsAsmParser    = apiGetFunctionAddress(LLVMCore.getLibrary(), "LLVMInitializeMipsAsmParser"),
+            InitializeMipsDisassembler = apiGetFunctionAddress(LLVMCore.getLibrary(), "LLVMInitializeMipsDisassembler");
+
+    }
+
+    protected LLVMTargetMips() {
+        throw new UnsupportedOperationException();
+    }
+
+    // --- [ LLVMInitializeMipsTargetInfo ] ---
+
+    public static void LLVMInitializeMipsTargetInfo() {
+        long __functionAddress = Functions.InitializeMipsTargetInfo;
+        invokeV(__functionAddress);
+    }
+
+    // --- [ LLVMInitializeMipsTarget ] ---
+
+    public static void LLVMInitializeMipsTarget() {
+        long __functionAddress = Functions.InitializeMipsTarget;
+        invokeV(__functionAddress);
+    }
+
+    // --- [ LLVMInitializeMipsTargetMC ] ---
+
+    public static void LLVMInitializeMipsTargetMC() {
+        long __functionAddress = Functions.InitializeMipsTargetMC;
+        invokeV(__functionAddress);
+    }
+
+    // --- [ LLVMInitializeMipsAsmPrinter ] ---
+
+    public static void LLVMInitializeMipsAsmPrinter() {
+        long __functionAddress = Functions.InitializeMipsAsmPrinter;
+        invokeV(__functionAddress);
+    }
+
+    // --- [ LLVMInitializeMipsAsmParser ] ---
+
+    public static void LLVMInitializeMipsAsmParser() {
+        long __functionAddress = Functions.InitializeMipsAsmParser;
+        invokeV(__functionAddress);
+    }
+
+    // --- [ LLVMInitializeMipsDisassembler ] ---
+
+    public static void LLVMInitializeMipsDisassembler() {
+        long __functionAddress = Functions.InitializeMipsDisassembler;
+        invokeV(__functionAddress);
+    }
+
+}

--- a/modules/lwjgl/llvm/src/generated/java/org/lwjgl/llvm/LLVMTargetPowerPC.java
+++ b/modules/lwjgl/llvm/src/generated/java/org/lwjgl/llvm/LLVMTargetPowerPC.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright LWJGL. All rights reserved.
+ * License terms: https://www.lwjgl.org/license
+ * MACHINE GENERATED FILE, DO NOT EDIT
+ */
+package org.lwjgl.llvm;
+
+import org.lwjgl.system.*;
+
+import static org.lwjgl.system.APIUtil.*;
+import static org.lwjgl.system.JNI.*;
+
+public class LLVMTargetPowerPC {
+
+    /** Contains the function pointers loaded from {@code LLVMCore.getLibrary()}. */
+    public static final class Functions {
+
+        private Functions() {}
+
+        /** Function address. */
+        public static final long
+            InitializePowerPCTargetInfo   = apiGetFunctionAddress(LLVMCore.getLibrary(), "LLVMInitializePowerPCTargetInfo"),
+            InitializePowerPCTarget       = apiGetFunctionAddress(LLVMCore.getLibrary(), "LLVMInitializePowerPCTarget"),
+            InitializePowerPCTargetMC     = apiGetFunctionAddress(LLVMCore.getLibrary(), "LLVMInitializePowerPCTargetMC"),
+            InitializePowerPCAsmPrinter   = apiGetFunctionAddress(LLVMCore.getLibrary(), "LLVMInitializePowerPCAsmPrinter"),
+            InitializePowerPCAsmParser    = apiGetFunctionAddress(LLVMCore.getLibrary(), "LLVMInitializePowerPCAsmParser"),
+            InitializePowerPCDisassembler = apiGetFunctionAddress(LLVMCore.getLibrary(), "LLVMInitializePowerPCDisassembler");
+
+    }
+
+    protected LLVMTargetPowerPC() {
+        throw new UnsupportedOperationException();
+    }
+
+    // --- [ LLVMInitializePowerPCTargetInfo ] ---
+
+    public static void LLVMInitializePowerPCTargetInfo() {
+        long __functionAddress = Functions.InitializePowerPCTargetInfo;
+        invokeV(__functionAddress);
+    }
+
+    // --- [ LLVMInitializePowerPCTarget ] ---
+
+    public static void LLVMInitializePowerPCTarget() {
+        long __functionAddress = Functions.InitializePowerPCTarget;
+        invokeV(__functionAddress);
+    }
+
+    // --- [ LLVMInitializePowerPCTargetMC ] ---
+
+    public static void LLVMInitializePowerPCTargetMC() {
+        long __functionAddress = Functions.InitializePowerPCTargetMC;
+        invokeV(__functionAddress);
+    }
+
+    // --- [ LLVMInitializePowerPCAsmPrinter ] ---
+
+    public static void LLVMInitializePowerPCAsmPrinter() {
+        long __functionAddress = Functions.InitializePowerPCAsmPrinter;
+        invokeV(__functionAddress);
+    }
+
+    // --- [ LLVMInitializePowerPCAsmParser ] ---
+
+    public static void LLVMInitializePowerPCAsmParser() {
+        long __functionAddress = Functions.InitializePowerPCAsmParser;
+        invokeV(__functionAddress);
+    }
+
+    // --- [ LLVMInitializePowerPCDisassembler ] ---
+
+    public static void LLVMInitializePowerPCDisassembler() {
+        long __functionAddress = Functions.InitializePowerPCDisassembler;
+        invokeV(__functionAddress);
+    }
+
+}

--- a/modules/lwjgl/llvm/src/generated/java/org/lwjgl/llvm/LLVMTargetRISCV.java
+++ b/modules/lwjgl/llvm/src/generated/java/org/lwjgl/llvm/LLVMTargetRISCV.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright LWJGL. All rights reserved.
+ * License terms: https://www.lwjgl.org/license
+ * MACHINE GENERATED FILE, DO NOT EDIT
+ */
+package org.lwjgl.llvm;
+
+import org.lwjgl.system.*;
+
+import static org.lwjgl.system.APIUtil.*;
+import static org.lwjgl.system.Checks.*;
+import static org.lwjgl.system.JNI.*;
+
+public class LLVMTargetRISCV {
+
+    /** Contains the function pointers loaded from {@code LLVMCore.getLibrary()}. */
+    public static final class Functions {
+
+        private Functions() {}
+
+        /** Function address. */
+        public static final long
+            InitializeRISCVTargetInfo   = apiGetFunctionAddress(LLVMCore.getLibrary(), "LLVMInitializeRISCVTargetInfo"),
+            InitializeRISCVTarget       = apiGetFunctionAddress(LLVMCore.getLibrary(), "LLVMInitializeRISCVTarget"),
+            InitializeRISCVTargetMC     = apiGetFunctionAddress(LLVMCore.getLibrary(), "LLVMInitializeRISCVTargetMC"),
+            InitializeRISCVTargetMCA    = apiGetFunctionAddressOptional(LLVMCore.getLibrary(), "LLVMInitializeRISCVTargetMCA"),
+            InitializeRISCVAsmPrinter   = apiGetFunctionAddress(LLVMCore.getLibrary(), "LLVMInitializeRISCVAsmPrinter"),
+            InitializeRISCVAsmParser    = apiGetFunctionAddress(LLVMCore.getLibrary(), "LLVMInitializeRISCVAsmParser"),
+            InitializeRISCVDisassembler = apiGetFunctionAddress(LLVMCore.getLibrary(), "LLVMInitializeRISCVDisassembler");
+
+    }
+
+    protected LLVMTargetRISCV() {
+        throw new UnsupportedOperationException();
+    }
+
+    // --- [ LLVMInitializeRISCVTargetInfo ] ---
+
+    public static void LLVMInitializeRISCVTargetInfo() {
+        long __functionAddress = Functions.InitializeRISCVTargetInfo;
+        invokeV(__functionAddress);
+    }
+
+    // --- [ LLVMInitializeRISCVTarget ] ---
+
+    public static void LLVMInitializeRISCVTarget() {
+        long __functionAddress = Functions.InitializeRISCVTarget;
+        invokeV(__functionAddress);
+    }
+
+    // --- [ LLVMInitializeRISCVTargetMC ] ---
+
+    public static void LLVMInitializeRISCVTargetMC() {
+        long __functionAddress = Functions.InitializeRISCVTargetMC;
+        invokeV(__functionAddress);
+    }
+
+    // --- [ LLVMInitializeRISCVTargetMCA ] ---
+
+    public static void LLVMInitializeRISCVTargetMCA() {
+        long __functionAddress = Functions.InitializeRISCVTargetMCA;
+        if (CHECKS) {
+            check(__functionAddress);
+        }
+        invokeV(__functionAddress);
+    }
+
+    // --- [ LLVMInitializeRISCVAsmPrinter ] ---
+
+    public static void LLVMInitializeRISCVAsmPrinter() {
+        long __functionAddress = Functions.InitializeRISCVAsmPrinter;
+        invokeV(__functionAddress);
+    }
+
+    // --- [ LLVMInitializeRISCVAsmParser ] ---
+
+    public static void LLVMInitializeRISCVAsmParser() {
+        long __functionAddress = Functions.InitializeRISCVAsmParser;
+        invokeV(__functionAddress);
+    }
+
+    // --- [ LLVMInitializeRISCVDisassembler ] ---
+
+    public static void LLVMInitializeRISCVDisassembler() {
+        long __functionAddress = Functions.InitializeRISCVDisassembler;
+        invokeV(__functionAddress);
+    }
+
+}

--- a/modules/lwjgl/llvm/src/generated/java/org/lwjgl/llvm/LLVMTargetWebAssembly.java
+++ b/modules/lwjgl/llvm/src/generated/java/org/lwjgl/llvm/LLVMTargetWebAssembly.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright LWJGL. All rights reserved.
+ * License terms: https://www.lwjgl.org/license
+ * MACHINE GENERATED FILE, DO NOT EDIT
+ */
+package org.lwjgl.llvm;
+
+import org.lwjgl.system.*;
+
+import static org.lwjgl.system.APIUtil.*;
+import static org.lwjgl.system.JNI.*;
+
+public class LLVMTargetWebAssembly {
+
+    /** Contains the function pointers loaded from {@code LLVMCore.getLibrary()}. */
+    public static final class Functions {
+
+        private Functions() {}
+
+        /** Function address. */
+        public static final long
+            InitializeWebAssemblyTargetInfo   = apiGetFunctionAddress(LLVMCore.getLibrary(), "LLVMInitializeWebAssemblyTargetInfo"),
+            InitializeWebAssemblyTarget       = apiGetFunctionAddress(LLVMCore.getLibrary(), "LLVMInitializeWebAssemblyTarget"),
+            InitializeWebAssemblyTargetMC     = apiGetFunctionAddress(LLVMCore.getLibrary(), "LLVMInitializeWebAssemblyTargetMC"),
+            InitializeWebAssemblyAsmPrinter   = apiGetFunctionAddress(LLVMCore.getLibrary(), "LLVMInitializeWebAssemblyAsmPrinter"),
+            InitializeWebAssemblyAsmParser    = apiGetFunctionAddress(LLVMCore.getLibrary(), "LLVMInitializeWebAssemblyAsmParser"),
+            InitializeWebAssemblyDisassembler = apiGetFunctionAddress(LLVMCore.getLibrary(), "LLVMInitializeWebAssemblyDisassembler");
+
+    }
+
+    protected LLVMTargetWebAssembly() {
+        throw new UnsupportedOperationException();
+    }
+
+    // --- [ LLVMInitializeWebAssemblyTargetInfo ] ---
+
+    public static void LLVMInitializeWebAssemblyTargetInfo() {
+        long __functionAddress = Functions.InitializeWebAssemblyTargetInfo;
+        invokeV(__functionAddress);
+    }
+
+    // --- [ LLVMInitializeWebAssemblyTarget ] ---
+
+    public static void LLVMInitializeWebAssemblyTarget() {
+        long __functionAddress = Functions.InitializeWebAssemblyTarget;
+        invokeV(__functionAddress);
+    }
+
+    // --- [ LLVMInitializeWebAssemblyTargetMC ] ---
+
+    public static void LLVMInitializeWebAssemblyTargetMC() {
+        long __functionAddress = Functions.InitializeWebAssemblyTargetMC;
+        invokeV(__functionAddress);
+    }
+
+    // --- [ LLVMInitializeWebAssemblyAsmPrinter ] ---
+
+    public static void LLVMInitializeWebAssemblyAsmPrinter() {
+        long __functionAddress = Functions.InitializeWebAssemblyAsmPrinter;
+        invokeV(__functionAddress);
+    }
+
+    // --- [ LLVMInitializeWebAssemblyAsmParser ] ---
+
+    public static void LLVMInitializeWebAssemblyAsmParser() {
+        long __functionAddress = Functions.InitializeWebAssemblyAsmParser;
+        invokeV(__functionAddress);
+    }
+
+    // --- [ LLVMInitializeWebAssemblyDisassembler ] ---
+
+    public static void LLVMInitializeWebAssemblyDisassembler() {
+        long __functionAddress = Functions.InitializeWebAssemblyDisassembler;
+        invokeV(__functionAddress);
+    }
+
+}

--- a/modules/lwjgl/llvm/src/generated/java/org/lwjgl/llvm/LLVMTargetX86.java
+++ b/modules/lwjgl/llvm/src/generated/java/org/lwjgl/llvm/LLVMTargetX86.java
@@ -8,6 +8,7 @@ package org.lwjgl.llvm;
 import org.lwjgl.system.*;
 
 import static org.lwjgl.system.APIUtil.*;
+import static org.lwjgl.system.Checks.*;
 import static org.lwjgl.system.JNI.*;
 
 public class LLVMTargetX86 {
@@ -22,6 +23,7 @@ public class LLVMTargetX86 {
             InitializeX86TargetInfo   = apiGetFunctionAddress(LLVMCore.getLibrary(), "LLVMInitializeX86TargetInfo"),
             InitializeX86Target       = apiGetFunctionAddress(LLVMCore.getLibrary(), "LLVMInitializeX86Target"),
             InitializeX86TargetMC     = apiGetFunctionAddress(LLVMCore.getLibrary(), "LLVMInitializeX86TargetMC"),
+            InitializeX86TargetMCA    = apiGetFunctionAddressOptional(LLVMCore.getLibrary(), "LLVMInitializeX86TargetMCA"),
             InitializeX86AsmPrinter   = apiGetFunctionAddress(LLVMCore.getLibrary(), "LLVMInitializeX86AsmPrinter"),
             InitializeX86AsmParser    = apiGetFunctionAddress(LLVMCore.getLibrary(), "LLVMInitializeX86AsmParser"),
             InitializeX86Disassembler = apiGetFunctionAddress(LLVMCore.getLibrary(), "LLVMInitializeX86Disassembler");
@@ -50,6 +52,16 @@ public class LLVMTargetX86 {
 
     public static void LLVMInitializeX86TargetMC() {
         long __functionAddress = Functions.InitializeX86TargetMC;
+        invokeV(__functionAddress);
+    }
+
+    // --- [ LLVMInitializeX86TargetMCA ] ---
+
+    public static void LLVMInitializeX86TargetMCA() {
+        long __functionAddress = Functions.InitializeX86TargetMCA;
+        if (CHECKS) {
+            check(__functionAddress);
+        }
         invokeV(__functionAddress);
     }
 

--- a/modules/lwjgl/llvm/src/templates/kotlin/llvm/templates/LLVMTargetAArch64.kt
+++ b/modules/lwjgl/llvm/src/templates/kotlin/llvm/templates/LLVMTargetAArch64.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright LWJGL. All rights reserved.
+ * License terms: https://www.lwjgl.org/license
+ */
+package llvm.templates
+
+import llvm.*
+import org.lwjgl.generator.*
+
+val LLVMTargetAArch64 = "LLVMTargetAArch64".nativeClass(
+    Module.LLVM,
+    prefixConstant = "LLVM",
+    prefixMethod = "LLVM",
+    binding = LLVM_BINDING_DELEGATE
+) {
+    documentation = ""
+
+    void("InitializeAArch64TargetInfo",   "", void())
+    void("InitializeAArch64Target",       "", void())
+    void("InitializeAArch64TargetMC",     "", void())
+    void("InitializeAArch64AsmPrinter",   "", void())
+    void("InitializeAArch64AsmParser",    "", void())
+    void("InitializeAArch64Disassembler", "", void())
+}

--- a/modules/lwjgl/llvm/src/templates/kotlin/llvm/templates/LLVMTargetAMDGPU.kt
+++ b/modules/lwjgl/llvm/src/templates/kotlin/llvm/templates/LLVMTargetAMDGPU.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright LWJGL. All rights reserved.
+ * License terms: https://www.lwjgl.org/license
+ */
+package llvm.templates
+
+import llvm.*
+import org.lwjgl.generator.*
+
+val LLVMTargetAMDGPU = "LLVMTargetAMDGPU".nativeClass(
+    Module.LLVM,
+    prefixConstant = "LLVM",
+    prefixMethod = "LLVM",
+    binding = LLVM_BINDING_DELEGATE
+) {
+    documentation = ""
+
+    void("InitializeAMDGPUTargetInfo",   "", void())
+    void("InitializeAMDGPUTarget",       "", void())
+    void("InitializeAMDGPUTargetMC",     "", void())
+    IgnoreMissing..
+    void("InitializeAMDGPUTargetMCA",    "", void())
+    void("InitializeAMDGPUAsmPrinter",   "", void())
+    void("InitializeAMDGPUAsmParser",    "", void())
+    void("InitializeAMDGPUDisassembler", "", void())
+}

--- a/modules/lwjgl/llvm/src/templates/kotlin/llvm/templates/LLVMTargetARM.kt
+++ b/modules/lwjgl/llvm/src/templates/kotlin/llvm/templates/LLVMTargetARM.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright LWJGL. All rights reserved.
+ * License terms: https://www.lwjgl.org/license
+ */
+package llvm.templates
+
+import llvm.*
+import org.lwjgl.generator.*
+
+val LLVMTargetARM = "LLVMTargetARM".nativeClass(
+    Module.LLVM,
+    prefixConstant = "LLVM",
+    prefixMethod = "LLVM",
+    binding = LLVM_BINDING_DELEGATE
+) {
+    documentation = ""
+
+    void("InitializeARMTargetInfo",   "", void())
+    void("InitializeARMTarget",       "", void())
+    void("InitializeARMTargetMC",     "", void())
+    void("InitializeARMAsmPrinter",   "", void())
+    void("InitializeARMAsmParser",    "", void())
+    void("InitializeARMDisassembler", "", void())
+}

--- a/modules/lwjgl/llvm/src/templates/kotlin/llvm/templates/LLVMTargetMips.kt
+++ b/modules/lwjgl/llvm/src/templates/kotlin/llvm/templates/LLVMTargetMips.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright LWJGL. All rights reserved.
+ * License terms: https://www.lwjgl.org/license
+ */
+package llvm.templates
+
+import llvm.*
+import org.lwjgl.generator.*
+
+val LLVMTargetMips = "LLVMTargetMips".nativeClass(
+    Module.LLVM,
+    prefixConstant = "LLVM",
+    prefixMethod = "LLVM",
+    binding = LLVM_BINDING_DELEGATE
+) {
+    documentation = ""
+
+    void("InitializeMipsTargetInfo",   "", void())
+    void("InitializeMipsTarget",       "", void())
+    void("InitializeMipsTargetMC",     "", void())
+    void("InitializeMipsAsmPrinter",   "", void())
+    void("InitializeMipsAsmParser",    "", void())
+    void("InitializeMipsDisassembler", "", void())
+}

--- a/modules/lwjgl/llvm/src/templates/kotlin/llvm/templates/LLVMTargetPowerPC.kt
+++ b/modules/lwjgl/llvm/src/templates/kotlin/llvm/templates/LLVMTargetPowerPC.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright LWJGL. All rights reserved.
+ * License terms: https://www.lwjgl.org/license
+ */
+package llvm.templates
+
+import llvm.*
+import org.lwjgl.generator.*
+
+val LLVMTargetPowerPC = "LLVMTargetPowerPC".nativeClass(
+    Module.LLVM,
+    prefixConstant = "LLVM",
+    prefixMethod = "LLVM",
+    binding = LLVM_BINDING_DELEGATE
+) {
+    documentation = ""
+
+    void("InitializePowerPCTargetInfo",   "", void())
+    void("InitializePowerPCTarget",       "", void())
+    void("InitializePowerPCTargetMC",     "", void())
+    void("InitializePowerPCAsmPrinter",   "", void())
+    void("InitializePowerPCAsmParser",    "", void())
+    void("InitializePowerPCDisassembler", "", void())
+}

--- a/modules/lwjgl/llvm/src/templates/kotlin/llvm/templates/LLVMTargetRISCV.kt
+++ b/modules/lwjgl/llvm/src/templates/kotlin/llvm/templates/LLVMTargetRISCV.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright LWJGL. All rights reserved.
+ * License terms: https://www.lwjgl.org/license
+ */
+package llvm.templates
+
+import llvm.*
+import org.lwjgl.generator.*
+
+val LLVMTargetRISCV = "LLVMTargetRISCV".nativeClass(
+    Module.LLVM,
+    prefixConstant = "LLVM",
+    prefixMethod = "LLVM",
+    binding = LLVM_BINDING_DELEGATE
+) {
+    documentation = ""
+
+    void("InitializeRISCVTargetInfo",   "", void())
+    void("InitializeRISCVTarget",       "", void())
+    void("InitializeRISCVTargetMC",     "", void())
+    IgnoreMissing..
+    void("InitializeRISCVTargetMCA",    "", void())
+    void("InitializeRISCVAsmPrinter",   "", void())
+    void("InitializeRISCVAsmParser",    "", void())
+    void("InitializeRISCVDisassembler", "", void())
+}

--- a/modules/lwjgl/llvm/src/templates/kotlin/llvm/templates/LLVMTargetWebAssembly.kt
+++ b/modules/lwjgl/llvm/src/templates/kotlin/llvm/templates/LLVMTargetWebAssembly.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright LWJGL. All rights reserved.
+ * License terms: https://www.lwjgl.org/license
+ */
+package llvm.templates
+
+import llvm.*
+import org.lwjgl.generator.*
+
+val LLVMTargetWebAssembly = "LLVMTargetWebAssembly".nativeClass(
+    Module.LLVM,
+    prefixConstant = "LLVM",
+    prefixMethod = "LLVM",
+    binding = LLVM_BINDING_DELEGATE
+) {
+    documentation = ""
+
+    void("InitializeWebAssemblyTargetInfo",   "", void())
+    void("InitializeWebAssemblyTarget",       "", void())
+    void("InitializeWebAssemblyTargetMC",     "", void())
+    void("InitializeWebAssemblyAsmPrinter",   "", void())
+    void("InitializeWebAssemblyAsmParser",    "", void())
+    void("InitializeWebAssemblyDisassembler", "", void())
+}

--- a/modules/lwjgl/llvm/src/templates/kotlin/llvm/templates/LLVMTargetX86.kt
+++ b/modules/lwjgl/llvm/src/templates/kotlin/llvm/templates/LLVMTargetX86.kt
@@ -15,10 +15,12 @@ val LLVMTargetX86 = "LLVMTargetX86".nativeClass(
 ) {
     documentation = ""
 
-    void("InitializeX86TargetInfo", "", void())
-    void("InitializeX86Target", "", void())
-    void("InitializeX86TargetMC", "", void())
-    void("InitializeX86AsmPrinter", "", void())
-    void("InitializeX86AsmParser", "", void())
+    void("InitializeX86TargetInfo",   "", void())
+    void("InitializeX86Target",       "", void())
+    void("InitializeX86TargetMC",     "", void())
+    IgnoreMissing..
+    void("InitializeX86TargetMCA",    "", void())
+    void("InitializeX86AsmPrinter",   "", void())
+    void("InitializeX86AsmParser",    "", void())
     void("InitializeX86Disassembler", "", void())
 }


### PR DESCRIPTION
As the title says, this PR adds target initialization bindings for some major CPU architectures which are missing in the LLVM module at the moment. Cheers.