### PR TITLE
Linux ppc64le: define POWERPC so the libffi wrapper uses the 64-bit ABI enum (fixes #1126)

### DIFF
--- a/config/linux/build.xml
+++ b/config/linux/build.xml
@@ -186,6 +186,7 @@
                 <arg value="-I${src.main.rel}/libffi/riscv64" if:set="build.arch.riscv64"/>
                 <arg value="-I${src.main.rel}/libffi/x86" if:set="build.arch.x64|x86"/>
                 <arg value="-DX86_64" if:set="build.arch.x64"/> <!-- for libffi/x86/ffitarget.h -->
+                <arg value="-DPOWERPC" if:set="build.arch.ppc64le"/> <!-- for libffi/ppc64le/ffitarget.h -->
                 <arg value="-I${src.main.rel}/${platform}/liburing"/>
                 <arg value="-I${src.main.rel}/${platform}/liburing/include"/>
                 <fileset dir=".">


### PR DESCRIPTION
## Problem

On Linux ppc64le, `LibFFI.FFI_DEFAULT_ABI` is computed from libffi's **32-bit SYSV** ABI enum instead of the **64-bit LINUX (POWERPC64)** enum, so it disagrees with the ABI the bundled `libffi.a` was actually built with. Every `ffi_prep_cif()` / callback creation then fails with `FFI_BAD_ABI`, making the official ppc64le natives unusable for anything that installs a native callback.

Full analysis and a core-only MCVE are in #1126. In short, on 3.4.1 ppc64le:

```
FFI_DEFAULT_ABI (binding constant)      = 28
ffi_get_default_abi() (inside libffi.a) = 11
FFI_LAST_ABI    (binding constant)      = 32
ffi_prep_cif(FFI_DEFAULT_ABI)           = 2 (FFI_BAD_ABI)
```

`LibFFITest#testConstants` (`assertEquals(ffi_get_default_abi(), FFI_DEFAULT_ABI)`) also fails on ppc64le — it just never runs there, since CI cross-compiles ppc64le without executing the suite.

## Root cause

`modules/lwjgl/core/src/main/c/libffi/ppc64le/ffitarget.h` only selects the 64-bit branch when `POWERPC64` is defined, which requires both `__powerpc64__` (a compiler builtin) **and** `POWERPC` (normally set by libffi's autotools build). The binding wrapper is compiled without `-DPOWERPC`, so it falls into the 32-bit SYSV branch, while `libffi.a` (built by autotools with `POWERPC`) uses the 64-bit branch.

## Fix

Pass `-DPOWERPC` for ppc64le, mirroring the existing `-DX86_64` for the x86 libffi header in the same block. The wrapper and `libffi.a` then use the same 64-bit ABI enum, `FFI_DEFAULT_ABI` matches `ffi_get_default_abi()`, `LibFFITest#testConstants` passes, and `ffi_prep_cif` returns `FFI_OK`.

```diff
 <arg value="-DX86_64" if:set="build.arch.x64"/> <!-- for libffi/x86/ffitarget.h -->
+<arg value="-DPOWERPC" if:set="build.arch.ppc64le"/> <!-- for libffi/ppc64le/ffitarget.h: selects the 64-bit ABI branch (POWERPC64) -->
```

## Verification

Byte-patching the shipped `liblwjgl.so`'s `FFI_DEFAULT_ABI()` (which is literally `li r3,28; blr`) to return a value the bundled `libffi.a` accepts makes `ffi_prep_cif` return `FFI_OK` and lets affected apps (e.g. Minecraft via GLFW callbacks) run — confirming the diagnosis end to end. This PR makes the build produce a correct value directly.

Fixes #1126