### PR TITLE
Reduce the overhead of MethodHandle composition

### DIFF
--- a/modules/lwjgl/core25/src/main/java/org/lwjgl/system/MemoryUtil.java
+++ b/modules/lwjgl/core25/src/main/java/org/lwjgl/system/MemoryUtil.java
@@ -2342,25 +2342,21 @@ public final class MemoryUtil {
         try {
             var lookup = MethodHandles.lookup();
 
-            var ofAddress = lookup
-                .findStatic(MemorySegment.class, "ofAddress", MethodType.methodType(MemorySegment.class, long.class));
+            var memorySegmentFull = MemorySegment.NULL.reinterpret(Long.MAX_VALUE);
 
-            var reinterpret = lookup
-                .findVirtual(MemorySegment.class, "reinterpret", MethodType.methodType(MemorySegment.class, long.class));
-
-            VH_JAVA_BYTE = createMemoryAccessVH(ValueLayout.JAVA_BYTE, ofAddress, reinterpret)
+            VH_JAVA_BYTE = createMemoryAccessVH(ValueLayout.JAVA_BYTE, memorySegmentFull)
                 .withInvokeExactBehavior();
 
-            VH_JAVA_SHORT_UNALIGNED = createMemoryAccessVH(ValueLayout.JAVA_SHORT_UNALIGNED, ofAddress, reinterpret).withInvokeExactBehavior();
-            VH_JAVA_INT_UNALIGNED = createMemoryAccessVH(ValueLayout.JAVA_INT_UNALIGNED, ofAddress, reinterpret).withInvokeExactBehavior();
-            VH_JAVA_LONG_UNALIGNED = createMemoryAccessVH(ValueLayout.JAVA_LONG_UNALIGNED, ofAddress, reinterpret).withInvokeExactBehavior();
-            VH_JAVA_FLOAT_UNALIGNED = createMemoryAccessVH(ValueLayout.JAVA_FLOAT_UNALIGNED, ofAddress, reinterpret).withInvokeExactBehavior();
-            VH_JAVA_DOUBLE_UNALIGNED = createMemoryAccessVH(ValueLayout.JAVA_DOUBLE_UNALIGNED, ofAddress, reinterpret).withInvokeExactBehavior();
+            VH_JAVA_SHORT_UNALIGNED = createMemoryAccessVH(ValueLayout.JAVA_SHORT_UNALIGNED, memorySegmentFull).withInvokeExactBehavior();
+            VH_JAVA_INT_UNALIGNED = createMemoryAccessVH(ValueLayout.JAVA_INT_UNALIGNED, memorySegmentFull).withInvokeExactBehavior();
+            VH_JAVA_LONG_UNALIGNED = createMemoryAccessVH(ValueLayout.JAVA_LONG_UNALIGNED, memorySegmentFull).withInvokeExactBehavior();
+            VH_JAVA_FLOAT_UNALIGNED = createMemoryAccessVH(ValueLayout.JAVA_FLOAT_UNALIGNED, memorySegmentFull).withInvokeExactBehavior();
+            VH_JAVA_DOUBLE_UNALIGNED = createMemoryAccessVH(ValueLayout.JAVA_DOUBLE_UNALIGNED, memorySegmentFull).withInvokeExactBehavior();
 
             var vh = createMemoryAccessVH(
                 CLONG_SIZE == 8
                     ? (ValueLayout.JAVA_LONG_UNALIGNED)
-                    : (ValueLayout.JAVA_INT_UNALIGNED), ofAddress, reinterpret);
+                    : (ValueLayout.JAVA_INT_UNALIGNED), memorySegmentFull);
 
             if (CLONG_SIZE == 4) {
                 vh = MethodHandles.filterValue(vh,
@@ -2379,7 +2375,7 @@ public final class MemoryUtil {
 
             vh = createMemoryAccessVH(BITS64
                 ? (ValueLayout.JAVA_LONG_UNALIGNED)
-                : (ValueLayout.JAVA_INT_UNALIGNED), ofAddress, reinterpret);
+                : (ValueLayout.JAVA_INT_UNALIGNED), memorySegmentFull);
 
             if (BITS32) {
                 vh = MethodHandles.filterValue(vh,
@@ -2397,16 +2393,16 @@ public final class MemoryUtil {
             VH_ADDRESS_UNALIGNED = vh.withInvokeExactBehavior();
 
             if (DEBUG) {
-                VH_JAVA_SHORT = createMemoryAccessVH(ValueLayout.JAVA_SHORT, ofAddress, reinterpret).withInvokeExactBehavior();
-                VH_JAVA_INT = createMemoryAccessVH(ValueLayout.JAVA_INT, ofAddress, reinterpret).withInvokeExactBehavior();
-                VH_JAVA_LONG = createMemoryAccessVH(ValueLayout.JAVA_LONG, ofAddress, reinterpret).withInvokeExactBehavior();
-                VH_JAVA_FLOAT = createMemoryAccessVH(ValueLayout.JAVA_FLOAT, ofAddress, reinterpret).withInvokeExactBehavior();
-                VH_JAVA_DOUBLE = createMemoryAccessVH(ValueLayout.JAVA_DOUBLE, ofAddress, reinterpret).withInvokeExactBehavior();
+                VH_JAVA_SHORT = createMemoryAccessVH(ValueLayout.JAVA_SHORT, memorySegmentFull).withInvokeExactBehavior();
+                VH_JAVA_INT = createMemoryAccessVH(ValueLayout.JAVA_INT, memorySegmentFull).withInvokeExactBehavior();
+                VH_JAVA_LONG = createMemoryAccessVH(ValueLayout.JAVA_LONG, memorySegmentFull).withInvokeExactBehavior();
+                VH_JAVA_FLOAT = createMemoryAccessVH(ValueLayout.JAVA_FLOAT, memorySegmentFull).withInvokeExactBehavior();
+                VH_JAVA_DOUBLE = createMemoryAccessVH(ValueLayout.JAVA_DOUBLE, memorySegmentFull).withInvokeExactBehavior();
 
                 vh = createMemoryAccessVH(
                     CLONG_SIZE == 8
                         ? ValueLayout.JAVA_LONG
-                        : ValueLayout.JAVA_INT, ofAddress, reinterpret);
+                        : ValueLayout.JAVA_INT, memorySegmentFull);
 
                 if (CLONG_SIZE == 4) {
                     vh = MethodHandles.filterValue(vh,
@@ -2425,7 +2421,7 @@ public final class MemoryUtil {
 
                 vh = createMemoryAccessVH(BITS64
                     ? ValueLayout.JAVA_LONG
-                    : ValueLayout.JAVA_INT, ofAddress, reinterpret);
+                    : ValueLayout.JAVA_INT, memorySegmentFull);
 
                 if (BITS32) {
                     vh = MethodHandles.filterValue(vh,
@@ -2457,14 +2453,13 @@ public final class MemoryUtil {
         }
     }
 
-    private static VarHandle createMemoryAccessVH(ValueLayout layout, MethodHandle ofAddress, MethodHandle reinterpret) {
+    private static VarHandle createMemoryAccessVH(ValueLayout layout, MemorySegment memorySegmentFull) {
+        // The resulting VarHandle is of type (MemorySegment base, long offset)TResult.
+        // When using MemorySegment(address=0, size=max) to fill the first parameter, the second parameter is the target address.
+
         var vh = layout.varHandle();
 
-        vh = MethodHandles.insertCoordinates(vh, 1, 0L);
-        vh = MethodHandles.filterCoordinates(vh, 0, MethodHandles.filterReturnValue(
-            ofAddress,
-            MethodHandles.insertArguments(reinterpret, 1, layout.byteSize())
-        ));
+        vh = MethodHandles.insertCoordinates(vh, 0, memorySegmentFull);
 
         return vh;
     }


### PR DESCRIPTION
#1111

Reduce system overhead by using methods defined by MemoryLayout itself.


CI/CD Result: https://github.com/Karlatemp/lwjgl3/actions/runs/23745588117


---------

Using reinterpret as MethodHandle incurs significant system overhead.

This is because `reinterpret` is a caller-sensitive method. When used as a `MethodHandle`, Java adds a lot of extra steps to ensure that the internal checks function correctly.

```java
    @CallerSensitive
    @Restricted
    MemorySegment reinterpret(long newSize);
```

See the analysis below for details.

> `-Djava.lang.invoke.MethodHandle.DEBUG_NAMES=true`

```kotlin
val lookup = MethodHandles.lookup()

    val ofAddress = lookup.findStatic(
        MemorySegment::class.java,
        "ofAddress",
        MethodType.methodType(MemorySegment::class.java, Long::class.javaPrimitiveType)
    )


    println("=================================================")
    val reinterpret = lookup.findVirtual(
        MemorySegment::class.java,
        "reinterpret",
        MethodType.methodType(MemorySegment::class.java, Long::class.javaPrimitiveType)
    )
    println("reinterpret: $reinterpret")
    println("=================================================")


    val layout = ValueLayout.JAVA_INT_UNALIGNED
    val layoutVh = layout.varHandle()


    val vhNullAddress = MethodHandles.insertCoordinates(layoutVh, 0, MemorySegment.NULL.reinterpret(Long.MAX_VALUE))
    println("null filled: ${vhNullAddress.toMethodHandle(VarHandle.AccessMode.GET)}")


    println("=================================================")

    val memorySegmentConvertor = MethodHandles.filterReturnValue(
        ofAddress,
        MethodHandles.insertArguments(reinterpret, 1, Int.SIZE_BYTES)
    )
    println("memorySegmentConvertor: $memorySegmentConvertor")
```

```text
VarHandle[varType=long, coord=[long]]
=================================================
reinterpret: MethodHandle(MemorySegment,long)MemorySegment : MH.delegate001_LLJ_L=Lambda(a0:L/DelegatingMethodHandle,a1:L,a2:J)=>{
    t3:L=DelegatingMethodHandle.getTarget(a0:L);
    t4:L=MethodHandle.invokeBasic(t3:L,a1:L,a2:J);t4:L}
=================================================
null filled: MethodHandle(long)int : invoke032_LJ_I=Lambda(a0:L/SpeciesData[LLL => BoundMethodHandle$Species_LLL],a1:J)=>{
    t2:L=BoundMethodHandle$Species_LLL.argL2(a0:L);
    t3:L=BoundMethodHandle$Species_LLL.argL1(a0:L);
    t4:L=BoundMethodHandle$Species_LLL.argL0(a0:L);
    t5:I=MethodHandle.invokeBasic(t4:L,t2:L,t3:L,a1:J);t5:I}
& BMH=[
  0: ( MethodHandle(VarHandle,MemorySegment,long)int : DMH.invokeStatic019_LLLJ_I=Lambda(a0:L,a1:L,a2:L,a3:J)=>{
    t4:L=DirectMethodHandle.internalMemberName(a0:L);
    t5:I=MethodHandle.linkToStatic(a1:L,a2:L,a3:J,t4:L);t5:I}
& DMH.MN=java.lang.invoke.VarHandleSegmentAsInts.get(VarHandle,Object,long)int/invokeStatic )
  1: ( MemorySegment{ kind: native, address: 0x0, byteSize: 9223372036854775807 } )
  2: ( VarHandle[varType=int, coord=[interface java.lang.foreign.MemorySegment, long]] )
]
=================================================
memorySegmentConvertor: MethodHandle(long)MemorySegment : invoke017_LJ_L=Lambda(a0:L/SpeciesData[LL => BoundMethodHandle$Species_LL],a1:J)=>{
    t2:L=BoundMethodHandle$Species_LL.argL0(a0:L);
    t3:L=MethodHandle.invokeBasic(t2:L,a1:J);
    t4:L=BoundMethodHandle$Species_LL.argL1(a0:L);
    t5:L=MethodHandle.invokeBasic(t4:L,t3:L);t5:L}
& BMH=[
  0: ( MethodHandle(long)MemorySegment : DMH.invokeStaticInit001_LJ_L=Lambda(a0:L,a1:J)=>{
    t2:L=DirectMethodHandle.internalMemberNameEnsureInit(a0:L);
    t3:L=MethodHandle.linkToStatic(a1:J,t2:L);t3:L}
& DMH.MN=java.lang.foreign.MemorySegment.ofAddress(long)MemorySegment/invokeStatic )
  1: ( MethodHandle(MemorySegment)MemorySegment : invoke016_LL_L=Lambda(a0:L/SpeciesData[LLLLLJ => BoundMethodHandle$Species_LLLLLJ],a1:L)=>{
    t2:J=BoundMethodHandle$Species_LLLLLJ.argJ5(a0:L);
    t3:L=BoundMethodHandle$Species_LLLLLJ.argL3(a0:L);
    t4:L=MethodHandle.invokeBasic(t3:L,t2:J);
    t5:L=BoundMethodHandle$Species_LLLLLJ.argL2(a0:L);
    t6:L=MethodHandle.invokeBasic(t5:L,a1:L,t4:L);
    t7:L=BoundMethodHandle$Species_LLLLLJ.argL1(a0:L);
    t8:L=BoundMethodHandle$Species_LLLLLJ.argL0(a0:L);
    t9:L=MethodHandle.invokeBasic(t8:L,t7:L,t6:L);
    t10:L=BoundMethodHandle$Species_LLLLLJ.argL4(a0:L);
    t11:L=MethodHandle.invokeBasic(t10:L,t9:L);t11:L}
& BMH=[
  0: ( MethodHandle(MethodHandle,Object[])Object : DMH.invokeStatic020_LLL_L=Lambda(a0:L,a1:L,a2:L)=>{
    t3:L=DirectMethodHandle.internalMemberName(a0:L);
    t4:L=MethodHandle.linkToStatic(a1:L,a2:L,t3:L);t4:L}
& DMH.MN=VvfKt$$InjectedInvoker/0x000000008105b000.invoke_V(MethodHandle,Object[])Object/invokeStatic )
  1: ( MethodHandle(Object[])Object : invoke012_LL_L=Lambda(a0:L/SpeciesData[LLL => BoundMethodHandle$Species_LLL],a1:L)=>{
    t2:V=MethodHandleImpl.checkSpreadArgument(a1:L,2);
    t3:L=ArrayAccessor.getElementL(a1:L,0);
    t4:L=ArrayAccessor.getElementL(a1:L,1);
    t5:L=BoundMethodHandle$Species_LLL.argL2(a0:L);
    t6:L=MethodHandle.invokeBasic(t5:L,t3:L);
    t7:L=BoundMethodHandle$Species_LLL.argL1(a0:L);
    t8:J=MethodHandle.invokeBasic(t7:L,t4:L);
    t9:L=BoundMethodHandle$Species_LLL.argL0(a0:L);
    t10:L=MethodHandle.invokeBasic(t9:L,t6:L,t8:J);t10:L}
& BMH=[
  0: ( MethodHandle(MemorySegment,long)MemorySegment : DMH.invokeInterface000_LLJ_L=Lambda(a0:L,a1:L,a2:J)=>{
    t3:L=DirectMethodHandle.internalMemberName(a0:L);
    t4:L=DirectMethodHandle.checkReceiver(a0:L,a1:L);
    t5:L=MethodHandle.linkToInterface(t4:L,a2:J,t3:L);t5:L}
& DMH.MN=java.lang.foreign.MemorySegment.reinterpret(long)MemorySegment/invokeInterface )
  1: ( MethodHandle(Object)long : invoke009_LL_J=Lambda(a0:L/SpeciesData[LI => BoundMethodHandle$Species_LI],a1:L)=>{
    t2:I=BoundMethodHandle$Species_LI.argI1(a0:L);
    t3:L=BoundMethodHandle$Species_LI.argL0(a0:L);
    t4:J=MethodHandle.invokeBasic(t3:L,a1:L,t2:I);t4:J}
& BMH=[
  0: ( MethodHandle(Object,boolean)long : DMH.invokeStatic003_LLI_J=Lambda(a0:L,a1:L,a2:I)=>{
    t3:L=DirectMethodHandle.internalMemberName(a0:L);
    t4:J=MethodHandle.linkToStatic(a1:L,a2:I,t3:L);t4:J}
& DMH.MN=sun.invoke.util.ValueConversions.unboxLong(Object,boolean)long/invokeStatic )
  1: ( 0 )
] )
  2: ( MethodHandle(Object)Object : invoke000_LL_L=Lambda(a0:L/SpeciesData[LL => BoundMethodHandle$Species_LL],a1:L)=>{
    t2:L=BoundMethodHandle$Species_LL.argL1(a0:L);
    t3:L=BoundMethodHandle$Species_LL.argL0(a0:L);
    t4:L=MethodHandle.invokeBasic(t3:L,t2:L,a1:L);t4:L}
& BMH=[
  0: ( MethodHandle(Class,Object)Object : DMH.invokeSpecial008_LLL_L=Lambda(a0:L,a1:L,a2:L)=>{
    t3:L=DirectMethodHandle.internalMemberName(a0:L);
    t4:L=MethodHandle.linkToSpecial(a1:L,a2:L,t3:L);t4:L}
& DMH.MN=java.lang.Class.cast(Object)Object/invokeSpecial )
  1: ( interface java.lang.foreign.MemorySegment )
] )
] )
  2: ( MethodHandle(Object,Object)Object[] : collector001_LLL_L=Lambda(a0:L/SpeciesData[L => Species_L],a1:L,a2:L)=>{
    t3:L=Species_L.argL0(a0:L);
    t4:L=MethodHandle.invokeBasic(t3:L,2);
    t5:V=ArrayAccessor.setElementL(t4:L,0,a1:L);
    t6:V=ArrayAccessor.setElementL(t4:L,1,a2:L);t4:L}
& BMH=[MethodHandle(int)Object[] : invoke005_LI_L=Lambda(a0:L/SpeciesData[LLL => BoundMethodHandle$Species_LLL],a1:I)=>{
    t2:L=BoundMethodHandle$Species_LLL.argL1(a0:L);
    t3:L=BoundMethodHandle$Species_LLL.argL0(a0:L);
    t4:L=MethodHandle.invokeBasic(t3:L,t2:L,a1:I);
    t5:L=BoundMethodHandle$Species_LLL.argL2(a0:L);
    t6:L=MethodHandle.invokeBasic(t5:L,t4:L);t6:L}
& BMH=[
  0: ( MethodHandle(Class,int)Object : DMH.invokeStatic001_LLI_L=Lambda(a0:L,a1:L,a2:I)=>{
    t3:L=DirectMethodHandle.internalMemberName(a0:L);
    t4:L=MethodHandle.linkToStatic(a1:L,a2:I,t3:L);t4:L}
& DMH.MN=java.lang.reflect.Array.newInstance(Class,int)Object/invokeStatic )
  1: ( class java.lang.Object )
  2: ( MethodHandle(Object)Object : invoke000_LL_L=Lambda(a0:L/SpeciesData[LL => BoundMethodHandle$Species_LL],a1:L)=>{
    t2:L=BoundMethodHandle$Species_LL.argL1(a0:L);
    t3:L=BoundMethodHandle$Species_LL.argL0(a0:L);
    t4:L=MethodHandle.invokeBasic(t3:L,t2:L,a1:L);t4:L}
& BMH=[
  0: ( MethodHandle(Class,Object)Object : DMH.invokeSpecial008_LLL_L=Lambda(a0:L,a1:L,a2:L)=>{
    t3:L=DirectMethodHandle.internalMemberName(a0:L);
    t4:L=MethodHandle.linkToSpecial(a1:L,a2:L,t3:L);t4:L}
& DMH.MN=java.lang.Class.cast(Object)Object/invokeSpecial )
  1: ( class [Ljava.lang.Object; )
] )
]] )
  3: ( MethodHandle(long)Long : DMH.invokeStatic021_LJ_L=Lambda(a0:L,a1:J)=>{
    t2:L=DirectMethodHandle.internalMemberName(a0:L);
    t3:L=MethodHandle.linkToStatic(a1:J,t2:L);t3:L}
& DMH.MN=sun.invoke.util.ValueConversions.boxLong(long)Long/invokeStatic )
  4: ( MethodHandle(Object)Object : invoke000_LL_L=Lambda(a0:L/SpeciesData[LL => BoundMethodHandle$Species_LL],a1:L)=>{
    t2:L=BoundMethodHandle$Species_LL.argL1(a0:L);
    t3:L=BoundMethodHandle$Species_LL.argL0(a0:L);
    t4:L=MethodHandle.invokeBasic(t3:L,t2:L,a1:L);t4:L}
& BMH=[
  0: ( MethodHandle(Class,Object)Object : DMH.invokeSpecial008_LLL_L=Lambda(a0:L,a1:L,a2:L)=>{
    t3:L=DirectMethodHandle.internalMemberName(a0:L);
    t4:L=MethodHandle.linkToSpecial(a1:L,a2:L,t3:L);t4:L}
& DMH.MN=java.lang.Class.cast(Object)Object/invokeSpecial )
  1: ( interface java.lang.foreign.MemorySegment )
] )
  5: ( 4 )
] )
]
```

As mentioned above, using reinterpret adds a lot of logic, resulting in very high system overhead.