### PR TITLE
fix(extract): run Swing code on the correct event dispatcher thread

### DIFF
--- a/modules/extract/src/main/kotlin/org/lwjgl/extract/Main.kt
+++ b/modules/extract/src/main/kotlin/org/lwjgl/extract/Main.kt
@@ -21,8 +21,6 @@ import javax.swing.event.*
 import javax.swing.plaf.basic.*
 
 fun main() {
-    UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName())
-
     System.setProperty("line.separator", "\n")
 
     if (Configuration.LLVM_CLANG_LIBRARY_NAME.get() == null) {
@@ -34,8 +32,12 @@ fun main() {
         }
     }
 
-    val app = Application()
-    app.frame.isVisible = true
+    SwingUtilities.invokeLater {
+        UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName())
+
+        val app = Application()
+        app.frame.isVisible = true
+    }
 }
 
 private fun checkModal() = Window.getWindows().none { it is Dialog && it.isModal && it.isVisible }


### PR DESCRIPTION
Swing requires running all setup and widget interaction code on the [AWT dispatcher thread](https://docs.oracle.com/javase/tutorial/uiswing/concurrency/dispatch.html), so in this PR I moved the app initialization over to that thread.

I've had some random native crashes when running the extractor locally, this fix might or might not have fixed them (they're too unpredictable to be sure), but the hs_err stacktraces looked to come from a variety of native AWT code failing to read standard java data structures which could be due to some state corruption due to a data race between threads.