### PR TITLE
Add support for glyph index based msdfgen-ext APIs

### DIFF
--- a/doc/notes/3.3.5.md
+++ b/doc/notes/3.3.5.md
@@ -25,6 +25,8 @@ This build includes the following changes:
 
 #### Improvements
 
+- msdfgen: Added support for glyph index based msdfgen-ext APIs. (#1002)
+
 #### Fixes
 
 - Core: Fixed support for `va_list` parameters.

--- a/modules/lwjgl/msdfgen/src/generated/c/org_lwjgl_util_msdfgen_MSDFGenExt.c
+++ b/modules/lwjgl/msdfgen/src/generated/c/org_lwjgl_util_msdfgen_MSDFGenExt.c
@@ -55,6 +55,34 @@ JNIEXPORT jint JNICALL Java_org_lwjgl_util_msdfgen_MSDFGenExt_nmsdf_1ft_1font_1l
     return (jint)msdf_ft_font_load_glyph(font, (unsigned)cp, coordinateScaling, shape);
 }
 
+JNIEXPORT jint JNICALL Java_org_lwjgl_util_msdfgen_MSDFGenExt_nmsdf_1ft_1font_1load_1glyph_1by_1index(JNIEnv *__env, jclass clazz, jlong fontAddress, jint index, jint coordinateScaling, jlong shapeAddress) {
+    msdf_ft_font_handle font = (msdf_ft_font_handle)(uintptr_t)fontAddress;
+    msdf_shape_handle *shape = (msdf_shape_handle *)(uintptr_t)shapeAddress;
+    UNUSED_PARAMS(__env, clazz)
+    return (jint)msdf_ft_font_load_glyph_by_index(font, (unsigned)index, coordinateScaling, shape);
+}
+
+JNIEXPORT jint JNICALL Java_org_lwjgl_util_msdfgen_MSDFGenExt_nmsdf_1ft_1font_1get_1glyph_1index(JNIEnv *__env, jclass clazz, jlong fontAddress, jint cp, jlong indexAddress) {
+    msdf_ft_font_handle font = (msdf_ft_font_handle)(uintptr_t)fontAddress;
+    unsigned *index = (unsigned *)(uintptr_t)indexAddress;
+    UNUSED_PARAMS(__env, clazz)
+    return (jint)msdf_ft_font_get_glyph_index(font, (unsigned)cp, index);
+}
+
+JNIEXPORT jint JNICALL Java_org_lwjgl_util_msdfgen_MSDFGenExt_nmsdf_1ft_1font_1get_1kerning(JNIEnv *__env, jclass clazz, jlong fontAddress, jint cp1, jint cp2, jlong kerningAddress) {
+    msdf_ft_font_handle font = (msdf_ft_font_handle)(uintptr_t)fontAddress;
+    double *kerning = (double *)(uintptr_t)kerningAddress;
+    UNUSED_PARAMS(__env, clazz)
+    return (jint)msdf_ft_font_get_kerning(font, (unsigned)cp1, (unsigned)cp2, kerning);
+}
+
+JNIEXPORT jint JNICALL Java_org_lwjgl_util_msdfgen_MSDFGenExt_nmsdf_1ft_1font_1get_1kerning_1by_1index(JNIEnv *__env, jclass clazz, jlong fontAddress, jint index1, jint index2, jlong kerningAddress) {
+    msdf_ft_font_handle font = (msdf_ft_font_handle)(uintptr_t)fontAddress;
+    double *kerning = (double *)(uintptr_t)kerningAddress;
+    UNUSED_PARAMS(__env, clazz)
+    return (jint)msdf_ft_font_get_kerning_by_index(font, (unsigned)index1, (unsigned)index2, kerning);
+}
+
 JNIEXPORT void JNICALL Java_org_lwjgl_util_msdfgen_MSDFGenExt_nmsdf_1ft_1font_1destroy(JNIEnv *__env, jclass clazz, jlong fontAddress) {
     msdf_ft_font_handle font = (msdf_ft_font_handle)(uintptr_t)fontAddress;
     UNUSED_PARAMS(__env, clazz)

--- a/modules/lwjgl/msdfgen/src/generated/java/org/lwjgl/util/msdfgen/MSDFGenExt.java
+++ b/modules/lwjgl/msdfgen/src/generated/java/org/lwjgl/util/msdfgen/MSDFGenExt.java
@@ -212,6 +212,99 @@ public class MSDFGenExt {
         return nmsdf_ft_font_load_glyph(font, cp, coordinateScaling, memAddress(shape));
     }
 
+    // --- [ msdf_ft_font_load_glyph_by_index ] ---
+
+    /** Unsafe version of: {@link #msdf_ft_font_load_glyph_by_index ft_font_load_glyph_by_index} */
+    public static native int nmsdf_ft_font_load_glyph_by_index(long font, int index, int coordinateScaling, long shape);
+
+    /**
+     * Loads a single glyph from the given font and converts it into a vector shape for rendering glyph sprites.
+     *
+     * @param font              a handle to the font to use for generating the glyph shape
+     * @param index             the glyph index to generate a shape for
+     * @param coordinateScaling the coordinate scaling to use. One of:<br><table><tr><td>{@link #MSDF_FONT_SCALING_NONE FONT_SCALING_NONE}</td><td>{@link #MSDF_FONT_SCALING_EM_NORMALIZED FONT_SCALING_EM_NORMALIZED}</td><td>{@link #MSDF_FONT_SCALING_LEGACY FONT_SCALING_LEGACY}</td></tr></table>
+     * @param shape             a pointer to a handle to be populated with the address of the newly created shape.
+     *                          
+     *                          <p>This shape must later be freed using {@link MSDFGen#msdf_shape_free shape_free}!</p>
+     *
+     * @return {@link MSDFGen#MSDF_SUCCESS SUCCESS} on success, otherwise one of the constants prefixed with {@code MSDF_ERR_}.
+     */
+    public static int msdf_ft_font_load_glyph_by_index(@NativeType("msdf_ft_font_handle") long font, @NativeType("unsigned") int index, int coordinateScaling, @NativeType("msdf_shape_handle *") PointerBuffer shape) {
+        if (CHECKS) {
+            check(font);
+            check(shape, 1);
+        }
+        return nmsdf_ft_font_load_glyph_by_index(font, index, coordinateScaling, memAddress(shape));
+    }
+
+    // --- [ msdf_ft_font_get_glyph_index ] ---
+
+    /** Unsafe version of: {@link #msdf_ft_font_get_glyph_index ft_font_get_glyph_index} */
+    public static native int nmsdf_ft_font_get_glyph_index(long font, int cp, long index);
+
+    /**
+     * Retrieves the glyph index of the given unicode codepoint.
+     *
+     * @param font  a handle to the font to retrieve the glyph index from
+     * @param cp    the codepoint to retrieve the glyph index for
+     * @param index a pointer to the glyph index to be retrieved
+     *
+     * @return {@link MSDFGen#MSDF_SUCCESS SUCCESS} on success, otherwise one of the constants prefixed with {@code MSDF_ERR_}.
+     */
+    public static int msdf_ft_font_get_glyph_index(@NativeType("msdf_ft_font_handle") long font, @NativeType("unsigned") int cp, @NativeType("unsigned *") IntBuffer index) {
+        if (CHECKS) {
+            check(font);
+            check(index, 1);
+        }
+        return nmsdf_ft_font_get_glyph_index(font, cp, memAddress(index));
+    }
+
+    // --- [ msdf_ft_font_get_kerning ] ---
+
+    /** Unsafe version of: {@link #msdf_ft_font_get_kerning ft_font_get_kerning} */
+    public static native int nmsdf_ft_font_get_kerning(long font, int cp1, int cp2, long kerning);
+
+    /**
+     * Retrieves the kerning between the two given codepoints.
+     *
+     * @param font    a handle to the font to retrieve the kerning from
+     * @param cp1     the left codepoint
+     * @param cp2     the right codepoint
+     * @param kerning a pointer to the kerning value to be retrieved
+     *
+     * @return {@link MSDFGen#MSDF_SUCCESS SUCCESS} on success, otherwise one of the constants prefixed with {@code MSDF_ERR_}.
+     */
+    public static int msdf_ft_font_get_kerning(@NativeType("msdf_ft_font_handle") long font, @NativeType("unsigned") int cp1, @NativeType("unsigned") int cp2, @NativeType("double *") DoubleBuffer kerning) {
+        if (CHECKS) {
+            check(font);
+            check(kerning, 1);
+        }
+        return nmsdf_ft_font_get_kerning(font, cp1, cp2, memAddress(kerning));
+    }
+
+    // --- [ msdf_ft_font_get_kerning_by_index ] ---
+
+    /** Unsafe version of: {@link #msdf_ft_font_get_kerning_by_index ft_font_get_kerning_by_index} */
+    public static native int nmsdf_ft_font_get_kerning_by_index(long font, int index1, int index2, long kerning);
+
+    /**
+     * etrieves the kerning between the two given glyphs.
+     *
+     * @param font    a handle to the font to retrieve the kerning from
+     * @param index1  the glyph index of the left glyph
+     * @param index2  the glyph index of the right glyph
+     * @param kerning a pointer to the kerning value to be retrieved
+     *
+     * @return {@link MSDFGen#MSDF_SUCCESS SUCCESS} on success, otherwise one of the constants prefixed with {@code MSDF_ERR_}.
+     */
+    public static int msdf_ft_font_get_kerning_by_index(@NativeType("msdf_ft_font_handle") long font, @NativeType("unsigned") int index1, @NativeType("unsigned") int index2, @NativeType("double *") DoubleBuffer kerning) {
+        if (CHECKS) {
+            check(font);
+            check(kerning, 1);
+        }
+        return nmsdf_ft_font_get_kerning_by_index(font, index1, index2, memAddress(kerning));
+    }
+
     // --- [ msdf_ft_font_destroy ] ---
 
     /** Unsafe version of: {@link #msdf_ft_font_destroy ft_font_destroy} */

--- a/modules/lwjgl/msdfgen/src/main/c/msdfgen-ext-c.cpp
+++ b/modules/lwjgl/msdfgen/src/main/c/msdfgen-ext-c.cpp
@@ -71,13 +71,49 @@ MSDF_API int msdf_ft_load_font_data(msdf_ft_handle handle, const void* data, con
     return MSDF_SUCCESS;
 }
 
-MSDF_API int msdf_ft_font_load_glyph(msdf_ft_font_handle font, const unsigned cp, int coordinateScaling, msdf_shape_handle* shape) {
+MSDF_API int msdf_ft_font_load_glyph(msdf_ft_font_handle font, const unsigned cp, const int coordinateScaling, msdf_shape_handle* shape) {
     if(font == nullptr || shape == nullptr) {
         return MSDF_ERR_INVALID_ARG;
     }
     auto* actual_shape = new msdfgen::Shape();
     msdfgen::loadGlyph(*actual_shape, reinterpret_cast<msdfgen::FontHandle*>(font), cp, (msdfgen::FontCoordinateScaling)coordinateScaling);
     *shape = reinterpret_cast<msdf_shape_handle>(actual_shape);
+    return MSDF_SUCCESS;
+}
+
+MSDF_API int msdf_ft_font_load_glyph_by_index(msdf_ft_font_handle font, const unsigned index, const int coordinateScaling, msdf_shape_handle* shape) {
+    if(font == nullptr || shape == nullptr) {
+        return MSDF_ERR_INVALID_ARG;
+    }
+    auto* actual_shape = new msdfgen::Shape();
+    msdfgen::loadGlyph(*actual_shape, reinterpret_cast<msdfgen::FontHandle*>(font), msdfgen::GlyphIndex(index), (msdfgen::FontCoordinateScaling)coordinateScaling);
+    *shape = reinterpret_cast<msdf_shape_handle>(actual_shape);
+    return MSDF_SUCCESS;
+}
+
+MSDF_API int msdf_ft_font_get_glyph_index(msdf_ft_font_handle font, unsigned cp, unsigned* index) {
+    if(font == nullptr || index == nullptr) {
+        return MSDF_ERR_INVALID_ARG;
+    }
+    msdfgen::GlyphIndex glyph_index{};
+    msdfgen::getGlyphIndex(glyph_index, reinterpret_cast<msdfgen::FontHandle*>(font), cp);
+    *index = glyph_index.getIndex();
+    return MSDF_SUCCESS;
+}
+
+MSDF_API int msdf_ft_font_get_kerning_by_index(msdf_ft_font_handle font, unsigned index1, unsigned index2, double* kerning) {
+    if(font == nullptr || kerning == nullptr) {
+        return MSDF_ERR_INVALID_ARG;
+    }
+    msdfgen::getKerning(*kerning, reinterpret_cast<msdfgen::FontHandle*>(font), msdfgen::GlyphIndex(index1), msdfgen::GlyphIndex(index2));
+    return MSDF_SUCCESS;
+}
+
+MSDF_API int msdf_ft_font_get_kerning(msdf_ft_font_handle font, unsigned cp1, unsigned cp2, double* kerning) {
+    if(font == nullptr || kerning == nullptr) {
+        return MSDF_ERR_INVALID_ARG;
+    }
+    msdfgen::getKerning(*kerning, reinterpret_cast<msdfgen::FontHandle*>(font), cp1, cp2);
     return MSDF_SUCCESS;
 }
 

--- a/modules/lwjgl/msdfgen/src/main/c/msdfgen-ext-c.h
+++ b/modules/lwjgl/msdfgen/src/main/c/msdfgen-ext-c.h
@@ -85,13 +85,54 @@ MSDF_API int msdf_ft_load_font_data(msdf_ft_handle handle, const void* data, siz
 /**
  * Loads a single glyph from the given font and converts it into a vector shape
  * for rendering glyph sprites.
- * @param font A handle to the font to use for generating the glyph shape.
+ * @param font A handle to the font to load the glyph shape from.
  * @param cp The codepoint to generate a shape for.
+ * @param coordinateScaling The type of coordinate transform applied to the shape.
  * @param shape A pointer to a handle to be populated with the address of the newly created shape.
  *  This shape must later be freed using msdf_shape_free!
  * @returns @code MSDF_SUCCESS@endcode on success, otherwise one of the constants prefixed with @code MSDF_ERR_@endcode.
  */
 MSDF_API int msdf_ft_font_load_glyph(msdf_ft_font_handle font, unsigned cp, int coordinateScaling, msdf_shape_handle* shape);
+
+/**
+ * Loads a single glyph from the given font and converts it into a vector shape
+ * for rendering glyph sprites.
+ * @param font A handle to the font to load the glyph shape from.
+ * @param index The glyph index to generate a shape for.
+ * @param coordinateScaling The type of coordinate transform applied to the shape.
+ * @param shape A pointer to a handle to be populated with the address of the newly created shape.
+ *  This shape must later be freed using msdf_shape_free!
+ * @returns @code MSDF_SUCCESS@endcode on success, otherwise one of the constants prefixed with @code MSDF_ERR_@endcode.
+ */
+MSDF_API int msdf_ft_font_load_glyph_by_index(msdf_ft_font_handle font, unsigned index, int coordinateScaling, msdf_shape_handle* shape);
+
+/**
+ * Retrieves the glyph index of the given unicode codepoint.
+ * @param font A handle to the font to retrieve the glyph index from.
+ * @param cp The codepoint to retrieve the glyph index for.
+ * @param index A pointer to the glyph index to be retrieved.
+ * @returns @code MSDF_SUCCESS@endcode on success, otherwise one of the constants prefixed with @code MSDF_ERR_@endcode.
+ */
+MSDF_API int msdf_ft_font_get_glyph_index(msdf_ft_font_handle font, unsigned cp, unsigned* index);
+
+/**
+ * Retrieves the kerning between the two given glyphs.
+ * @param font A handle to the font to retrieve the kerning from.
+ * @param index1 The glyph index of the left glyph.
+ * @param index2 The glyph index of the right glyph.
+ * @param kerning A pointer to the kerning value to be retrieved.
+ * @returns @code MSDF_SUCCESS@endcode on success, otherwise one of the constants prefixed with @code MSDF_ERR_@endcode.
+ */
+MSDF_API int msdf_ft_font_get_kerning_by_index(msdf_ft_font_handle font, unsigned index1, unsigned index2, double* kerning);
+
+/**
+ * Retrieves the kerning between the two given codepoints.
+ * @param font A handle to the font to retrieve the kerning from.
+ * @param cp1 The left codepoint.
+ * @param cp2 The right codepoint.
+ * @param kerning A pointer to the kerning value to be retrieved.
+ */
+MSDF_API int msdf_ft_font_get_kerning(msdf_ft_font_handle font, unsigned cp1, unsigned cp2, double* kerning);
 
 /**
  * Frees the underlying instance of the given FreeType font.

--- a/modules/lwjgl/msdfgen/src/templates/kotlin/msdfgen/templates/msdfgen_ext.kt
+++ b/modules/lwjgl/msdfgen/src/templates/kotlin/msdfgen/templates/msdfgen_ext.kt
@@ -105,6 +105,60 @@ val msdfGenExt = "MSDFGenExt".nativeClass(Module.MSDFGEN, prefix = "MSDF", prefi
         returnDoc = returnDoc
     )
 
+    int(
+        "ft_font_load_glyph_by_index",
+        "Loads a single glyph from the given font and converts it into a vector shape for rendering glyph sprites.",
+
+        msdf_ft_font_handle("font", "a handle to the font to use for generating the glyph shape"),
+        unsigned("index", "the glyph index to generate a shape for"),
+        int("coordinateScaling", "the coordinate scaling to use", "FONT_SCALING_\\w+"),
+        Check(1)..msdf_shape_handle.p(
+            "shape",
+            """
+            a pointer to a handle to be populated with the address of the newly created shape.
+            
+            This shape must later be freed using #shape_free()!
+            """
+        ),
+
+        returnDoc = returnDoc
+    )
+
+    int(
+        "ft_font_get_glyph_index",
+        "Retrieves the glyph index of the given unicode codepoint.",
+
+        msdf_ft_font_handle("font", "a handle to the font to retrieve the glyph index from"),
+        unsigned("cp", "the codepoint to retrieve the glyph index for"),
+        Check(1)..unsigned.p("index", "a pointer to the glyph index to be retrieved"),
+
+        returnDoc = returnDoc
+    )
+
+    int(
+        "ft_font_get_kerning",
+        "Retrieves the kerning between the two given codepoints.",
+
+        msdf_ft_font_handle("font", "a handle to the font to retrieve the kerning from"),
+        unsigned("cp1", "the left codepoint"),
+        unsigned("cp2", "the right codepoint"),
+        Check(1)..double.p("kerning", "a pointer to the kerning value to be retrieved"),
+
+        returnDoc = returnDoc
+    )
+
+    int(
+        "ft_font_get_kerning_by_index",
+        "etrieves the kerning between the two given glyphs.",
+
+        msdf_ft_font_handle("font", "a handle to the font to retrieve the kerning from"),
+        unsigned("index1", "the glyph index of the left glyph"),
+        unsigned("index2", "the glyph index of the right glyph"),
+        Check(1)..double.p("kerning", "a pointer to the kerning value to be retrieved"),
+
+        returnDoc = returnDoc
+    )
+
     void(
         "ft_font_destroy",
         "Frees the underlying instance of the given FreeType font.",


### PR DESCRIPTION
This PR adds support for the following msdfgen-ext functions:
- `msdfgen::loadGlyph(msdfgen::Shape, msdfgen::FontHandle, msdfgen::GlyphIndex, int)` for loading glyphs by their glyph ID directly instead of their codepoint
- `msdfgen::getGlyphIndex(msdfgen::FontHandle, unsigned)` for retrieving the glyph index of a given codepoint
- `msdfgen::getKerning(double&, msdfgen::FontHandle, unsigned, unsigned)` for retrieving the kerning between the two given unicode codepoints
- `msdfgen::getKerning(double&, msdfgen::FontHandle, msdfgen::GlyphIndex, msdfgen::GlyphIndex)` for retrieving the kerning between the two given glyphs referenced by their indices

This allows using this library in conjunction with other libraries like harfbuzz.