### PR TITLE
build(core) fix undefined reference while linking

### DIFF
--- a/modules/lwjgl/core/src/generated/c/org_lwjgl_system_libc_LibCStdlib.c
+++ b/modules/lwjgl/core/src/generated/c/org_lwjgl_system_libc_LibCStdlib.c
@@ -12,7 +12,7 @@
     #if defined(__USE_ISOC11)
         #define __aligned_alloc aligned_alloc
     #else
-        inline void* __aligned_alloc(size_t alignment, size_t size) {
+        static inline void* __aligned_alloc(size_t alignment, size_t size) {
             void *p;
             return posix_memalign(&p, alignment, size) ? NULL : p;
         }

--- a/modules/lwjgl/core/src/main/c/common_tools.c
+++ b/modules/lwjgl/core/src/main/c/common_tools.c
@@ -116,7 +116,7 @@ static inline void linkEnvData(EnvData* data, JNIEnv *env) {
         return data;
     }
 
-    inline EnvData* tlsGetEnvData(void) {
+    static inline EnvData* tlsGetEnvData(void) {
         EnvData* data = (EnvData*)TlsGetValue(envTLS);
         if (data == NULL) {
             data = tlsCreateEnvData();
@@ -181,7 +181,7 @@ static inline void linkEnvData(EnvData* data, JNIEnv *env) {
         return data;
     }
 
-    inline EnvData* tlsGetEnvData(void) {
+    static inline EnvData* tlsGetEnvData(void) {
         EnvData* data = (EnvData*)pthread_getspecific(envTLS);
         if (data == NULL) {
             data = tlsCreateEnvData();
@@ -190,7 +190,7 @@ static inline void linkEnvData(EnvData* data, JNIEnv *env) {
     }
 #endif
 
-inline JNIEnv* getEnv(jboolean *async) {
+JNIEnv* getEnv(jboolean *async) {
     EnvData* data = tlsGetEnvData();
     *async = data->async;
     return data->env;

--- a/modules/lwjgl/core/src/templates/kotlin/core/libc/templates/stdlib.kt
+++ b/modules/lwjgl/core/src/templates/kotlin/core/libc/templates/stdlib.kt
@@ -19,7 +19,7 @@ val stdlib = "LibCStdlib".nativeClass(Module.CORE_LIBC) {
     #if defined(__USE_ISOC11)
         #define __aligned_alloc aligned_alloc
     #else
-        inline void* __aligned_alloc(size_t alignment, size_t size) {
+        static inline void* __aligned_alloc(size_t alignment, size_t size) {
             void *p;
             return posix_memalign(&p, alignment, size) ? NULL : p;
         }


### PR DESCRIPTION
The error might be specific to some recent toolchain version

```
[Linker] /usr/lib/gcc/x86_64-alpine-linux-musl/15.2.0/../../../../x86_64-alpine-linux-musl/bin/ld: /tmp/ccPKemNA.ltrans3.ltrans.o: in function `Java_org_lwjgl_system_libc_LibCStdlib_naligned_1alloc':
[Linker] <artificial>:(.text+0x50b6): undefined reference to `__aligned_alloc'
[Linker] collect2: error: ld returned 1 exit status
```