### PR TITLE
fix(llvm) change return type of `LLVMLookupIntrinsicID` function(s) in generated bindings from `void` to (unsigned) `int`

### DIFF
--- a/doc/notes/3.3.4.md
+++ b/doc/notes/3.3.4.md
@@ -37,6 +37,7 @@ This build includes the following changes:
 
 - Core: Fixed callback wrapper memory leak with the CHM closure registry. (#927)
 - LLVM: Fixed `LLVMGetBufferStart` to return `ByteBuffer` instead of `String`. (#934)
+- LLVM: Fixed `LookupIntrinsicID` to return `unsigned` instead of `void`. (#950)
 - tinyfd: The `aDefaultPath` parameter of `tinyfd_selectFolderDialog` is now nullable. (#922)
 
 #### Breaking Changes

--- a/modules/lwjgl/llvm/src/generated/java/org/lwjgl/llvm/LLVMCore.java
+++ b/modules/lwjgl/llvm/src/generated/java/org/lwjgl/llvm/LLVMCore.java
@@ -7907,12 +7907,12 @@ public class LLVMCore {
     // --- [ LLVMLookupIntrinsicID ] ---
 
     /** Unsafe version of: {@link #LLVMLookupIntrinsicID LookupIntrinsicID} */
-    public static void nLLVMLookupIntrinsicID(long Name, long NameLen) {
+    public static int nLLVMLookupIntrinsicID(long Name, long NameLen) {
         long __functionAddress = Functions.LookupIntrinsicID;
         if (CHECKS) {
             check(__functionAddress);
         }
-        invokePPV(Name, NameLen, __functionAddress);
+        return invokePPI(Name, NameLen, __functionAddress);
     }
 
     /**
@@ -7920,8 +7920,9 @@ public class LLVMCore {
      *
      * @since 9
      */
-    public static void LLVMLookupIntrinsicID(@NativeType("char const *") ByteBuffer Name) {
-        nLLVMLookupIntrinsicID(memAddress(Name), Name.remaining());
+    @NativeType("unsigned int")
+    public static int LLVMLookupIntrinsicID(@NativeType("char const *") ByteBuffer Name) {
+        return nLLVMLookupIntrinsicID(memAddress(Name), Name.remaining());
     }
 
     /**
@@ -7929,12 +7930,13 @@ public class LLVMCore {
      *
      * @since 9
      */
-    public static void LLVMLookupIntrinsicID(@NativeType("char const *") CharSequence Name) {
+    @NativeType("unsigned int")
+    public static int LLVMLookupIntrinsicID(@NativeType("char const *") CharSequence Name) {
         MemoryStack stack = stackGet(); int stackPointer = stack.getPointer();
         try {
             int NameEncodedLength = stack.nUTF8(Name, false);
             long NameEncoded = stack.getPointerAddress();
-            nLLVMLookupIntrinsicID(NameEncoded, NameEncodedLength);
+            return nLLVMLookupIntrinsicID(NameEncoded, NameEncodedLength);
         } finally {
             stack.setPointer(stackPointer);
         }

--- a/modules/lwjgl/llvm/src/templates/kotlin/llvm/templates/LLVMCore.kt
+++ b/modules/lwjgl/llvm/src/templates/kotlin/llvm/templates/LLVMCore.kt
@@ -3233,7 +3233,7 @@ val LLVMCore = "LLVMCore".nativeClass(
         LLVMValueRef("PersonalityFn", "")
     )
 
-    IgnoreMissing..void(
+    IgnoreMissing..unsigned_int(
         "LookupIntrinsicID",
         "Obtain the intrinsic ID number which matches the given function name.",
 


### PR DESCRIPTION
As the title suggests, this fixes the LLVMLookupIntrinsicID family of functions in the generated bindings to allow accessing things like `llvm.trap` and `llvm.debugtrap`.