### PR TITLE
fix(demo): add GL_SRGB8 to swapchain formats of HelloOpenXRGL

### DIFF
--- a/modules/samples/src/test/java/org/lwjgl/demo/openxr/HelloOpenXRGL.java
+++ b/modules/samples/src/test/java/org/lwjgl/demo/openxr/HelloOpenXRGL.java
@@ -436,6 +436,7 @@ public class HelloOpenXRGL {
 
                 long[] desiredSwapchainFormats = {
                     GL_RGB10_A2,
+                    GL_SRGB8,
                     GL_RGBA16F,
                     // The two below should only be used as a fallback, as they are linear color formats without enough bits for color
                     // depth, thus leading to banding.


### PR DESCRIPTION
According to https://github.com/LWJGL/lwjgl3/issues/1031, this GL format is one of the few OpenXR swapchain formats supported by SteamVR, so it is good to add it to the desired swapchain formats.