### PR TITLE
fix(OpenGL) Added missing constant GL_BLEND_COLOR and GL_BLEND_EQUATION to GL14

### DIFF
--- a/modules/lwjgl/opengl/src/generated/java/org/lwjgl/opengl/GL14.java
+++ b/modules/lwjgl/opengl/src/generated/java/org/lwjgl/opengl/GL14.java
@@ -53,11 +53,17 @@ public class GL14 extends GL13 {
         GL_CONSTANT_ALPHA           = 0x8003,
         GL_ONE_MINUS_CONSTANT_ALPHA = 0x8004;
 
+    /** Accepted by the {@code pname} parameter of GetBooleanv, GetIntegerv, GetFloatv, and GetDoublev. */
+    public static final int GL_BLEND_COLOR = 0x8005;
+
     /** Accepted by the {@code mode} parameter of BlendEquation. */
     public static final int
         GL_FUNC_ADD = 0x8006,
         GL_MIN      = 0x8007,
         GL_MAX      = 0x8008;
+
+    /** Accepted by the {@code pname} parameter of GetBooleanv, GetIntegerv, GetFloatv, and GetDoublev. */
+    public static final int GL_BLEND_EQUATION = 0x8009;
 
     /** Accepted by the {@code mode} parameter of BlendEquation. */
     public static final int

--- a/modules/lwjgl/opengl/src/generated/java/org/lwjgl/opengl/GL14C.java
+++ b/modules/lwjgl/opengl/src/generated/java/org/lwjgl/opengl/GL14C.java
@@ -44,11 +44,17 @@ public class GL14C extends GL13C {
         GL_CONSTANT_ALPHA           = 0x8003,
         GL_ONE_MINUS_CONSTANT_ALPHA = 0x8004;
 
+    /** Accepted by the {@code pname} parameter of GetBooleanv, GetIntegerv, GetFloatv, and GetDoublev. */
+    public static final int GL_BLEND_COLOR = 0x8005;
+
     /** Accepted by the {@code mode} parameter of BlendEquation. */
     public static final int
         GL_FUNC_ADD = 0x8006,
         GL_MIN      = 0x8007,
         GL_MAX      = 0x8008;
+
+    /** Accepted by the {@code pname} parameter of GetBooleanv, GetIntegerv, GetFloatv, and GetDoublev. */
+    public static final int GL_BLEND_EQUATION = 0x8009;
 
     /** Accepted by the {@code mode} parameter of BlendEquation. */
     public static final int

--- a/modules/lwjgl/opengl/src/templates/kotlin/opengl/templates/GL14.kt
+++ b/modules/lwjgl/opengl/src/templates/kotlin/opengl/templates/GL14.kt
@@ -56,6 +56,12 @@ val GL14 = "GL14".nativeClassGL("GL14") {
         "ONE_MINUS_CONSTANT_ALPHA"..0x8004
     )
 
+    IntConstant(
+        "Accepted by the {@code pname} parameter of GetBooleanv, GetIntegerv, GetFloatv, and GetDoublev.",
+
+        "BLEND_COLOR"..0x8005
+    )
+
     reuse(GL14C, "BlendColor")
 
     // EXT_blend_minmax
@@ -66,6 +72,12 @@ val GL14 = "GL14".nativeClassGL("GL14") {
         "FUNC_ADD"..0x8006,
         "MIN"..0x8007,
         "MAX"..0x8008
+    )
+
+    IntConstant(
+        "Accepted by the {@code pname} parameter of GetBooleanv, GetIntegerv, GetFloatv, and GetDoublev.",
+
+        "BLEND_EQUATION"..0x8009
     )
 
     reuse(GL14C, "BlendEquation")

--- a/modules/lwjgl/opengl/src/templates/kotlin/opengl/templates/GL14Core.kt
+++ b/modules/lwjgl/opengl/src/templates/kotlin/opengl/templates/GL14Core.kt
@@ -39,6 +39,12 @@ val GL14C = "GL14C".nativeClassGL("GL14C") {
         "ONE_MINUS_CONSTANT_ALPHA"..0x8004
     )
 
+    IntConstant(
+        "Accepted by the {@code pname} parameter of GetBooleanv, GetIntegerv, GetFloatv, and GetDoublev.",
+
+        "BLEND_COLOR"..0x8005
+    )
+
     void(
         "BlendColor",
         "Specifies the constant color C<sub>c</sub> to be used in blending.",
@@ -57,6 +63,12 @@ val GL14C = "GL14C".nativeClassGL("GL14C") {
         "FUNC_ADD"..0x8006,
         "MIN"..0x8007,
         "MAX"..0x8008
+    )
+
+    IntConstant(
+        "Accepted by the {@code pname} parameter of GetBooleanv, GetIntegerv, GetFloatv, and GetDoublev.",
+
+        "BLEND_EQUATION"..0x8009
     )
 
     void(


### PR DESCRIPTION
https://registry.khronos.org/OpenGL/specs/gl/glspec14.pdf
https://registry.khronos.org/OpenGL/specs/gl/glspec13.pdf

From the specifications above we can see that these constants moved from being part of the arb imaging extensions to part of opengl. This can also be verified by generating headers using GLAD without extensions , for opengl 1.4 and finding these constants present in the headers.

To find these constants in the specifications consult the the state tables specifically the pixel operations table.