### PR TITLE
feat(core) EspressoVM compatibility

### DIFF
--- a/modules/lwjgl/core/src/main/java/org/lwjgl/system/ThreadLocalUtil.java
+++ b/modules/lwjgl/core/src/main/java/org/lwjgl/system/ThreadLocalUtil.java
@@ -186,7 +186,13 @@ public final class ThreadLocalUtil {
     public static void setFunctionMissingAddresses(int functionCount) {
         long ptr = JNI_NATIVE_INTERFACE + CAPABILITIES_OFFSET;
 
+        // aka. reserved3
+        //
+        // OpenJDK: NULL
+        // EspressoVM: NULL
+        // GraalVM Native Image: pointer to UnimplementedWithJNIEnvArgument function (see #875)
         long currentTable = memGetAddress(ptr);
+
         if (functionCount == 0) {
             if (currentTable != FUNCTION_MISSING_ABORT) {
                 FUNCTION_MISSING_ABORT_TABLE = NULL;
@@ -195,7 +201,7 @@ public final class ThreadLocalUtil {
             }
         } else {
             // OpenJDK: NULL
-            // EspressoVM: NULL
+            // EspressoVM: pointer to VM internal
             // GraalVM Native Image: pointer to UnimplementedWithJNIEnvArgument function (see #875)
             long RESERVED0_NULL = memGetAddress(JNI_NATIVE_INTERFACE);
 

--- a/modules/lwjgl/core/src/main/java/org/lwjgl/system/ThreadLocalUtil.java
+++ b/modules/lwjgl/core/src/main/java/org/lwjgl/system/ThreadLocalUtil.java
@@ -210,7 +210,7 @@ public final class ThreadLocalUtil {
             // GraalVM Native Image: pointer to UnimplementedWithJNIEnvArgument function (see #875)
             long RESERVED0_NULL = memGetAddress(JNI_NATIVE_INTERFACE);
 
-            boolean slotAvailable = currentTable == RESERVED3_NULL; // on HotSpot or Espresso
+            boolean slotAvailable = currentTable == NULL; // on HotSpot or Espresso
             slotAvailable |= currentTable == RESERVED0_NULL; // on Native Image
 
             if (!slotAvailable) {

--- a/modules/lwjgl/core/src/main/java/org/lwjgl/system/ThreadLocalUtil.java
+++ b/modules/lwjgl/core/src/main/java/org/lwjgl/system/ThreadLocalUtil.java
@@ -188,7 +188,7 @@ public final class ThreadLocalUtil {
 
         long currentTable = memGetAddress(ptr);
         if (functionCount == 0) {
-            if (currentTable != RESERVED3_NULL) {
+            if (currentTable != FUNCTION_MISSING_ABORT) {
                 FUNCTION_MISSING_ABORT_TABLE = NULL;
                 getAllocator().free(currentTable);
                 memPutAddress(ptr, NULL);

--- a/modules/lwjgl/core/src/main/java/org/lwjgl/system/ThreadLocalUtil.java
+++ b/modules/lwjgl/core/src/main/java/org/lwjgl/system/ThreadLocalUtil.java
@@ -93,11 +93,6 @@ public final class ThreadLocalUtil {
     /** The offset in JNIEnv at which to store the pointer to the capabilities array. */
     private static final int CAPABILITIES_OFFSET = 3 * POINTER_SIZE;
 
-    // OpenJDK: NULL
-    // EspressoVM: NULL
-    // GraalVM Native Image: pointer to UnimplementedWithJNIEnvArgument function (see #875)
-    private static long RESERVED3_NULL = memGetAddress(JNI_NATIVE_INTERFACE + CAPABILITIES_OFFSET);
-
     /** The number of pointers in the JNIEnv struct. */
     private static final int JNI_NATIVE_INTERFACE_FUNCTION_COUNT;
 
@@ -199,7 +194,15 @@ public final class ThreadLocalUtil {
                 memPutAddress(ptr, NULL);
             }
         } else {
-            if (currentTable != RESERVED3_NULL) {
+            // OpenJDK: NULL
+            // EspressoVM: NULL
+            // GraalVM Native Image: pointer to UnimplementedWithJNIEnvArgument function (see #875)
+            long RESERVED0_NULL = memGetAddress(JNI_NATIVE_INTERFACE);
+
+            boolean slotAvailable = currentTable == NULL; // on HotSpot or Espresso
+            slotAvailable |= currentTable == RESERVED0_NULL; // on Native Image
+
+            if (!slotAvailable) {
                 throw new IllegalStateException("setFunctionMissingAddresses has been called already");
             }
             if (currentTable != NULL) {

--- a/modules/lwjgl/core/src/main/java/org/lwjgl/system/ThreadLocalUtil.java
+++ b/modules/lwjgl/core/src/main/java/org/lwjgl/system/ThreadLocalUtil.java
@@ -90,9 +90,6 @@ public final class ThreadLocalUtil {
     /** The global JNIEnv. */
     private static final long JNI_NATIVE_INTERFACE = memGetAddress(getThreadJNIEnv());
 
-    /** The offset in JNIEnv at which to store the pointer to the capabilities array. */
-    private static final int CAPABILITIES_OFFSET = 3 * POINTER_SIZE;
-
     /** The number of pointers in the JNIEnv struct. */
     private static final int JNI_NATIVE_INTERFACE_FUNCTION_COUNT;
 
@@ -105,6 +102,9 @@ public final class ThreadLocalUtil {
      * <p>The array size depends on whether OpenGL or OpenGL ES is used.</p>
      */
     private static long FUNCTION_MISSING_ABORT_TABLE = NULL;
+
+    /** The offset in JNIEnv at which to store the pointer to the capabilities array. */
+    private static final int CAPABILITIES_OFFSET = 3 * POINTER_SIZE;
 
     static {
         int JNI_VERSION = GetVersion();

--- a/modules/lwjgl/core/src/main/java/org/lwjgl/system/ThreadLocalUtil.java
+++ b/modules/lwjgl/core/src/main/java/org/lwjgl/system/ThreadLocalUtil.java
@@ -199,7 +199,7 @@ public final class ThreadLocalUtil {
         long currentTable = memGetAddress(ptr);
 
         if (functionCount == 0) {
-            if (currentTable != FUNCTION_MISSING_ABORT) {
+            if (currentTable == FUNCTION_MISSING_ABORT) {
                 FUNCTION_MISSING_ABORT_TABLE = NULL;
                 getAllocator().free(currentTable);
                 memPutAddress(ptr, RESERVED3_NULL);


### PR DESCRIPTION
`reserved0` is used by EspressoVM, thus it cannot serve as a "reference NULL" as on HotSpot: https://github.com/oracle/graal/blob/3149f62458029ffe92b8dcefe0b3e59612684cfa/espresso/src/com.oracle.truffle.espresso.mokapot/include/mokapot.h#L67-L73

The relevant config is `MOKA_LATTE`. `reserved3` is `NULL` though.


-----

EspressoVM aka. Java on Truffle: https://www.graalvm.org/latest/reference-manual/java-on-truffle/

I tested the fix with Espresso, but I'm not 100% sure about the implications for other implementations.  So please understand this PR more like a bug report 🙂  In general, I saw that in https://github.com/LWJGL/lwjgl3/issues/875#issuecomment-1501178071 it is mentioned that you want to get rid of (ab)using `reserved3`, so I think that's the better fix going forward.