### PR TITLE
fix(opencl) prevent sign extension in CL.createPlatformCapabilities

### DIFF
--- a/modules/lwjgl/opencl/src/main/java/org/lwjgl/opencl/CL.java
+++ b/modules/lwjgl/opencl/src/main/java/org/lwjgl/opencl/CL.java
@@ -247,12 +247,12 @@ public final class CL {
         try (MemoryStack stack = stackPush()) {
             IntBuffer pi = stack.mallocInt(1);
 
-            checkCLError(nclGetDeviceIDs(cl_platform_id, CL_DEVICE_TYPE_ALL, 0, NULL, memAddress(pi)));
+            checkCLError(nclGetDeviceIDs(cl_platform_id, CL_DEVICE_TYPE_ALL & 0xFFFF_FFFFl, 0, NULL, memAddress(pi)));
             int num_devices = pi.get(0);
             if (num_devices != 0) {
                 PointerBuffer pp = stack.mallocPointer(num_devices);
 
-                checkCLError(nclGetDeviceIDs(cl_platform_id, CL_DEVICE_TYPE_ALL, num_devices, memAddress(pp), NULL));
+                checkCLError(nclGetDeviceIDs(cl_platform_id, CL_DEVICE_TYPE_ALL & 0xFFFF_FFFFl, num_devices, memAddress(pp), NULL));
 
                 // Add device extensions to the set
                 for (int i = 0; i < num_devices; i++) {


### PR DESCRIPTION
The specification for [clGetDeviceIDs](https://registry.khronos.org/OpenCL/specs/3.0-unified/html/OpenCL_API.html#platform-querying-devices) allows the implementation to error on any value not explicitly listed. `CL_DEVICE_TYPE_ALL` is defined as the integer `0xFFFF_FFFF = -1`. When directly passed to `nclGetDeviceIDs`, the sign is extended to `0xFFFF_FFFF_FFFF_FFFFl = -1l`. As the specification only requires the implementation to accept `0xFFFF_FFFFl`, this may lead to `nclGetDeviceIDs` failing and returning `CL_INVALID_DEVICE_TYPE`.

I encountered this bug using the opencl-mesa drivers on arch linux. This fix only enables `createPlatformCapabilities` to return successfully. The problem still occurs anytime `CL_DEVICE_TYPE_ALL` is passed to `(n)clGetDeviceIDs`. This can be prevented by the user using the same method as this fix to prevent sign extension. As this isn't ideal, the types of `CL_DEVICE_TYPE_*` should probably be changed to long in a release where breaking backwards compatibility is acceptable if possible.

An other option would be to trim the upper 32 bits of the long passed to `(n)clGetDeviceIDs` to undo the sign extension retroactively, to fix this problem without breaking compatibility. I briefly tried implementing this approach, but was unsure how to approach it, as the java code blocks won't apply to `nclGetDeviceIDs` while `nativeBeforeCall` creates JNI code and needs to load a library.