### PR TITLE
Update tinyfiledialogs to v3.19.1

### DIFF
--- a/doc/notes/3.4.0.md
+++ b/doc/notes/3.4.0.md
@@ -9,6 +9,7 @@ This build includes the following changes:
 - Added [SDL 3](https://libsdl.org/) bindings.
 - OpenAL Soft: Updated to 1.24.2 (up from 1.24.1)
   * Added `AL_SOFT_bformat_hoa` extension.
+- tinyfiledialogs: Updated to 3.19.1 (up from 3.18.1)
 - Vulkan: Updated to 1.4.305 (up from 1.4.304)
 
 LWJGL bindings no longer include API documentation in javadoc form. What remains: 

--- a/modules/lwjgl/tinyfd/src/generated/java/org/lwjgl/util/tinyfd/TinyFileDialogs.java
+++ b/modules/lwjgl/tinyfd/src/generated/java/org/lwjgl/util/tinyfd/TinyFileDialogs.java
@@ -27,15 +27,14 @@ public class TinyFileDialogs {
     }
 
     public static final String
-        tinyfd_version              = "tinyfd_version",
-        tinyfd_needs                = "tinyfd_needs",
-        tinyfd_response             = "tinyfd_response",
-        tinyfd_verbose              = "tinyfd_verbose",
-        tinyfd_silent               = "tinyfd_silent",
-        tinyfd_allowCursesDialogs   = "tinyfd_allowCursesDialogs",
-        tinyfd_forceConsole         = "tinyfd_forceConsole",
-        tinyfd_assumeGraphicDisplay = "tinyfd_assumeGraphicDisplay",
-        tinyfd_winUtf8              = "tinyfd_winUtf8";
+        tinyfd_version            = "tinyfd_version",
+        tinyfd_needs              = "tinyfd_needs",
+        tinyfd_response           = "tinyfd_response",
+        tinyfd_verbose            = "tinyfd_verbose",
+        tinyfd_silent             = "tinyfd_silent",
+        tinyfd_allowCursesDialogs = "tinyfd_allowCursesDialogs",
+        tinyfd_forceConsole       = "tinyfd_forceConsole",
+        tinyfd_winUtf8            = "tinyfd_winUtf8";
 
     protected TinyFileDialogs() {
         throw new UnsupportedOperationException();

--- a/modules/lwjgl/tinyfd/src/main/c/tinyfiledialogs.h
+++ b/modules/lwjgl/tinyfd/src/main/c/tinyfiledialogs.h
@@ -7,7 +7,7 @@ Copyright (c) 2014 - 2024 Guillaume Vareille http://ysengrin.com
 
 ********* TINY FILE DIALOGS OFFICIAL WEBSITE IS ON SOURCEFORGE *********
   _________
- /         \ tinyfiledialogs.h v3.18.1 [May 2, 2024]
+ /         \ tinyfiledialogs.h v3.19.1 [Jan 27, 2025]
  |tiny file| Unique header file created [November 9, 2014]
  | dialogs |
  \____  ___/ http://tinyfiledialogs.sourceforge.net
@@ -112,7 +112,7 @@ extern int tinyfd_forceConsole;  /* 0 (default) or 1 */
    if enabled, it can use the package Dialog or dialog.exe.
    on windows it only make sense for console applications */
 
-extern int tinyfd_assumeGraphicDisplay; /* 0 (default) or 1  */
+/* extern int tinyfd_assumeGraphicDisplay; */ /* 0 (default) or 1  */
 /* some systems don't set the environment variable DISPLAY even when a graphic display is present.
 set this to 1 to tell tinyfiledialogs to assume the existence of a graphic display */
 

--- a/modules/lwjgl/tinyfd/src/templates/kotlin/tinyfd/templates/tinyfiledialogs.kt
+++ b/modules/lwjgl/tinyfd/src/templates/kotlin/tinyfd/templates/tinyfiledialogs.kt
@@ -17,7 +17,6 @@ val tinyfiledialogs = "TinyFileDialogs".nativeClass(Module.TINYFD, prefix = "tin
         "silent".."tinyfd_silent",
         "allowCursesDialogs".."tinyfd_allowCursesDialogs",
         "forceConsole".."tinyfd_forceConsole",
-        "assumeGraphicDisplay".."tinyfd_assumeGraphicDisplay",
         "winUtf8".."tinyfd_winUtf8"
     )
 


### PR DESCRIPTION
This version fixes a bug, that when running on Linux under Wayland but with XWayland disabled, tinyfiledialog thinks it not running in a graphical session.