### PR TITLE
fix(Nuklear): wrong autogenerated point count

### DIFF
--- a/doc/notes/3.3.4.md
+++ b/doc/notes/3.3.4.md
@@ -44,6 +44,7 @@ This build includes the following changes:
 - Core: Fixed callback wrapper memory leak with the CHM closure registry. (#927)
 - LLVM: Fixed `LLVMGetBufferStart` to return `ByteBuffer` instead of `String`. (#934)
 - LLVM: Fixed `LookupIntrinsicID` to return `unsigned` instead of `void`. (#950)
+- Nuklear: Fixed auto-sizing of `nk_stroke_polyline`, `nk_stroke_polygon`, `nk_fill_polygon` buffers. (#978)
 - tinyfd: The `aDefaultPath` parameter of `tinyfd_selectFolderDialog` is now nullable. (#922)
 
 #### Breaking Changes

--- a/modules/lwjgl/nuklear/src/generated/java/org/lwjgl/nuklear/Nuklear.java
+++ b/modules/lwjgl/nuklear/src/generated/java/org/lwjgl/nuklear/Nuklear.java
@@ -9003,7 +9003,7 @@ public class Nuklear {
     public static native void nnk_stroke_polyline(long b, long points, int point_count, float line_thickness, long col);
 
     public static void nk_stroke_polyline(@NativeType("struct nk_command_buffer *") NkCommandBuffer b, @NativeType("float *") FloatBuffer points, float line_thickness, @NativeType("struct nk_color") NkColor col) {
-        nnk_stroke_polyline(b.address(), memAddress(points), points.remaining(), line_thickness, col.address());
+        nnk_stroke_polyline(b.address(), memAddress(points), points.remaining() >> 1, line_thickness, col.address());
     }
 
     // --- [ nk_stroke_polygon ] ---
@@ -9011,7 +9011,7 @@ public class Nuklear {
     public static native void nnk_stroke_polygon(long b, long points, int point_count, float line_thickness, long color);
 
     public static void nk_stroke_polygon(@NativeType("struct nk_command_buffer *") NkCommandBuffer b, @NativeType("float *") FloatBuffer points, float line_thickness, @NativeType("struct nk_color") NkColor color) {
-        nnk_stroke_polygon(b.address(), memAddress(points), points.remaining(), line_thickness, color.address());
+        nnk_stroke_polygon(b.address(), memAddress(points), points.remaining() >> 1, line_thickness, color.address());
     }
 
     // --- [ nk_fill_rect ] ---
@@ -9059,7 +9059,7 @@ public class Nuklear {
     public static native void nnk_fill_polygon(long b, long points, int point_count, long color);
 
     public static void nk_fill_polygon(@NativeType("struct nk_command_buffer *") NkCommandBuffer b, @NativeType("float *") FloatBuffer points, @NativeType("struct nk_color") NkColor color) {
-        nnk_fill_polygon(b.address(), memAddress(points), points.remaining(), color.address());
+        nnk_fill_polygon(b.address(), memAddress(points), points.remaining() >> 1, color.address());
     }
 
     // --- [ nk_draw_image ] ---
@@ -10871,7 +10871,7 @@ public class Nuklear {
 
     /** Array version of: {@link #nk_stroke_polyline stroke_polyline} */
     public static void nk_stroke_polyline(@NativeType("struct nk_command_buffer *") NkCommandBuffer b, @NativeType("float *") float[] points, float line_thickness, @NativeType("struct nk_color") NkColor col) {
-        nnk_stroke_polyline(b.address(), points, points.length, line_thickness, col.address());
+        nnk_stroke_polyline(b.address(), points, points.length >> 1, line_thickness, col.address());
     }
 
     /** Array version of: {@link #nnk_stroke_polygon} */
@@ -10879,7 +10879,7 @@ public class Nuklear {
 
     /** Array version of: {@link #nk_stroke_polygon stroke_polygon} */
     public static void nk_stroke_polygon(@NativeType("struct nk_command_buffer *") NkCommandBuffer b, @NativeType("float *") float[] points, float line_thickness, @NativeType("struct nk_color") NkColor color) {
-        nnk_stroke_polygon(b.address(), points, points.length, line_thickness, color.address());
+        nnk_stroke_polygon(b.address(), points, points.length >> 1, line_thickness, color.address());
     }
 
     /** Array version of: {@link #nnk_fill_polygon} */
@@ -10887,7 +10887,7 @@ public class Nuklear {
 
     /** Array version of: {@link #nk_fill_polygon fill_polygon} */
     public static void nk_fill_polygon(@NativeType("struct nk_command_buffer *") NkCommandBuffer b, @NativeType("float *") float[] points, @NativeType("struct nk_color") NkColor color) {
-        nnk_fill_polygon(b.address(), points, points.length, color.address());
+        nnk_fill_polygon(b.address(), points, points.length >> 1, color.address());
     }
 
     /** Array version of: {@link #nnk_font_atlas_bake} */

--- a/modules/lwjgl/nuklear/src/templates/kotlin/nuklear/templates/nuklear.kt
+++ b/modules/lwjgl/nuklear/src/templates/kotlin/nuklear/templates/nuklear.kt
@@ -4410,7 +4410,7 @@ nk_style_pop_vec2(ctx);""")}
 
             cmd,
             float.p("points", ""),
-            AutoSize("points")..int("point_count", ""),
+            AutoSizeShr("1", "points")..int("point_count", ""),
             float("line_thickness", ""),
             nk_color("col", "")
         )
@@ -4421,7 +4421,7 @@ nk_style_pop_vec2(ctx);""")}
 
             cmd,
             float.p("points", ""),
-            AutoSize("points")..int("point_count", ""),
+            AutoSizeShr("1", "points")..int("point_count", ""),
             float("line_thickness", ""),
             nk_color("color", "")
         )
@@ -4490,7 +4490,7 @@ nk_style_pop_vec2(ctx);""")}
 
             cmd,
             float.p("points", ""),
-            AutoSize("points")..int("point_count", ""),
+            AutoSizeShr("1", "points")..int("point_count", ""),
             nk_color("color", "")
         )
 


### PR DESCRIPTION
The autogenerated point count for polygon operations is wrong (array size needs to be divided by two).
I checked that the following methods are affected:
* stroke_polyline
* stroke_polygon
* fill_polygon

Note that I didn't manage to build new JAR files, so I was not able to test the fix.

See below issue for screenshots.

Closes #978