### PR TITLE
fix(bgfx) Change parameters for `is_frame_buffer_valid`

### DIFF
--- a/doc/notes/3.3.4.md
+++ b/doc/notes/3.3.4.md
@@ -61,6 +61,7 @@ This build includes the following changes:
 
 - Core: Fixed callback wrapper memory leak with the CHM closure registry. (#927)
 - Core: The `SharedLibraryLoader` will now always test if `System::load` works before choosing the extract path. (#987)
+- bgfx: Fixed `bgfx_is_frame_buffer_valid` to accept `BGFXAttachment.Buffer`. (#993)
 - JAWT: Fixed `JAWT_MACOSX_USE_CALAYER` value.
 - LLVM: Fixed `LLVMGetBufferStart` to return `ByteBuffer` instead of `String`. (#934)
 - LLVM: Fixed `LookupIntrinsicID` to return `unsigned` instead of `void`. (#950)

--- a/modules/lwjgl/bgfx/src/generated/java/org/lwjgl/bgfx/BGFX.java
+++ b/modules/lwjgl/bgfx/src/generated/java/org/lwjgl/bgfx/BGFX.java
@@ -2985,7 +2985,11 @@ public class BGFX {
 
     // --- [ bgfx_is_frame_buffer_valid ] ---
 
-    /** Unsafe version of: {@link #bgfx_is_frame_buffer_valid is_frame_buffer_valid} */
+    /**
+     * Unsafe version of: {@link #bgfx_is_frame_buffer_valid is_frame_buffer_valid}
+     *
+     * @param _num number of attachments
+     */
     public static boolean nbgfx_is_frame_buffer_valid(byte _num, long _attachment) {
         long __functionAddress = Functions.is_frame_buffer_valid;
         return invokeUPZ(_num, _attachment, __functionAddress);
@@ -2994,14 +2998,13 @@ public class BGFX {
     /**
      * Validate frame buffer parameters.
      *
-     * @param _num        number of attachments
      * @param _attachment attachment texture info
      *
      * @return true if a frame buffer with the same parameters can be created
      */
     @NativeType("bool")
-    public static boolean bgfx_is_frame_buffer_valid(@NativeType("uint8_t") int _num, @NativeType("bgfx_attachment_t const *") BGFXAttachment _attachment) {
-        return nbgfx_is_frame_buffer_valid((byte)_num, _attachment.address());
+    public static boolean bgfx_is_frame_buffer_valid(@NativeType("bgfx_attachment_t const *") BGFXAttachment.Buffer _attachment) {
+        return nbgfx_is_frame_buffer_valid((byte)_attachment.remaining(), _attachment.address());
     }
 
     // --- [ bgfx_calc_texture_size ] ---

--- a/modules/lwjgl/bgfx/src/templates/kotlin/bgfx/templates/BGFX.kt
+++ b/modules/lwjgl/bgfx/src/templates/kotlin/bgfx/templates/BGFX.kt
@@ -1544,7 +1544,7 @@ RGBA16S
         "is_frame_buffer_valid",
         "Validate frame buffer parameters.",
 
-        MapToInt..uint8_t("_num", "number of attachments"),
+        AutoSize("_attachment")..uint8_t("_num", "number of attachments"),
         bgfx_attachment_t.const.p("_attachment", "attachment texture info"),
 
         returnDoc = "true if a frame buffer with the same parameters can be created"


### PR DESCRIPTION
BGFX's method `bgfx::isFrameBufferValid` takes array size, and array reference of `Attachment`'s.
However in the bindings there is only single `BGFXAttachment` object, instead of `BGFXAttachment.Buffer` as it's done in the `bgfx_create_frame_buffer_from_attachment`.

I'm replaced `MapToInt` with `AutoSize`, now `is_frame_buffer_valid` has `BGFXAttachment.Buffer` and same buffer could be utilized both for validating attachments and creating framebuffer from attachments.